### PR TITLE
Family graph data model and persistence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
           distribution: temurin
           java-version: '21'
 
+      # Installs cmdline-tools and accepts the SDK licences. The platform itself is left to
+      # AGP: platform 37 uses the new SDK minor-version id (`platforms;android-37.0`), which the
+      # runner's bundled cmdline-tools is too old to resolve.
       - uses: android-actions/setup-android@v3
-        with:
-          packages: 'platforms;android-37 build-tools;36.0.0'
 
       - uses: gradle/actions/setup-gradle@v4
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -33,6 +35,15 @@ android {
     buildFeatures {
         compose = true
     }
+
+    packaging {
+        resources.excludes += "/META-INF/{AL2.0,LGPL2.1}"
+    }
+}
+
+// Emit the Room schema so migrations can be written against a checked-in history.
+ksp {
+    arg("room.schemaLocation", "$projectDir/schemas")
 }
 
 kotlin {
@@ -51,13 +62,26 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.navigation.compose)
+
+    implementation(libs.androidx.room.runtime)
+    implementation(libs.androidx.room.ktx)
+    ksp(libs.androidx.room.compiler)
+
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.coil.compose)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.androidx.room.testing)
+    androidTestImplementation(libs.kotlinx.coroutines.test)
 }

--- a/app/schemas/com.vibethroughcode.ftree.data.FTreeDatabase/1.json
+++ b/app/schemas/com.vibethroughcode.ftree.data.FTreeDatabase/1.json
@@ -1,0 +1,254 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "0486286b08144dfb9f2d514eda5b27ef",
+    "entities": [
+      {
+        "tableName": "people",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT, `gender` TEXT NOT NULL, `birthDate` TEXT, `deathDate` TEXT, `deceased` INTEGER NOT NULL, `photoId` TEXT, `notes` TEXT, `createdAt` INTEGER NOT NULL DEFAULT 0, `updatedAt` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "gender",
+            "columnName": "gender",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deathDate",
+            "columnName": "deathDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deceased",
+            "columnName": "deceased",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoId",
+            "columnName": "photoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_people_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_people_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "relationships",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `fromPersonId` TEXT NOT NULL, `toPersonId` TEXT NOT NULL, `type` TEXT NOT NULL, `subtype` TEXT, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`fromPersonId`) REFERENCES `people`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`toPersonId`) REFERENCES `people`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromPersonId",
+            "columnName": "fromPersonId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toPersonId",
+            "columnName": "toPersonId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtype",
+            "columnName": "subtype",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_relationships_fromPersonId_toPersonId_type",
+            "unique": true,
+            "columnNames": [
+              "fromPersonId",
+              "toPersonId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_relationships_fromPersonId_toPersonId_type` ON `${TABLE_NAME}` (`fromPersonId`, `toPersonId`, `type`)"
+          },
+          {
+            "name": "index_relationships_fromPersonId_type",
+            "unique": false,
+            "columnNames": [
+              "fromPersonId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_relationships_fromPersonId_type` ON `${TABLE_NAME}` (`fromPersonId`, `type`)"
+          },
+          {
+            "name": "index_relationships_toPersonId_type",
+            "unique": false,
+            "columnNames": [
+              "toPersonId",
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_relationships_toPersonId_type` ON `${TABLE_NAME}` (`toPersonId`, `type`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "people",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "fromPersonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "people",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "toPersonId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "person_origins",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`personId` TEXT NOT NULL, `sourceTreeId` TEXT NOT NULL, `sourcePersonId` TEXT NOT NULL, PRIMARY KEY(`personId`, `sourceTreeId`, `sourcePersonId`), FOREIGN KEY(`personId`) REFERENCES `people`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "personId",
+            "columnName": "personId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourceTreeId",
+            "columnName": "sourceTreeId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sourcePersonId",
+            "columnName": "sourcePersonId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "personId",
+            "sourceTreeId",
+            "sourcePersonId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_person_origins_sourceTreeId_sourcePersonId",
+            "unique": false,
+            "columnNames": [
+              "sourceTreeId",
+              "sourcePersonId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_person_origins_sourceTreeId_sourcePersonId` ON `${TABLE_NAME}` (`sourceTreeId`, `sourcePersonId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "people",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "personId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '0486286b08144dfb9f2d514eda5b27ef')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyDatabaseTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyDatabaseTest.kt
@@ -165,6 +165,20 @@ class FamilyDatabaseTest {
     }
 
     @Test
+    fun childrenAreOrderedByBirthWithUnknownDatesLast() = runTest {
+        person("me")
+        person("youngest", "Youngest", birth = "2015")
+        person("unknown", "Unknown birthday")
+        person("eldest", "Eldest", birth = "2005")
+        listOf("youngest", "unknown", "eldest").forEach { parentOf("me", it) }
+
+        assertEquals(
+            listOf("Eldest", "Youngest", "Unknown birthday"),
+            edges.observeChildren("me").first().map { it.name },
+        )
+    }
+
+    @Test
     fun siblingsAreDerivedFromSharedParents() = runTest {
         person("father"); person("mother")
         person("me", "Me"); person("sister", "Sister")

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyDatabaseTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyDatabaseTest.kt
@@ -1,0 +1,240 @@
+package com.vibethroughcode.ftree.data
+
+import android.content.Context
+import android.database.sqlite.SQLiteConstraintException
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Exercises the schema itself: that the graph survives a round trip, that the database refuses
+ * invalid states on its own, and that the two deletion modes behave differently in the way the
+ * product depends on.
+ */
+@RunWith(AndroidJUnit4::class)
+class FamilyDatabaseTest {
+
+    private lateinit var db: FTreeDatabase
+    private lateinit var people: PersonDao
+    private lateinit var edges: RelationshipDao
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, FTreeDatabase::class.java)
+            .addCallback(FTreeDatabase.enforceForeignKeys)
+            .build()
+        people = db.personDao()
+        edges = db.relationshipDao()
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private suspend fun person(id: String, name: String? = null, birth: String? = null): Person =
+        Person(id = id, name = name, birthDate = birth).also { people.insert(it) }
+
+    private suspend fun parentOf(parent: String, child: String) =
+        edges.insert(Relationship.of(parent, child, RelationshipType.PARENT))
+
+    @Test
+    fun personRoundTripsThroughTheDatabase() = runTest {
+        val stored = Person(
+            id = "p1",
+            name = "Ankit",
+            gender = Gender.MALE,
+            birthDate = "1990-05-01",
+            notes = "note",
+        )
+        people.insert(stored)
+
+        assertEquals(stored, people.findById("p1"))
+    }
+
+    @Test
+    fun aPersonWithNoDetailsAtAllCanBeStored() = runTest {
+        people.insert(Person(id = "unknown"))
+
+        val loaded = people.findById("unknown")!!
+        assertTrue(loaded.isUnnamed)
+        assertNull(loaded.name)
+    }
+
+    @Test
+    fun unknownPeopleSortAfterNamedOnes() = runTest {
+        person("b", "Zoe")
+        person("a", "Adam")
+        person("c")
+
+        val order = people.observeAll().first().map { it.id }
+        assertEquals(listOf("a", "b", "c"), order)
+    }
+
+    @Test
+    fun theUniqueIndexRejectsADuplicateEdge() = runTest {
+        person("parent"); person("child")
+        parentOf("parent", "child")
+
+        try {
+            parentOf("parent", "child")
+            throw AssertionError("expected the unique index to reject the duplicate")
+        } catch (_: SQLiteConstraintException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun aSpouseEdgeIsTheSameRowFromEitherDirection() = runTest {
+        person("zoe"); person("adam")
+        edges.insert(Relationship.of("zoe", "adam", RelationshipType.SPOUSE))
+
+        try {
+            edges.insert(Relationship.of("adam", "zoe", RelationshipType.SPOUSE))
+            throw AssertionError("expected canonical ordering to make this a duplicate")
+        } catch (_: SQLiteConstraintException) {
+            // expected
+        }
+        assertEquals(1, edges.allRelationships().size)
+    }
+
+    @Test
+    fun anEdgeToAPersonWhoDoesNotExistIsRejected() = runTest {
+        person("real")
+        try {
+            parentOf("real", "ghost")
+            throw AssertionError("expected the foreign key to reject the dangling edge")
+        } catch (_: SQLiteConstraintException) {
+            // expected
+        }
+    }
+
+    @Test
+    fun deletingCompletelyCascadesToEveryEdge() = runTest {
+        person("father"); person("me"); person("child")
+        parentOf("father", "me")
+        parentOf("me", "child")
+
+        people.deleteById("me")
+
+        assertNull(people.findById("me"))
+        assertEquals(emptyList<Relationship>(), edges.allRelationships())
+        assertEquals(2, people.count())
+    }
+
+    @Test
+    fun keepingAsUnknownPreservesEveryRelationship() = runTest {
+        person("father", "Raj"); person("me", "Ankit"); person("child", "Kid")
+        parentOf("father", "me")
+        parentOf("me", "child")
+
+        people.clearDetails("me")
+
+        val stripped = people.findById("me")!!
+        assertTrue(stripped.isUnnamed)
+        assertEquals(Gender.UNSPECIFIED, stripped.gender)
+        // The shape of the family is untouched.
+        assertEquals(2, edges.edgeCount("me"))
+        assertEquals(listOf("Raj"), edges.observeParents("me").first().map { it.name })
+        assertEquals(listOf("Kid"), edges.observeChildren("me").first().map { it.name })
+    }
+
+    @Test
+    fun parentsChildrenAndSpousesAreQueryable() = runTest {
+        person("father", "Father"); person("mother", "Mother")
+        person("me", "Me"); person("wife", "Wife"); person("kid", "Kid")
+        parentOf("father", "me")
+        parentOf("mother", "me")
+        parentOf("me", "kid")
+        parentOf("wife", "kid")
+        edges.insert(Relationship.of("me", "wife", RelationshipType.SPOUSE))
+
+        assertEquals(setOf("Father", "Mother"), edges.observeParents("me").first().map { it.name }.toSet())
+        assertEquals(listOf("Kid"), edges.observeChildren("me").first().map { it.name })
+        assertEquals(listOf("Wife"), edges.observeSpouses("me").first().map { it.name })
+        // Symmetric, so it reads the same from the other side.
+        assertEquals(listOf("Me"), edges.observeSpouses("wife").first().map { it.name })
+    }
+
+    @Test
+    fun siblingsAreDerivedFromSharedParents() = runTest {
+        person("father"); person("mother")
+        person("me", "Me"); person("sister", "Sister")
+        listOf("me", "sister").forEach { parentOf("father", it); parentOf("mother", it) }
+
+        assertEquals(listOf("Sister"), edges.observeSiblings("me").first().map { it.name })
+        assertEquals(listOf("Me"), edges.observeSiblings("sister").first().map { it.name })
+    }
+
+    @Test
+    fun aHalfSiblingSharingOneParentIsStillASibling() = runTest {
+        person("father"); person("mother"); person("stepmother")
+        person("me", "Me"); person("halfBrother", "Half brother")
+        parentOf("father", "me"); parentOf("mother", "me")
+        parentOf("father", "halfBrother"); parentOf("stepmother", "halfBrother")
+
+        assertEquals(listOf("Half brother"), edges.observeSiblings("me").first().map { it.name })
+    }
+
+    @Test
+    fun derivedSiblingsAreNotDuplicatedWhenBothParentsAreShared() = runTest {
+        person("father"); person("mother"); person("me"); person("sister", "Sister")
+        listOf("me", "sister").forEach { parentOf("father", it); parentOf("mother", it) }
+
+        assertEquals(1, edges.observeSiblings("me").first().size)
+    }
+
+    @Test
+    fun anExplicitSiblingEdgeCoversTheCaseWhereParentsAreUnknown() = runTest {
+        person("me", "Me"); person("brother", "Brother")
+        edges.insert(Relationship.of("me", "brother", RelationshipType.SIBLING))
+
+        assertEquals(listOf("Brother"), edges.observeSiblings("me").first().map { it.name })
+        assertEquals(listOf("Me"), edges.observeSiblings("brother").first().map { it.name })
+    }
+
+    @Test
+    fun aSiblingKnownBothExplicitlyAndThroughParentsAppearsOnce() = runTest {
+        person("father"); person("me", "Me"); person("brother", "Brother")
+        parentOf("father", "me"); parentOf("father", "brother")
+        edges.insert(Relationship.of("me", "brother", RelationshipType.SIBLING))
+
+        assertEquals(listOf("Brother"), edges.observeSiblings("me").first().map { it.name })
+    }
+
+    @Test
+    fun childrenAcrossDifferentSpousesAreAllChildren() = runTest {
+        person("me", "Me"); person("first", "First wife"); person("second", "Second wife")
+        person("childA", "A", ); person("childB", "B")
+        edges.insert(Relationship.of("me", "first", RelationshipType.SPOUSE))
+        edges.insert(Relationship.of("me", "second", RelationshipType.SPOUSE))
+        parentOf("me", "childA"); parentOf("first", "childA")
+        parentOf("me", "childB"); parentOf("second", "childB")
+
+        assertEquals(setOf("A", "B"), edges.observeChildren("me").first().map { it.name }.toSet())
+        assertEquals(setOf("First wife", "Second wife"), edges.observeSpouses("me").first().map { it.name }.toSet())
+        // Half-siblings through the shared father.
+        assertEquals(listOf("B"), edges.observeSiblings("childA").first().map { it.name })
+    }
+
+    @Test
+    fun anUnrecognisedRelationshipTypeSurvivesAReadAsUnknown() = runTest {
+        person("a"); person("b")
+        db.openHelper.writableDatabase.execSQL(
+            "INSERT INTO relationships (id, fromPersonId, toPersonId, type, subtype, createdAt) " +
+                "VALUES ('r1', 'a', 'b', 'GODPARENT_FROM_THE_FUTURE', NULL, 0)"
+        )
+
+        // The row is kept rather than dropped; only its meaning is degraded.
+        val stored = edges.findById("r1")!!
+        assertEquals(RelationshipType.UNKNOWN, stored.type)
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".FTreeApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
@@ -1,0 +1,17 @@
+package com.vibethroughcode.ftree
+
+import android.content.Context
+import com.vibethroughcode.ftree.data.FTreeDatabase
+import com.vibethroughcode.ftree.data.FamilyRepository
+
+/**
+ * Hand-rolled dependency wiring.
+ *
+ * The app has a handful of screens and one repository; a DI framework would add a compiler plugin
+ * and a layer of indirection to solve a problem this size does not have. Tests construct the
+ * repository directly against an in-memory database.
+ */
+class AppContainer(context: Context) {
+    private val database: FTreeDatabase by lazy { FTreeDatabase.build(context) }
+    val familyRepository: FamilyRepository by lazy { FamilyRepository(database) }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/FTreeApplication.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/FTreeApplication.kt
@@ -1,0 +1,13 @@
+package com.vibethroughcode.ftree
+
+import android.app.Application
+
+class FTreeApplication : Application() {
+    lateinit var container: AppContainer
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        container = AppContainer(this)
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/Converters.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/Converters.kt
@@ -1,0 +1,19 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.TypeConverter
+
+/** Enums are persisted by name so the stored value stays readable and stable across releases. */
+class Converters {
+    @TypeConverter
+    fun genderToString(value: Gender): String = value.name
+
+    @TypeConverter
+    fun stringToGender(value: String?): Gender =
+        Gender.entries.firstOrNull { it.name == value } ?: Gender.UNSPECIFIED
+
+    @TypeConverter
+    fun relationshipTypeToString(value: RelationshipType): String = value.name
+
+    @TypeConverter
+    fun stringToRelationshipType(value: String?): RelationshipType = RelationshipType.fromName(value)
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/FTreeDatabase.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/FTreeDatabase.kt
@@ -1,0 +1,41 @@
+package com.vibethroughcode.ftree.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+@Database(
+    entities = [Person::class, Relationship::class, PersonOrigin::class],
+    version = 1,
+    exportSchema = true,
+)
+@TypeConverters(Converters::class)
+abstract class FTreeDatabase : RoomDatabase() {
+
+    abstract fun personDao(): PersonDao
+    abstract fun relationshipDao(): RelationshipDao
+    abstract fun personOriginDao(): PersonOriginDao
+
+    companion object {
+        private const val NAME = "f-tree.db"
+
+        /**
+         * Foreign keys are off by default in SQLite, and the ON DELETE CASCADE rules are the only
+         * thing stopping a hard delete from leaving orphaned edges behind. Exposed so tests build
+         * their in-memory database with exactly the same guarantees as the real one.
+         */
+        val enforceForeignKeys = object : Callback() {
+            override fun onOpen(db: SupportSQLiteDatabase) {
+                db.execSQL("PRAGMA foreign_keys=ON")
+            }
+        }
+
+        fun build(context: Context): FTreeDatabase =
+            Room.databaseBuilder(context.applicationContext, FTreeDatabase::class.java, NAME)
+                .addCallback(enforceForeignKeys)
+                .build()
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
@@ -1,0 +1,101 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.withTransaction
+import com.vibethroughcode.ftree.graph.RelationshipCheck
+import com.vibethroughcode.ftree.graph.RelationshipRejection
+import com.vibethroughcode.ftree.graph.RelationshipRules
+import kotlinx.coroutines.flow.Flow
+
+/** What to do with a person's relationships when the person is removed. */
+enum class DeletionMode {
+    /**
+     * Strip the person back to an unknown placeholder but keep the node and every edge, so the
+     * shape of the family survives losing one name.
+     */
+    KEEP_AS_UNKNOWN,
+
+    /** Remove the person and, by cascade, every edge that touched them. */
+    DELETE_COMPLETELY,
+}
+
+/**
+ * The single door to family data.
+ *
+ * Reads are `Flow`-based and deliberately narrow — one person, one person's relatives — rather
+ * than "load the graph", because the graph is expected to reach thousands of people.
+ */
+class FamilyRepository(
+    private val db: FTreeDatabase,
+    private val people: PersonDao = db.personDao(),
+    private val relationships: RelationshipDao = db.relationshipDao(),
+    private val origins: PersonOriginDao = db.personOriginDao(),
+) {
+
+    fun observeAllPeople(): Flow<List<Person>> = people.observeAll()
+    fun observePerson(id: String): Flow<Person?> = people.observeById(id)
+    fun observePersonCount(): Flow<Int> = people.observeCount()
+    fun searchPeople(query: String): Flow<List<Person>> = people.search(query)
+
+    fun observeParents(id: String): Flow<List<Person>> = relationships.observeParents(id)
+    fun observeChildren(id: String): Flow<List<Person>> = relationships.observeChildren(id)
+    fun observeSpouses(id: String): Flow<List<Person>> = relationships.observeSpouses(id)
+    fun observeSiblings(id: String): Flow<List<Person>> = relationships.observeSiblings(id)
+    fun observeEdgesOf(id: String): Flow<List<Relationship>> = relationships.observeEdgesOf(id)
+
+    suspend fun person(id: String): Person? = people.findById(id)
+    suspend fun relationshipCount(id: String): Int = relationships.edgeCount(id)
+
+    suspend fun addPerson(person: Person): Person {
+        people.insert(person)
+        return person
+    }
+
+    suspend fun updatePerson(person: Person) {
+        people.update(person.copy(updatedAt = System.currentTimeMillis()))
+    }
+
+    suspend fun deletePerson(id: String, mode: DeletionMode) = db.withTransaction {
+        when (mode) {
+            DeletionMode.KEEP_AS_UNKNOWN -> people.clearDetails(id)
+            DeletionMode.DELETE_COMPLETELY -> people.deleteById(id)
+        }
+    }
+
+    /**
+     * Records an edge if the rules allow it.
+     *
+     * Validation runs inside the transaction that writes, so two rapid taps cannot both pass the
+     * duplicate check. The unique index is the final backstop.
+     */
+    suspend fun addRelationship(
+        fromPersonId: String,
+        toPersonId: String,
+        type: RelationshipType,
+        subtype: String? = null,
+    ): Result<Relationship> = db.withTransaction {
+        val check = RelationshipRules.check(
+            fromPersonId = fromPersonId,
+            toPersonId = toPersonId,
+            type = type,
+            existingEdgeExists = { from, to, edgeType ->
+                relationships.countExact(from, to, edgeType) > 0
+            },
+            parentsOf = { relationships.parentIdsOf(it) },
+        )
+        when (check) {
+            is RelationshipCheck.Rejected -> Result.failure(RelationshipRejectedException(check.reason))
+            RelationshipCheck.Allowed -> {
+                val edge = Relationship.of(fromPersonId, toPersonId, type, subtype)
+                relationships.insert(edge)
+                Result.success(edge)
+            }
+        }
+    }
+
+    suspend fun removeRelationship(id: String) = relationships.deleteById(id)
+
+    suspend fun originsOf(personIds: List<String>): List<PersonOrigin> = origins.originsOf(personIds)
+}
+
+class RelationshipRejectedException(val reason: RelationshipRejection) :
+    IllegalArgumentException("Relationship rejected: $reason")

--- a/app/src/main/java/com/vibethroughcode/ftree/data/Gender.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/Gender.kt
@@ -1,0 +1,12 @@
+package com.vibethroughcode.ftree.data
+
+/**
+ * Recorded only because it is what lets the app say "Father" instead of "Parent" and pick a
+ * default avatar. It is never required, and [UNSPECIFIED] is a first-class answer.
+ */
+enum class Gender {
+    MALE,
+    FEMALE,
+    OTHER,
+    UNSPECIFIED,
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/PartialDate.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/PartialDate.kt
@@ -1,0 +1,78 @@
+package com.vibethroughcode.ftree.data
+
+import java.time.DateTimeException
+import java.time.LocalDate
+
+/**
+ * A date that may be known only to the year or the month.
+ *
+ * Family history is full of "born sometime in 1938", so a full [LocalDate] would force people to
+ * invent a day they do not know. Stored as a partial ISO-8601 string — `1938`, `1938-04`, or
+ * `1938-04-17` — which sorts correctly as text and needs no separate "is approximate" flag: the
+ * precision *is* the statement about how much is known.
+ */
+data class PartialDate(
+    val year: Int,
+    val month: Int? = null,
+    val day: Int? = null,
+) : Comparable<PartialDate> {
+
+    /** The ISO-8601 string that gets persisted. */
+    fun serialize(): String = when {
+        month == null -> "%04d".format(year)
+        day == null -> "%04d-%02d".format(year, month)
+        else -> "%04d-%02d-%02d".format(year, month, day)
+    }
+
+    /** Earliest instant this date could refer to; used for age arithmetic and ordering. */
+    fun earliest(): LocalDate = LocalDate.of(year, month ?: 1, day ?: 1)
+
+    /** Latest instant this date could refer to. */
+    fun latest(): LocalDate {
+        if (month == null) return LocalDate.of(year, 12, 31)
+        val firstOfMonth = LocalDate.of(year, month, 1)
+        return if (day == null) firstOfMonth.withDayOfMonth(firstOfMonth.lengthOfMonth())
+        else firstOfMonth.withDayOfMonth(day)
+    }
+
+    /** True when the two dates could describe the same day, allowing for differing precision. */
+    fun isCompatibleWith(other: PartialDate): Boolean =
+        !earliest().isAfter(other.latest()) && !other.earliest().isAfter(latest())
+
+    override fun compareTo(other: PartialDate): Int = earliest().compareTo(other.earliest())
+
+    override fun toString(): String = serialize()
+
+    companion object {
+        private val PATTERN = Regex("""^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$""")
+
+        /** Returns null for anything that is not a well-formed, real partial date. */
+        fun parse(value: String?): PartialDate? {
+            val match = PATTERN.matchEntire(value?.trim().orEmpty()) ?: return null
+            val (y, m, d) = match.destructured
+            val year = y.toInt()
+            val month = m.takeIf { it.isNotEmpty() }?.toInt()
+            val day = d.takeIf { it.isNotEmpty() }?.toInt()
+            return try {
+                PartialDate(year, month, day).also { it.earliest(); it.latest() }
+            } catch (_: DateTimeException) {
+                null
+            }
+        }
+
+        fun ofYear(year: Int): PartialDate = PartialDate(year)
+    }
+}
+
+/**
+ * Whole years between two partial dates, or null when it cannot be stated.
+ *
+ * Computed from the earliest possible instants, which is the conventional reading of "born in
+ * 1938" and keeps the answer stable as precision improves.
+ */
+fun yearsBetween(from: PartialDate, to: PartialDate): Int? {
+    val start = from.earliest()
+    val end = to.earliest()
+    if (end.isBefore(start)) return null
+    return java.time.Period.between(start, end).years
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/Person.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/Person.kt
@@ -1,0 +1,63 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.LocalDate
+import java.util.UUID
+
+/**
+ * A node in the family graph.
+ *
+ * Every descriptive field is optional. That is not laziness in the schema — it is the feature:
+ * "my grandfather had a brother, but I never knew his name" has to be representable as a real
+ * entity so that a relationship can hang off it and a name can be filled in years later without
+ * rebuilding anything.
+ */
+@Entity(
+    tableName = "people",
+    indices = [Index(value = ["name"])],
+)
+data class Person(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+
+    /** Null or blank means an unknown/placeholder person. */
+    val name: String? = null,
+
+    val gender: Gender = Gender.UNSPECIFIED,
+
+    /** Partial ISO-8601 date; see [PartialDate]. */
+    val birthDate: String? = null,
+    val deathDate: String? = null,
+
+    /** Someone can be known to have died without the date being known, so this is not derived. */
+    val deceased: Boolean = false,
+
+    /**
+     * File name within the app's internal `photos/` directory — never an absolute path, so the
+     * reference survives reinstall, restore and a change of storage location.
+     */
+    val photoId: String? = null,
+
+    val notes: String? = null,
+
+    @ColumnInfo(defaultValue = "0") val createdAt: Long = System.currentTimeMillis(),
+    @ColumnInfo(defaultValue = "0") val updatedAt: Long = System.currentTimeMillis(),
+) {
+    /** True when this person carries no identifying information yet. */
+    val isUnnamed: Boolean get() = name.isNullOrBlank()
+
+    val birth: PartialDate? get() = PartialDate.parse(birthDate)
+    val death: PartialDate? get() = PartialDate.parse(deathDate)
+
+    /**
+     * Age in whole years, or null when it cannot be stated. Derived rather than stored so there is
+     * exactly one source of truth and it can never drift out of date.
+     */
+    fun age(today: LocalDate = LocalDate.now()): Int? {
+        val born = birth ?: return null
+        val end = death ?: if (deceased) return null else PartialDate(today.year, today.monthValue, today.dayOfMonth)
+        return yearsBetween(born, end)
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/PersonDao.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/PersonDao.kt
@@ -1,0 +1,84 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Update
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PersonDao {
+
+    @Query("SELECT * FROM people WHERE id = :id")
+    suspend fun findById(id: String): Person?
+
+    @Query("SELECT * FROM people WHERE id = :id")
+    fun observeById(id: String): Flow<Person?>
+
+    @Query("SELECT * FROM people WHERE id IN (:ids)")
+    suspend fun findByIds(ids: List<String>): List<Person>
+
+    /** Named people first, alphabetically; unknown people collected at the end. */
+    @Query(
+        """
+        SELECT * FROM people
+        ORDER BY CASE WHEN name IS NULL OR TRIM(name) = '' THEN 1 ELSE 0 END,
+                 name COLLATE NOCASE
+        """
+    )
+    fun observeAll(): Flow<List<Person>>
+
+    @Query(
+        """
+        SELECT * FROM people
+        WHERE name LIKE '%' || :query || '%' COLLATE NOCASE
+        ORDER BY name COLLATE NOCASE
+        LIMIT :limit
+        """
+    )
+    fun search(query: String, limit: Int = 100): Flow<List<Person>>
+
+    @Query("SELECT COUNT(*) FROM people")
+    fun observeCount(): Flow<Int>
+
+    @Query("SELECT COUNT(*) FROM people")
+    suspend fun count(): Int
+
+    @Query("SELECT * FROM people")
+    suspend fun allPeople(): List<Person>
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(person: Person)
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insertAll(people: List<Person>)
+
+    @Update
+    suspend fun update(person: Person)
+
+    @Upsert
+    suspend fun upsert(person: Person)
+
+    @Delete
+    suspend fun delete(person: Person)
+
+    @Query("DELETE FROM people WHERE id = :id")
+    suspend fun deleteById(id: String)
+
+    /**
+     * Strips a person back to an unknown placeholder while leaving every edge intact, so deleting
+     * someone you know little about does not tear a hole in the shape of the family.
+     */
+    @Query(
+        """
+        UPDATE people
+        SET name = NULL, gender = 'UNSPECIFIED', birthDate = NULL, deathDate = NULL,
+            deceased = 0, photoId = NULL, notes = NULL, updatedAt = :now
+        WHERE id = :id
+        """
+    )
+    suspend fun clearDetails(id: String, now: Long = System.currentTimeMillis())
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/PersonOrigin.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/PersonOrigin.kt
@@ -1,0 +1,35 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+
+/**
+ * Where an imported person came from.
+ *
+ * This is what turns "is this the same Ankit Kumar?" from a guess into a fact. An export stamps
+ * every person with the exporting install's tree id, so re-importing the same file — or a file
+ * derived from it — matches exactly instead of relying on name heuristics, which is what makes
+ * repeated imports idempotent.
+ *
+ * A person accumulates origins as they are merged from several sources, hence one row per source
+ * rather than a column on [Person].
+ */
+@Entity(
+    tableName = "person_origins",
+    primaryKeys = ["personId", "sourceTreeId", "sourcePersonId"],
+    foreignKeys = [
+        ForeignKey(
+            entity = Person::class,
+            parentColumns = ["id"],
+            childColumns = ["personId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [Index(value = ["sourceTreeId", "sourcePersonId"])],
+)
+data class PersonOrigin(
+    val personId: String,
+    val sourceTreeId: String,
+    val sourcePersonId: String,
+)

--- a/app/src/main/java/com/vibethroughcode/ftree/data/PersonOriginDao.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/PersonOriginDao.kt
@@ -1,0 +1,24 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface PersonOriginDao {
+
+    @Query("SELECT * FROM person_origins WHERE personId IN (:personIds)")
+    suspend fun originsOf(personIds: List<String>): List<PersonOrigin>
+
+    @Query("SELECT * FROM person_origins")
+    suspend fun all(): List<PersonOrigin>
+
+    @Query(
+        "SELECT personId FROM person_origins WHERE sourceTreeId = :treeId AND sourcePersonId = :personId"
+    )
+    suspend fun localIdFor(treeId: String, personId: String): String?
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertAll(origins: List<PersonOrigin>)
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/Relationship.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/Relationship.kt
@@ -1,0 +1,88 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.UUID
+
+/**
+ * An edge in the family graph.
+ *
+ * The graph is modelled as people plus edges rather than as a tree, because real families are not
+ * trees: multiple spouses, children across different spouses, half-siblings and unknown ancestors
+ * all have to be expressible without special cases.
+ */
+@Entity(
+    tableName = "relationships",
+    foreignKeys = [
+        ForeignKey(
+            entity = Person::class,
+            parentColumns = ["id"],
+            childColumns = ["fromPersonId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+        ForeignKey(
+            entity = Person::class,
+            parentColumns = ["id"],
+            childColumns = ["toPersonId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        // Makes "this relationship already exists" a database guarantee rather than a race the
+        // application layer has to win. Symmetric edges are stored canonically so both orderings
+        // collide here.
+        Index(value = ["fromPersonId", "toPersonId", "type"], unique = true),
+        Index(value = ["fromPersonId", "type"]),
+        Index(value = ["toPersonId", "type"]),
+    ],
+)
+data class Relationship(
+    @PrimaryKey val id: String = UUID.randomUUID().toString(),
+
+    /** For [RelationshipType.PARENT] this is the parent. */
+    val fromPersonId: String,
+
+    /** For [RelationshipType.PARENT] this is the child. */
+    val toPersonId: String,
+
+    val type: RelationshipType,
+
+    /**
+     * Refinement of [type] — a [ParentKind], [SpouseKind] or [SiblingKind] name. Free text rather
+     * than a typed column so a new refinement never needs a schema migration.
+     */
+    val subtype: String? = null,
+
+    val createdAt: Long = System.currentTimeMillis(),
+) {
+    fun other(personId: String): String? = when (personId) {
+        fromPersonId -> toPersonId
+        toPersonId -> fromPersonId
+        else -> null
+    }
+
+    companion object {
+        /**
+         * Builds an edge, putting symmetric ones in canonical order so that A–B and B–A are the
+         * same row. Without this, "add spouse" from either side would create two rows describing
+         * one marriage.
+         */
+        fun of(
+            fromPersonId: String,
+            toPersonId: String,
+            type: RelationshipType,
+            subtype: String? = null,
+            id: String = UUID.randomUUID().toString(),
+            createdAt: Long = System.currentTimeMillis(),
+        ): Relationship {
+            val (a, b) = if (type.isSymmetric && fromPersonId > toPersonId) {
+                toPersonId to fromPersonId
+            } else {
+                fromPersonId to toPersonId
+            }
+            return Relationship(id, a, b, type, subtype, createdAt)
+        }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
@@ -1,0 +1,116 @@
+package com.vibethroughcode.ftree.data
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface RelationshipDao {
+
+    @Query("SELECT * FROM relationships WHERE id = :id")
+    suspend fun findById(id: String): Relationship?
+
+    @Query("SELECT * FROM relationships")
+    suspend fun allRelationships(): List<Relationship>
+
+    /** Every edge touching this person, in either direction. */
+    @Query("SELECT * FROM relationships WHERE fromPersonId = :personId OR toPersonId = :personId")
+    suspend fun edgesOf(personId: String): List<Relationship>
+
+    @Query("SELECT * FROM relationships WHERE fromPersonId = :personId OR toPersonId = :personId")
+    fun observeEdgesOf(personId: String): Flow<List<Relationship>>
+
+    @Query("SELECT COUNT(*) FROM relationships WHERE fromPersonId = :personId OR toPersonId = :personId")
+    suspend fun edgeCount(personId: String): Int
+
+    @Query(
+        """
+        SELECT p.* FROM people p
+        JOIN relationships r ON r.fromPersonId = p.id
+        WHERE r.toPersonId = :personId AND r.type = 'PARENT'
+        """
+    )
+    fun observeParents(personId: String): Flow<List<Person>>
+
+    @Query(
+        """
+        SELECT p.* FROM people p
+        JOIN relationships r ON r.toPersonId = p.id
+        WHERE r.fromPersonId = :personId AND r.type = 'PARENT'
+        ORDER BY p.birthDate
+        """
+    )
+    fun observeChildren(personId: String): Flow<List<Person>>
+
+    @Query(
+        """
+        SELECT p.* FROM people p
+        JOIN relationships r
+          ON (r.fromPersonId = p.id AND r.toPersonId = :personId)
+          OR (r.toPersonId = p.id AND r.fromPersonId = :personId)
+        WHERE r.type = 'SPOUSE'
+        """
+    )
+    fun observeSpouses(personId: String): Flow<List<Person>>
+
+    /**
+     * Siblings are *derived* from shared parents rather than stored, so they stay correct when a
+     * parent is added later and the graph never accumulates O(n^2) redundant edges. Explicit
+     * SIBLING edges are unioned in to cover the case where the shared parents are unknown.
+     */
+    @Query(
+        """
+        SELECT DISTINCT p.* FROM people p
+        JOIN relationships mine ON mine.toPersonId = :personId AND mine.type = 'PARENT'
+        JOIN relationships theirs
+          ON theirs.fromPersonId = mine.fromPersonId
+         AND theirs.type = 'PARENT'
+         AND theirs.toPersonId = p.id
+        WHERE p.id != :personId
+
+        UNION
+
+        SELECT p.* FROM people p
+        JOIN relationships r
+          ON (r.fromPersonId = p.id AND r.toPersonId = :personId)
+          OR (r.toPersonId = p.id AND r.fromPersonId = :personId)
+        WHERE r.type = 'SIBLING' AND p.id != :personId
+        """
+    )
+    fun observeSiblings(personId: String): Flow<List<Person>>
+
+    @Query("SELECT toPersonId FROM relationships WHERE fromPersonId = :personId AND type = 'PARENT'")
+    suspend fun childIdsOf(personId: String): List<String>
+
+    @Query("SELECT fromPersonId FROM relationships WHERE toPersonId = :personId AND type = 'PARENT'")
+    suspend fun parentIdsOf(personId: String): List<String>
+
+    @Query(
+        """
+        SELECT COUNT(*) FROM relationships
+        WHERE type = :type AND fromPersonId = :from AND toPersonId = :to
+        """
+    )
+    suspend fun countExact(from: String, to: String, type: RelationshipType): Int
+
+    /**
+     * ABORT rather than REPLACE: a colliding insert means the edge already exists, and the caller
+     * needs to know that instead of silently replacing a row (and its id) that other data may
+     * reference.
+     */
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    suspend fun insert(relationship: Relationship)
+
+    /** Used by import, where an already-present edge is expected and simply nothing to do. */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertIgnoringDuplicates(relationships: List<Relationship>): List<Long>
+
+    @Delete
+    suspend fun delete(relationship: Relationship)
+
+    @Query("DELETE FROM relationships WHERE id = :id")
+    suspend fun deleteById(id: String)
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
@@ -40,7 +40,7 @@ interface RelationshipDao {
         SELECT p.* FROM people p
         JOIN relationships r ON r.toPersonId = p.id
         WHERE r.fromPersonId = :personId AND r.type = 'PARENT'
-        ORDER BY p.birthDate
+        ORDER BY CASE WHEN p.birthDate IS NULL THEN 1 ELSE 0 END, p.birthDate
         """
     )
     fun observeChildren(personId: String): Flow<List<Person>>

--- a/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipType.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipType.kt
@@ -1,0 +1,42 @@
+package com.vibethroughcode.ftree.data
+
+/**
+ * Edge kinds in the family graph.
+ *
+ * Stored as the enum *name* in a TEXT column rather than as an ordinal, so adding a new kind is
+ * additive and never renumbers existing rows. [UNKNOWN] is the fallback for a value written by a
+ * newer version of the app (or a newer export) than the one doing the reading — a row is never
+ * dropped just because its type is unrecognised.
+ */
+enum class RelationshipType {
+    /** Directed: `from` is the parent of `to`. */
+    PARENT,
+
+    /** Symmetric. */
+    SPOUSE,
+
+    /**
+     * Symmetric, and deliberately rare: siblings are normally *derived* from shared parents.
+     * An explicit edge exists only when the shared parents are unknown.
+     */
+    SIBLING,
+
+    UNKNOWN;
+
+    /** Symmetric edges are stored canonically so that duplicates collide on the unique index. */
+    val isSymmetric: Boolean get() = this == SPOUSE || this == SIBLING
+
+    companion object {
+        fun fromName(value: String?): RelationshipType =
+            entries.firstOrNull { it.name == value } ?: UNKNOWN
+    }
+}
+
+/** How a parent relates to a child. Stored as free text in `subtype`; absent means biological. */
+enum class ParentKind { BIOLOGICAL, ADOPTIVE, STEP, FOSTER }
+
+/** The state of a spouse relationship. Absent means simply "married or partnered". */
+enum class SpouseKind { MARRIED, PARTNER, DIVORCED, WIDOWED }
+
+/** Only meaningful on explicit sibling edges. */
+enum class SiblingKind { FULL, HALF }

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/FamilyGraph.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/FamilyGraph.kt
@@ -1,0 +1,59 @@
+package com.vibethroughcode.ftree.graph
+
+/**
+ * Graph algorithms over the family tree.
+ *
+ * These take an adjacency lookup rather than a database, which keeps them ordinary functions:
+ * fast to run, trivial to test, and impossible to accidentally couple to Room. The lookups are
+ * `suspend` so the same implementation serves both a live database walk and an in-memory one — a
+ * plain lambda satisfies a suspending function type, so callers with data already loaded pay
+ * nothing for it.
+ */
+object FamilyGraph {
+
+    /**
+     * Every ancestor of [personId], walking upwards.
+     *
+     * The visited set makes this safe even if the stored data somehow already contains a cycle, so
+     * one bad row can never hang the app.
+     */
+    suspend fun ancestorsOf(
+        personId: String,
+        parentsOf: suspend (String) -> List<String>,
+    ): Set<String> = reachable(personId, parentsOf)
+
+    /** Everyone reachable downwards from [personId]. */
+    suspend fun descendantsOf(
+        personId: String,
+        childrenOf: suspend (String) -> List<String>,
+    ): Set<String> = reachable(personId, childrenOf)
+
+    /**
+     * True when making [parentId] a parent of [childId] would make someone their own ancestor.
+     *
+     * Genealogically this is nonsense, and structurally it would let a tree walk upwards forever,
+     * so it is rejected when the edge is created rather than defended against at every read.
+     *
+     * Checked by walking *up* from the proposed parent: if the proposed child is already somewhere
+     * above them, the edge would close a loop.
+     */
+    suspend fun wouldCreateAncestorCycle(
+        parentId: String,
+        childId: String,
+        parentsOf: suspend (String) -> List<String>,
+    ): Boolean = parentId == childId || childId in ancestorsOf(parentId, parentsOf)
+
+    private suspend fun reachable(
+        start: String,
+        next: suspend (String) -> List<String>,
+    ): Set<String> {
+        val found = LinkedHashSet<String>()
+        val queue = ArrayDeque(next(start))
+        while (queue.isNotEmpty()) {
+            val node = queue.removeFirst()
+            if (node == start || !found.add(node)) continue
+            queue.addAll(next(node))
+        }
+        return found
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/RelationshipRules.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/RelationshipRules.kt
@@ -1,0 +1,69 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.RelationshipType
+
+/** Why a proposed relationship was refused. */
+enum class RelationshipRejection {
+    /** A person cannot be their own parent, spouse or sibling. */
+    SELF_REFERENCE,
+
+    /** The same edge, in either direction for symmetric types, already exists. */
+    DUPLICATE,
+
+    /** The edge would make someone their own ancestor. */
+    ANCESTOR_CYCLE,
+
+    /** The two people are already parent and child, so they cannot also be siblings or spouses. */
+    CONTRADICTS_EXISTING,
+}
+
+sealed interface RelationshipCheck {
+    data object Allowed : RelationshipCheck
+    data class Rejected(val reason: RelationshipRejection) : RelationshipCheck
+}
+
+/**
+ * Whether a proposed edge is a sane thing to record.
+ *
+ * Kept pure — it is handed the small amount of graph context it needs — so that the rules can be
+ * exhaustively unit tested without a database, and so the same rules apply whether an edge arrives
+ * from the UI or from an import.
+ */
+object RelationshipRules {
+
+    suspend fun check(
+        fromPersonId: String,
+        toPersonId: String,
+        type: RelationshipType,
+        existingEdgeExists: suspend (from: String, to: String, type: RelationshipType) -> Boolean,
+        parentsOf: suspend (String) -> List<String>,
+    ): RelationshipCheck {
+        if (fromPersonId == toPersonId) {
+            return RelationshipCheck.Rejected(RelationshipRejection.SELF_REFERENCE)
+        }
+
+        val duplicate = existingEdgeExists(fromPersonId, toPersonId, type) ||
+            (type.isSymmetric && existingEdgeExists(toPersonId, fromPersonId, type))
+        if (duplicate) {
+            return RelationshipCheck.Rejected(RelationshipRejection.DUPLICATE)
+        }
+
+        // A parent cannot also be a spouse or sibling of their own child.
+        if (type != RelationshipType.PARENT) {
+            val alreadyParentChild =
+                existingEdgeExists(fromPersonId, toPersonId, RelationshipType.PARENT) ||
+                    existingEdgeExists(toPersonId, fromPersonId, RelationshipType.PARENT)
+            if (alreadyParentChild) {
+                return RelationshipCheck.Rejected(RelationshipRejection.CONTRADICTS_EXISTING)
+            }
+        }
+
+        if (type == RelationshipType.PARENT &&
+            FamilyGraph.wouldCreateAncestorCycle(fromPersonId, toPersonId, parentsOf)
+        ) {
+            return RelationshipCheck.Rejected(RelationshipRejection.ANCESTOR_CYCLE)
+        }
+
+        return RelationshipCheck.Allowed
+    }
+}

--- a/app/src/test/java/com/vibethroughcode/ftree/data/PartialDateTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/data/PartialDateTest.kt
@@ -1,0 +1,80 @@
+package com.vibethroughcode.ftree.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class PartialDateTest {
+
+    @Test
+    fun `parses all three precisions`() {
+        assertEquals(PartialDate(1938), PartialDate.parse("1938"))
+        assertEquals(PartialDate(1938, 4), PartialDate.parse("1938-04"))
+        assertEquals(PartialDate(1938, 4, 17), PartialDate.parse("1938-04-17"))
+    }
+
+    @Test
+    fun `rejects malformed and impossible dates`() {
+        assertNull(PartialDate.parse(null))
+        assertNull(PartialDate.parse(""))
+        assertNull(PartialDate.parse("38"))
+        assertNull(PartialDate.parse("1938-4-17"))
+        assertNull(PartialDate.parse("1938-13"))
+        assertNull(PartialDate.parse("1938-02-30"))
+        assertNull(PartialDate.parse("not a date"))
+    }
+
+    @Test
+    fun `round trips through serialisation`() {
+        listOf("1938", "1938-04", "1938-04-17").forEach {
+            assertEquals(it, PartialDate.parse(it)!!.serialize())
+        }
+    }
+
+    @Test
+    fun `a year spans the whole year`() {
+        val year = PartialDate.parse("1938")!!
+        assertEquals(LocalDate.of(1938, 1, 1), year.earliest())
+        assertEquals(LocalDate.of(1938, 12, 31), year.latest())
+    }
+
+    @Test
+    fun `a month spans that month including a leap day`() {
+        val february = PartialDate.parse("2024-02")!!
+        assertEquals(LocalDate.of(2024, 2, 1), february.earliest())
+        assertEquals(LocalDate.of(2024, 2, 29), february.latest())
+    }
+
+    @Test
+    fun `dates of differing precision are compatible when they could be the same day`() {
+        val year = PartialDate.parse("1938")!!
+        val exact = PartialDate.parse("1938-04-17")!!
+        val otherYear = PartialDate.parse("1939")!!
+
+        assertTrue(year.isCompatibleWith(exact))
+        assertTrue(exact.isCompatibleWith(year))
+        assertFalse(year.isCompatibleWith(otherYear))
+    }
+
+    @Test
+    fun `orders by earliest possible instant`() {
+        val sorted = listOf("1940", "1938-04-17", "1938").mapNotNull(PartialDate::parse).sorted()
+        assertEquals(listOf("1938", "1938-04-17", "1940"), sorted.map { it.serialize() })
+    }
+
+    @Test
+    fun `years between is null when the end precedes the start`() {
+        val born = PartialDate.parse("1990")!!
+        val died = PartialDate.parse("1980")!!
+        assertNull(yearsBetween(born, died))
+    }
+
+    @Test
+    fun `years between counts whole years`() {
+        assertEquals(42, yearsBetween(PartialDate.parse("1938-04-17")!!, PartialDate.parse("1980-05-01")!!))
+        assertEquals(41, yearsBetween(PartialDate.parse("1938-04-17")!!, PartialDate.parse("1980-03-01")!!))
+    }
+}

--- a/app/src/test/java/com/vibethroughcode/ftree/data/PersonTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/data/PersonTest.kt
@@ -1,0 +1,55 @@
+package com.vibethroughcode.ftree.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+
+class PersonTest {
+
+    private val today = LocalDate.of(2026, 8, 30)
+
+    @Test
+    fun `a person with no details at all is valid and unnamed`() {
+        val unknown = Person()
+        assertTrue(unknown.isUnnamed)
+        assertNull(unknown.age(today))
+    }
+
+    @Test
+    fun `blank names count as unnamed`() {
+        assertTrue(Person(name = "   ").isUnnamed)
+        assertFalse(Person(name = "Ankit").isUnnamed)
+    }
+
+    @Test
+    fun `age is derived from the birth date`() {
+        val person = Person(name = "Ankit", birthDate = "1990-05-01")
+        assertEquals(36, person.age(today))
+    }
+
+    @Test
+    fun `a birthday later this year has not happened yet`() {
+        val person = Person(name = "Ankit", birthDate = "1990-12-01")
+        assertEquals(35, person.age(today))
+    }
+
+    @Test
+    fun `a year-only birth date still yields an age`() {
+        assertEquals(88, Person(birthDate = "1938").age(today))
+    }
+
+    @Test
+    fun `age at death is used once someone has died`() {
+        val person = Person(name = "Grandfather", birthDate = "1938", deathDate = "2010", deceased = true)
+        assertEquals(72, person.age(today))
+    }
+
+    @Test
+    fun `no age is claimed for someone known dead on an unknown date`() {
+        val person = Person(name = "Grandfather", birthDate = "1938", deceased = true)
+        assertNull(person.age(today))
+    }
+}

--- a/app/src/test/java/com/vibethroughcode/ftree/data/RelationshipTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/data/RelationshipTest.kt
@@ -1,0 +1,49 @@
+package com.vibethroughcode.ftree.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RelationshipTest {
+
+    @Test
+    fun `symmetric edges are stored in canonical order whichever way round they are created`() {
+        val one = Relationship.of("zoe", "adam", RelationshipType.SPOUSE)
+        val other = Relationship.of("adam", "zoe", RelationshipType.SPOUSE)
+
+        assertEquals("adam", one.fromPersonId)
+        assertEquals("zoe", one.toPersonId)
+        assertEquals(one.fromPersonId, other.fromPersonId)
+        assertEquals(one.toPersonId, other.toPersonId)
+    }
+
+    @Test
+    fun `parent edges keep their direction because it carries meaning`() {
+        val edge = Relationship.of("zoe", "adam", RelationshipType.PARENT)
+        assertEquals("zoe", edge.fromPersonId)
+        assertEquals("adam", edge.toPersonId)
+    }
+
+    @Test
+    fun `the other end of an edge is resolvable from either side`() {
+        val edge = Relationship.of("a", "b", RelationshipType.SPOUSE)
+        assertEquals("b", edge.other("a"))
+        assertEquals("a", edge.other("b"))
+        assertNull(edge.other("someone-else"))
+    }
+
+    @Test
+    fun `an unrecognised type falls back to UNKNOWN rather than failing`() {
+        assertEquals(RelationshipType.UNKNOWN, RelationshipType.fromName("GODPARENT_FROM_A_FUTURE_VERSION"))
+        assertEquals(RelationshipType.UNKNOWN, RelationshipType.fromName(null))
+        assertEquals(RelationshipType.PARENT, RelationshipType.fromName("PARENT"))
+    }
+
+    @Test
+    fun `only spouse and sibling are symmetric`() {
+        assertTrue(RelationshipType.SPOUSE.isSymmetric)
+        assertTrue(RelationshipType.SIBLING.isSymmetric)
+        assertEquals(false, RelationshipType.PARENT.isSymmetric)
+    }
+}

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/FamilyGraphTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/FamilyGraphTest.kt
@@ -1,0 +1,71 @@
+package com.vibethroughcode.ftree.graph
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FamilyGraphTest {
+
+    // great-grandfather -> grandfather -> father -> me, plus an unrelated branch
+    private val parents = mapOf(
+        "me" to listOf("father", "mother"),
+        "father" to listOf("grandfather"),
+        "grandfather" to listOf("great-grandfather"),
+        "mother" to emptyList(),
+        "sister" to listOf("father", "mother"),
+    )
+    private val parentsOf: (String) -> List<String> = { parents[it].orEmpty() }
+
+    private val children = parents.entries
+        .flatMap { (child, ps) -> ps.map { it to child } }
+        .groupBy({ it.first }, { it.second })
+    private val childrenOf: (String) -> List<String> = { children[it].orEmpty() }
+
+    @Test
+    fun `ancestors walk the whole way up`() = runTest {
+        assertEquals(
+            setOf("father", "mother", "grandfather", "great-grandfather"),
+            FamilyGraph.ancestorsOf("me", parentsOf),
+        )
+    }
+
+    @Test
+    fun `someone with no recorded parents has no ancestors`() = runTest {
+        assertEquals(emptySet<String>(), FamilyGraph.ancestorsOf("great-grandfather", parentsOf))
+    }
+
+    @Test
+    fun `descendants walk the whole way down`() = runTest {
+        assertEquals(
+            setOf("grandfather", "father", "me", "sister"),
+            FamilyGraph.descendantsOf("great-grandfather", childrenOf),
+        )
+    }
+
+    @Test
+    fun `a person cannot be their own parent`() = runTest {
+        assertTrue(FamilyGraph.wouldCreateAncestorCycle("me", "me", parentsOf))
+    }
+
+    @Test
+    fun `making a descendant into an ancestor is a cycle`() = runTest {
+        // "me" becoming the parent of "grandfather" would close the loop.
+        assertTrue(FamilyGraph.wouldCreateAncestorCycle("me", "grandfather", parentsOf))
+        assertTrue(FamilyGraph.wouldCreateAncestorCycle("father", "great-grandfather", parentsOf))
+    }
+
+    @Test
+    fun `ordinary new parents are not cycles`() = runTest {
+        assertFalse(FamilyGraph.wouldCreateAncestorCycle("great-grandfather", "someone-new", parentsOf))
+        assertFalse(FamilyGraph.wouldCreateAncestorCycle("me", "my-child", parentsOf))
+    }
+
+    @Test
+    fun `already-cyclic data is traversed without hanging`() = runTest {
+        val cyclic = mapOf("a" to listOf("b"), "b" to listOf("c"), "c" to listOf("a"))
+        val lookup: (String) -> List<String> = { cyclic[it].orEmpty() }
+        assertEquals(setOf("b", "c"), FamilyGraph.ancestorsOf("a", lookup))
+    }
+}

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/RelationshipRulesTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/RelationshipRulesTest.kt
@@ -1,0 +1,88 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.RelationshipType
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RelationshipRulesTest {
+
+    /** Edges present in the fake graph, as (from, to, type). */
+    private fun rules(
+        existing: Set<Triple<String, String, RelationshipType>> = emptySet(),
+        parents: Map<String, List<String>> = emptyMap(),
+    ): suspend (String, String, RelationshipType) -> RelationshipCheck = { from, to, type ->
+        RelationshipRules.check(
+            fromPersonId = from,
+            toPersonId = to,
+            type = type,
+            existingEdgeExists = { f, t, ty -> Triple(f, t, ty) in existing },
+            parentsOf = { parents[it].orEmpty() },
+        )
+    }
+
+    private fun assertRejected(reason: RelationshipRejection, actual: RelationshipCheck) =
+        assertEquals(RelationshipCheck.Rejected(reason), actual)
+
+    @Test
+    fun `a person cannot be their own parent spouse or sibling`() = runTest {
+        val check = rules()
+        RelationshipType.entries.forEach { type ->
+            assertRejected(RelationshipRejection.SELF_REFERENCE, check("me", "me", type))
+        }
+    }
+
+    @Test
+    fun `an identical edge is a duplicate`() = runTest {
+        val check = rules(existing = setOf(Triple("father", "me", RelationshipType.PARENT)))
+        assertRejected(RelationshipRejection.DUPLICATE, check("father", "me", RelationshipType.PARENT))
+    }
+
+    @Test
+    fun `a symmetric edge is a duplicate from either side`() = runTest {
+        val check = rules(existing = setOf(Triple("a", "b", RelationshipType.SPOUSE)))
+        assertRejected(RelationshipRejection.DUPLICATE, check("b", "a", RelationshipType.SPOUSE))
+    }
+
+    @Test
+    fun `a parent edge is directional so the reverse is not a duplicate`() = runTest {
+        // father -> me existing must not block me -> father being *checked*; it is instead
+        // rejected as a cycle, which is the accurate reason.
+        val check = rules(
+            existing = setOf(Triple("father", "me", RelationshipType.PARENT)),
+            parents = mapOf("me" to listOf("father")),
+        )
+        assertRejected(RelationshipRejection.ANCESTOR_CYCLE, check("me", "father", RelationshipType.PARENT))
+    }
+
+    @Test
+    fun `a parent cannot also be a spouse or sibling of their child`() = runTest {
+        val check = rules(existing = setOf(Triple("father", "me", RelationshipType.PARENT)))
+        assertRejected(
+            RelationshipRejection.CONTRADICTS_EXISTING,
+            check("father", "me", RelationshipType.SPOUSE),
+        )
+        assertRejected(
+            RelationshipRejection.CONTRADICTS_EXISTING,
+            check("me", "father", RelationshipType.SIBLING),
+        )
+    }
+
+    @Test
+    fun `an edge that would make someone their own ancestor is rejected`() = runTest {
+        val check = rules(parents = mapOf("me" to listOf("father"), "father" to listOf("grandfather")))
+        assertRejected(
+            RelationshipRejection.ANCESTOR_CYCLE,
+            check("me", "grandfather", RelationshipType.PARENT),
+        )
+    }
+
+    @Test
+    fun `ordinary relationships are allowed`() = runTest {
+        val check = rules(parents = mapOf("me" to listOf("father")))
+        assertEquals(RelationshipCheck.Allowed, check("mother", "me", RelationshipType.PARENT))
+        assertEquals(RelationshipCheck.Allowed, check("me", "wife", RelationshipType.SPOUSE))
+        assertEquals(RelationshipCheck.Allowed, check("me", "child", RelationshipType.PARENT))
+        assertEquals(RelationshipCheck.Allowed, check("me", "brother", RelationshipType.SIBLING))
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ room = "2.8.4"
 serialization = "1.11.0"
 coil = "3.6.0"
 junit = "4.13.2"
-coroutines = "1.11.0"
+coroutines = "1.10.2"
 androidxJunit = "1.3.0"
 espresso = "3.7.0"
 


### PR DESCRIPTION
Closes #1.

Establishes the Room schema, DAOs and repository that the rest of the app builds on.

## The shape of the model

People plus typed edges, not a nested tree. Multiple spouses, children across different spouses,
half-siblings and unknown ancestors then all work with no special-casing.

| Table | Purpose |
|---|---|
| `people` | every field optional; a null name **is** the unknown-person mechanism |
| `relationships` | `PARENT` (directed), `SPOUSE`/`SIBLING` (symmetric, canonical order) |
| `person_origins` | provenance, so a later re-import can match exactly instead of guessing |

## Decisions

- **Symmetric edges are stored canonically** (lower id first), so a unique index on
  `(from, to, type)` makes duplicate prevention a database guarantee rather than a race the app
  has to win. Adding a spouse from either side describes one marriage, not two.
- **Partial ISO dates** (`1938`, `1938-04`, `1938-04-17`) mean nobody has to invent a day they do
  not know, and no separate "is approximate" flag is needed — the precision is the statement.
  Age is derived from them, never stored.
- **Siblings are derived** from shared parents in SQL rather than stored. They stay correct when a
  parent is added later, and the graph never accumulates O(n²) redundant edges. Explicit sibling
  edges remain only for siblings whose parents are unknown.
- **Relationship type is persisted by name with an `UNKNOWN` fallback**, so a future edge kind
  needs no migration and a row written by a newer version is degraded rather than dropped.
- **Two deletion modes**, because losing one name should not tear a hole in the family:
  *keep as unknown* strips details but preserves every edge; *delete completely* cascades.
- **No DI framework.** A hand-rolled `AppContainer` wires one repository for a handful of screens.

## Tests

51 green: 35 JVM unit tests over the pure logic, 16 instrumented tests over the schema on
`pixel7_api36`. The database tests assert the guarantees rather than the happy path — duplicate
rejection from either direction, foreign keys refusing dangling edges, both deletion modes,
half-sibling derivation, and forward-compatible relationship types.

Coroutines-test is pinned to 1.10.2 to match the runtime version AndroidX constrains the app to;
the 1.11.0 test artifact failed on device with `NoSuchMethodError`.