### PR TITLE
Relationships and the flow for building a family

### DIFF
--- a/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyRepositoryTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyRepositoryTest.kt
@@ -1,0 +1,241 @@
+package com.vibethroughcode.ftree.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vibethroughcode.ftree.graph.RelationshipRejection
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** The relationship operations as the user experiences them, over a real database. */
+@RunWith(AndroidJUnit4::class)
+class FamilyRepositoryTest {
+
+    private lateinit var db: FTreeDatabase
+    private lateinit var repository: FamilyRepository
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, FTreeDatabase::class.java)
+            .addCallback(FTreeDatabase.enforceForeignKeys)
+            .build()
+        repository = FamilyRepository(db)
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    private suspend fun person(id: String, name: String? = null): String {
+        repository.addPerson(Person(id = id, name = name))
+        return id
+    }
+
+    private fun Result<*>.rejection(): RelationshipRejection? =
+        (exceptionOrNull() as? RelationshipRejectedException)?.reason
+
+    @Test
+    fun addingAParentIsReadableFromBothEnds() = runTest {
+        person("me", "Me"); person("father", "Father")
+
+        assertTrue(repository.addRelative("me", "father", RelativeKind.PARENT).isSuccess)
+
+        assertEquals(listOf("Father"), repository.observeParents("me").first().map { it.name })
+        assertEquals(listOf("Me"), repository.observeChildren("father").first().map { it.name })
+    }
+
+    @Test
+    fun addingAChildIsTheSameEdgeSeenTheOtherWay() = runTest {
+        person("me", "Me"); person("kid", "Kid")
+
+        repository.addRelative("me", "kid", RelativeKind.CHILD)
+
+        assertEquals(listOf("Kid"), repository.observeChildren("me").first().map { it.name })
+        assertEquals(listOf("Me"), repository.observeParents("kid").first().map { it.name })
+    }
+
+    @Test
+    fun aSpouseIsRecordedOnceAndReadsFromEitherSide() = runTest {
+        person("me", "Me"); person("wife", "Wife")
+
+        repository.addRelative("me", "wife", RelativeKind.SPOUSE)
+
+        assertEquals(listOf("Wife"), repository.observeSpouses("me").first().map { it.name })
+        assertEquals(listOf("Me"), repository.observeSpouses("wife").first().map { it.name })
+        assertEquals(1, db.relationshipDao().allRelationships().size)
+    }
+
+    @Test
+    fun aSiblingIsAttachedToTheParentsThatMakeThemOne() = runTest {
+        person("father", "Father"); person("mother", "Mother")
+        person("me", "Me"); person("brother", "Brother")
+        repository.addRelative("me", "father", RelativeKind.PARENT)
+        repository.addRelative("me", "mother", RelativeKind.PARENT)
+
+        repository.addRelative("me", "brother", RelativeKind.SIBLING)
+
+        // Not an explicit sibling edge — they share the parents, which is what makes them siblings
+        // and what keeps the relationship true as more is recorded.
+        assertEquals(
+            setOf("Father", "Mother"),
+            repository.observeParents("brother").first().map { it.name }.toSet(),
+        )
+        assertEquals(listOf("Brother"), repository.observeSiblings("me").first().map { it.name })
+        assertTrue(db.relationshipDao().allRelationships().none { it.type == RelationshipType.SIBLING })
+    }
+
+    @Test
+    fun aSiblingWithNoKnownParentsGetsAnExplicitEdge() = runTest {
+        person("me", "Me"); person("brother", "Brother")
+
+        repository.addRelative("me", "brother", RelativeKind.SIBLING)
+
+        assertEquals(listOf("Brother"), repository.observeSiblings("me").first().map { it.name })
+        assertEquals(
+            listOf(RelationshipType.SIBLING),
+            db.relationshipDao().allRelationships().map { it.type },
+        )
+    }
+
+    @Test
+    fun addingASiblingWhoAlreadySharesOneParentIsNotAnError() = runTest {
+        person("father"); person("mother")
+        person("me", "Me"); person("halfBrother", "Half brother")
+        repository.addRelative("me", "father", RelativeKind.PARENT)
+        repository.addRelative("me", "mother", RelativeKind.PARENT)
+        repository.addRelative("halfBrother", "father", RelativeKind.PARENT)
+
+        val result = repository.addRelative("me", "halfBrother", RelativeKind.SIBLING)
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, repository.observeParents("halfBrother").first().size)
+    }
+
+    @Test
+    fun nobodyCanBeTheirOwnRelative() = runTest {
+        person("me")
+        RelativeKind.entries.forEach { kind ->
+            assertEquals(
+                RelationshipRejection.SELF_REFERENCE,
+                repository.addRelative("me", "me", kind).rejection(),
+            )
+        }
+    }
+
+    @Test
+    fun theSameRelationshipCannotBeRecordedTwice() = runTest {
+        person("me"); person("father")
+        repository.addRelative("me", "father", RelativeKind.PARENT)
+
+        assertEquals(
+            RelationshipRejection.DUPLICATE,
+            repository.addRelative("me", "father", RelativeKind.PARENT).rejection(),
+        )
+    }
+
+    @Test
+    fun aSpouseCannotBeAddedTwiceFromTheOtherSide() = runTest {
+        person("me"); person("wife")
+        repository.addRelative("me", "wife", RelativeKind.SPOUSE)
+
+        assertEquals(
+            RelationshipRejection.DUPLICATE,
+            repository.addRelative("wife", "me", RelativeKind.SPOUSE).rejection(),
+        )
+    }
+
+    @Test
+    fun someoneCannotBecomeTheirOwnAncestor() = runTest {
+        person("grandfather"); person("father"); person("me")
+        repository.addRelative("father", "grandfather", RelativeKind.PARENT)
+        repository.addRelative("me", "father", RelativeKind.PARENT)
+
+        assertEquals(
+            RelationshipRejection.ANCESTOR_CYCLE,
+            repository.addRelative("grandfather", "me", RelativeKind.PARENT).rejection(),
+        )
+    }
+
+    @Test
+    fun aParentCannotAlsoBeMarkedAsASpouse() = runTest {
+        person("father"); person("me")
+        repository.addRelative("me", "father", RelativeKind.PARENT)
+
+        assertEquals(
+            RelationshipRejection.CONTRADICTS_EXISTING,
+            repository.addRelative("me", "father", RelativeKind.SPOUSE).rejection(),
+        )
+    }
+
+    @Test
+    fun aFailedAddLeavesTheTreeExactlyAsItWas() = runTest {
+        person("me", "Me"); person("father", "Father")
+        repository.addRelative("me", "father", RelativeKind.PARENT)
+        val peopleBefore = db.personDao().count()
+        val edgesBefore = db.relationshipDao().allRelationships().size
+
+        // A colliding id is a caller mistake; it must surface as a failed Result rather than
+        // crashing or leaving the person written without their relationship.
+        val result = repository.addNewRelative("me", Person(id = "father"), RelativeKind.PARENT)
+
+        assertTrue(result.isFailure)
+        assertEquals(peopleBefore, db.personDao().count())
+        assertEquals(edgesBefore, db.relationshipDao().allRelationships().size)
+    }
+
+    @Test
+    fun creatingAnUnknownRelativeRecordsARealPerson() = runTest {
+        person("me", "Me")
+
+        val result = repository.addNewRelative("me", Person(), RelativeKind.PARENT)
+
+        assertTrue(result.isSuccess)
+        val parents = repository.observeParents("me").first()
+        assertEquals(1, parents.size)
+        assertTrue(parents.single().isUnnamed)
+    }
+
+    @Test
+    fun anUnknownRelativeCanBeNamedLaterWithoutTouchingTheRelationship() = runTest {
+        person("me", "Me")
+        val unknown = repository.addNewRelative("me", Person(), RelativeKind.PARENT).getOrThrow()
+
+        repository.updatePerson(unknown.copy(name = "Raj Kumar"))
+
+        assertEquals(listOf("Raj Kumar"), repository.observeParents("me").first().map { it.name })
+    }
+
+    @Test
+    fun removingARelationshipKeepsBothPeople() = runTest {
+        person("me", "Me"); person("father", "Father")
+        repository.addRelative("me", "father", RelativeKind.PARENT)
+
+        repository.edgesBetween("me", "father").forEach { repository.removeRelationship(it.id) }
+
+        assertEquals(emptyList<Person>(), repository.observeParents("me").first())
+        assertEquals(2, db.personDao().count())
+    }
+
+    @Test
+    fun childrenAcrossTwoMarriagesAreHalfSiblings() = runTest {
+        person("me", "Me"); person("first", "First"); person("second", "Second")
+        person("a", "A"); person("b", "B")
+        repository.addRelative("me", "first", RelativeKind.SPOUSE)
+        repository.addRelative("me", "second", RelativeKind.SPOUSE)
+        repository.addRelative("me", "a", RelativeKind.CHILD)
+        repository.addRelative("first", "a", RelativeKind.CHILD)
+        repository.addRelative("me", "b", RelativeKind.CHILD)
+        repository.addRelative("second", "b", RelativeKind.CHILD)
+
+        assertEquals(setOf("A", "B"), repository.observeChildren("me").first().map { it.name }.toSet())
+        assertEquals(listOf("B"), repository.observeSiblings("a").first().map { it.name })
+        assertEquals(2, repository.observeSpouses("me").first().size)
+    }
+}

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationshipFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationshipFlowTest.kt
@@ -1,0 +1,170 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.ui.person.EditNameFieldTag
+import com.vibethroughcode.ftree.ui.person.EditSaveTag
+import com.vibethroughcode.ftree.ui.person.PersonEditTag
+import com.vibethroughcode.ftree.ui.person.addSectionTag
+import com.vibethroughcode.ftree.ui.relative.AddRelativeNameTag
+import com.vibethroughcode.ftree.ui.relative.AddRelativeSaveTag
+import com.vibethroughcode.ftree.ui.relative.AddRelativeUnknownTag
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Building a family out from one person — the flow the whole app is organised around.
+ */
+@RunWith(AndroidJUnit4::class)
+class RelationshipFlowTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    @Before
+    fun emptyTheTree() {
+        val app = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+        app.container.database.clearAllTables()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Build your family tree").fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithText("Add your first person").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(EditNameFieldTag).performTextInput("Ankit")
+        rule.onNodeWithTag(EditSaveTag).performScrollTo().performClick()
+        rule.waitForIdle()
+    }
+
+    /** Adds a named relative of [kind] to whoever's page is open. */
+    private fun addRelative(kind: RelativeKind, name: String) {
+        rule.onNodeWithTag(addSectionTag(kind)).performScrollTo().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(AddRelativeNameTag).performTextInput(name)
+        rule.onNodeWithTag(AddRelativeSaveTag).performScrollTo().performClick()
+        rule.waitForIdle()
+    }
+
+    @Test
+    fun parentsSpousesAndChildrenAllAttachToTheOpenPerson() {
+        addRelative(RelativeKind.PARENT, "Raj Kumar")
+        addRelative(RelativeKind.SPOUSE, "Priya")
+        addRelative(RelativeKind.CHILD, "Aarav")
+
+        rule.onNodeWithText("Raj Kumar").assertIsDisplayed()
+        rule.onNodeWithText("Priya").assertIsDisplayed()
+        rule.onNodeWithText("Aarav").assertIsDisplayed()
+    }
+
+    @Test
+    fun aRelativeIsLabelledByTheRoleTheyPlay() {
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(AddRelativeNameTag).performTextInput("Raj Kumar")
+        rule.onNodeWithText("Male").performClick()
+        rule.onNodeWithTag(AddRelativeSaveTag).performScrollTo().performClick()
+        rule.waitForIdle()
+
+        // The graph stores one PARENT edge; the reader sees "Father".
+        rule.onNodeWithText("Father").assertIsDisplayed()
+    }
+
+    @Test
+    fun aRelativeWhoseNameIsUnknownIsStillARealPerson() {
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(AddRelativeUnknownTag).performScrollTo().performClick()
+        rule.waitForIdle()
+
+        rule.onNodeWithText("Unknown").assertIsDisplayed()
+    }
+
+    @Test
+    fun anUnknownRelativeCanBeNamedLaterWithoutLosingTheConnection() {
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(AddRelativeUnknownTag).performScrollTo().performClick()
+        rule.waitForIdle()
+
+        // Open the placeholder and give them a name.
+        rule.onNodeWithText("Unknown").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(PersonEditTag).performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(EditNameFieldTag).performTextInput("Raj Kumar")
+        rule.onNodeWithTag(EditSaveTag).performScrollTo().performClick()
+        rule.waitForIdle()
+
+        // Back on Ankit, the same relationship now names them.
+        rule.onNodeWithContentDescription("Back").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithText("Raj Kumar").assertIsDisplayed()
+    }
+
+    @Test
+    fun siblingsAreDerivedFromTheParentsTheyShare() {
+        addRelative(RelativeKind.PARENT, "Raj Kumar")
+        addRelative(RelativeKind.SIBLING, "Neha")
+
+        rule.onNodeWithText("Neha").assertIsDisplayed()
+
+        // Neha is attached to the same parent, which is what makes them siblings.
+        rule.onNodeWithText("Neha").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithText("Raj Kumar").assertIsDisplayed()
+        rule.onNodeWithText("Ankit").assertIsDisplayed()
+    }
+
+    @Test
+    fun navigatingBetweenRelativesWorksInBothDirections() {
+        addRelative(RelativeKind.CHILD, "Aarav")
+
+        rule.onNodeWithText("Aarav").performClick()
+        rule.waitForIdle()
+        // From the child's page, the anchor now appears as a parent.
+        rule.onNodeWithText("Ankit").assertIsDisplayed()
+
+        rule.onNodeWithText("Ankit").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithText("Aarav").assertIsDisplayed()
+    }
+
+    @Test
+    fun aDescendantIsNotOfferedAsAPossibleParent() {
+        addRelative(RelativeKind.CHILD, "Aarav")
+
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.waitForIdle()
+
+        // Aarav could only ever be refused as a parent, so he is not offered at all.
+        assertTrue(rule.onAllNodesWithText("Aarav").fetchSemanticsNodes().isEmpty())
+    }
+
+    @Test
+    fun anAlreadyRecordedRelationshipIsRefusedWithAReason() {
+        addRelative(RelativeKind.PARENT, "Raj Kumar")
+
+        // Try to add the same person as a parent a second time.
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithText("Raj Kumar").performScrollTo().performClick()
+        rule.waitForIdle()
+
+        rule.onNodeWithText("That relationship is already recorded.").assertIsDisplayed()
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!--
+          Debug builds only. Lets `adb shell am broadcast` fill the tree with a realistic family,
+          which is how the chart and large-tree behaviour get exercised without tapping through
+          hundreds of forms. Never present in a release build.
+        -->
+        <receiver
+            android:name=".debug.SeedReceiver"
+            android:exported="true" />
+    </application>
+</manifest>

--- a/app/src/debug/java/com/vibethroughcode/ftree/debug/SampleData.kt
+++ b/app/src/debug/java/com/vibethroughcode/ftree/debug/SampleData.kt
@@ -1,0 +1,130 @@
+package com.vibethroughcode.ftree.debug
+
+import com.vibethroughcode.ftree.data.FTreeDatabase
+import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+
+/**
+ * Sample trees for development.
+ *
+ * [family] is deliberately awkward rather than tidy: it has unknown ancestors, two marriages,
+ * half-siblings and a person with no dates, because those are the cases the layout and the merge
+ * logic have to survive and a clean nuclear family would prove nothing.
+ */
+class SampleData(
+    private val repository: FamilyRepository,
+    private val database: FTreeDatabase,
+) {
+
+    suspend fun clear() = database.clearAllTables()
+
+    suspend fun family() {
+        clear()
+
+        suspend fun add(
+            name: String?,
+            gender: Gender = Gender.UNSPECIFIED,
+            born: String? = null,
+            died: String? = null,
+        ): String {
+            val person = Person(
+                name = name,
+                gender = gender,
+                birthDate = born,
+                deathDate = died,
+                deceased = died != null,
+            )
+            repository.addPerson(person)
+            return person.id
+        }
+
+        // Generation 1 — the edge of what is remembered.
+        val greatGrandfather = add("Shyam Lal", Gender.MALE, "1905", "1978")
+        val greatGrandmother = add(null, Gender.FEMALE)
+
+        // Generation 2
+        val grandfather = add("Raj Kumar", Gender.MALE, "1938", "2010")
+        val grandmother = add("Sushila Devi", Gender.FEMALE, "1942")
+        val greatUncle = add(null, Gender.MALE)
+
+        // Generation 3
+        val father = add("Vinod Kumar", Gender.MALE, "1962")
+        val mother = add("Anita Kumar", Gender.FEMALE, "1965")
+        val aunt = add("Meena", Gender.FEMALE, "1968")
+
+        // Generation 4
+        val me = add("Ankit Kumar", Gender.MALE, "1990-05-01")
+        val sister = add("Neha Kumar", Gender.FEMALE, "1993")
+        val wife = add("Priya Sharma", Gender.FEMALE, "1992")
+        val cousin = add("Rohit", Gender.MALE, "1995")
+
+        // Generation 5
+        val child = add("Aarav Kumar", Gender.MALE, "2020")
+
+        listOf(greatGrandfather, greatGrandmother).forEach {
+            repository.addRelative(grandfather, it, RelativeKind.PARENT)
+            repository.addRelative(greatUncle, it, RelativeKind.PARENT)
+        }
+        repository.addRelative(greatGrandfather, greatGrandmother, RelativeKind.SPOUSE)
+
+        repository.addRelative(grandfather, grandmother, RelativeKind.SPOUSE)
+        listOf(father, aunt).forEach {
+            repository.addRelative(it, grandfather, RelativeKind.PARENT)
+            repository.addRelative(it, grandmother, RelativeKind.PARENT)
+        }
+
+        repository.addRelative(father, mother, RelativeKind.SPOUSE)
+        listOf(me, sister).forEach {
+            repository.addRelative(it, father, RelativeKind.PARENT)
+            repository.addRelative(it, mother, RelativeKind.PARENT)
+        }
+
+        repository.addRelative(aunt, cousin, RelativeKind.CHILD)
+
+        repository.addRelative(me, wife, RelativeKind.SPOUSE)
+        repository.addRelative(me, child, RelativeKind.CHILD)
+        repository.addRelative(wife, child, RelativeKind.CHILD)
+    }
+
+    /**
+     * A wide, deep tree for performance work: each generation has several children, so the person
+     * count grows quickly without the graph becoming unrealistic.
+     */
+    suspend fun large(size: Int) {
+        clear()
+        var created = 0
+        var generation = listOf(newPerson("Ancestor", 1900).also { created++ })
+        var year = 1900
+
+        while (created < size) {
+            year += 28
+            val next = mutableListOf<String>()
+            for (parent in generation) {
+                if (created >= size) break
+                val partner = newPerson(null, year - 26).also { created++ }
+                repository.addRelative(parent, partner, RelativeKind.SPOUSE)
+                repeat(3) {
+                    if (created >= size) return@repeat
+                    val child = newPerson("Person $created", year).also { created++ }
+                    repository.addRelative(child, parent, RelativeKind.PARENT)
+                    repository.addRelative(child, partner, RelativeKind.PARENT)
+                    next += child
+                }
+            }
+            if (next.isEmpty()) break
+            generation = next
+        }
+    }
+
+    private suspend fun newPerson(name: String?, born: Int): String {
+        val person = Person(
+            name = name,
+            gender = if (born % 2 == 0) Gender.MALE else Gender.FEMALE,
+            birthDate = born.toString(),
+        )
+        repository.addPerson(person)
+        return person.id
+    }
+}

--- a/app/src/debug/java/com/vibethroughcode/ftree/debug/SeedReceiver.kt
+++ b/app/src/debug/java/com/vibethroughcode/ftree/debug/SeedReceiver.kt
@@ -1,0 +1,48 @@
+package com.vibethroughcode.ftree.debug
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.vibethroughcode.ftree.FTreeApplication
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+/**
+ * Fills the tree with sample data, for development only.
+ *
+ * ```
+ * adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+ *     -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode family
+ * adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+ *     -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode large --ei size 2000
+ * adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+ *     -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode clear
+ * ```
+ */
+class SeedReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val app = context.applicationContext as FTreeApplication
+        val mode = intent.getStringExtra("mode") ?: "family"
+        val size = intent.getIntExtra("size", 500)
+        val pending = goAsync()
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val seeder = SampleData(app.container.familyRepository, app.container.database)
+                when (mode) {
+                    "clear" -> seeder.clear()
+                    "large" -> seeder.large(size)
+                    else -> seeder.family()
+                }
+                Log.i("SeedReceiver", "seeded: $mode")
+            } catch (e: Exception) {
+                Log.e("SeedReceiver", "seeding failed", e)
+            } finally {
+                pending.finish()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
@@ -1,6 +1,7 @@
 package com.vibethroughcode.ftree.data
 
 import androidx.room.withTransaction
+import com.vibethroughcode.ftree.graph.FamilyGraph
 import com.vibethroughcode.ftree.graph.RelationshipCheck
 import com.vibethroughcode.ftree.graph.RelationshipRejection
 import com.vibethroughcode.ftree.graph.RelationshipRules
@@ -44,6 +45,14 @@ class FamilyRepository(
 
     suspend fun person(id: String): Person? = people.findById(id)
     suspend fun relationshipCount(id: String): Int = relationships.edgeCount(id)
+
+    suspend fun edgesBetween(a: String, b: String): List<Relationship> = relationships.edgesBetween(a, b)
+
+    suspend fun ancestorIdsOf(personId: String): Set<String> =
+        FamilyGraph.ancestorsOf(personId) { relationships.parentIdsOf(it) }
+
+    suspend fun descendantIdsOf(personId: String): Set<String> =
+        FamilyGraph.descendantsOf(personId) { relationships.childIdsOf(it) }
 
     suspend fun addPerson(person: Person): Person {
         people.insert(person)
@@ -93,6 +102,72 @@ class FamilyRepository(
     }
 
     suspend fun removeRelationship(id: String) = relationships.deleteById(id)
+
+    /**
+     * Records a relationship the way the user described it.
+     *
+     * Adding a sibling is the one case that is not a single edge. If the anchor already has known
+     * parents, the new sibling is attached to those same parents — which is what actually makes
+     * them siblings, keeps half-siblings and later-added relatives consistent, and avoids inventing
+     * a placeholder parent nobody asked for. Only when no parents are known does an explicit
+     * sibling edge get written, because that is the one case shared parents cannot express.
+     */
+    suspend fun addRelative(
+        anchorId: String,
+        relativeId: String,
+        kind: RelativeKind,
+    ): Result<Unit> = when (kind) {
+        RelativeKind.PARENT -> addRelationship(relativeId, anchorId, RelationshipType.PARENT).map {}
+        RelativeKind.CHILD -> addRelationship(anchorId, relativeId, RelationshipType.PARENT).map {}
+        RelativeKind.SPOUSE -> addRelationship(anchorId, relativeId, RelationshipType.SPOUSE).map {}
+        RelativeKind.SIBLING -> addSibling(anchorId, relativeId)
+    }
+
+    private suspend fun addSibling(anchorId: String, siblingId: String): Result<Unit> {
+        if (anchorId == siblingId) {
+            return Result.failure(RelationshipRejectedException(RelationshipRejection.SELF_REFERENCE))
+        }
+        val parents = db.withTransaction { relationships.parentIdsOf(anchorId) }
+        if (parents.isEmpty()) {
+            return addRelationship(anchorId, siblingId, RelationshipType.SIBLING).map {}
+        }
+
+        // Attaching to shared parents is what makes them siblings. A parent the sibling already
+        // has is not an error, so a duplicate is skipped rather than failing the whole operation.
+        var attached = false
+        var lastFailure: Throwable? = null
+        parents.forEach { parentId ->
+            val result = addRelationship(parentId, siblingId, RelationshipType.PARENT)
+            result.onSuccess { attached = true }.onFailure { failure ->
+                val duplicate = (failure as? RelationshipRejectedException)?.reason ==
+                    RelationshipRejection.DUPLICATE
+                if (duplicate) attached = true else lastFailure = failure
+            }
+        }
+        return if (attached) Result.success(Unit) else Result.failure(
+            lastFailure ?: RelationshipRejectedException(RelationshipRejection.DUPLICATE)
+        )
+    }
+
+    /**
+     * Creates a person and relates them, atomically.
+     *
+     * Failure anywhere — the insert or the relationship rules — throws out of the transaction so
+     * the database rolls the whole thing back. That is stronger than deleting the person again by
+     * hand, which would only undo the cases it remembered to, and it means a caller mistake
+     * surfaces as a failed Result rather than a half-written tree.
+     */
+    suspend fun addNewRelative(
+        anchorId: String,
+        person: Person,
+        kind: RelativeKind,
+    ): Result<Person> = runCatching {
+        db.withTransaction {
+            people.insert(person)
+            addRelative(anchorId, person.id, kind).getOrThrow()
+            person
+        }
+    }
 
     suspend fun originsOf(personIds: List<String>): List<PersonOrigin> = origins.originsOf(personIds)
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
@@ -26,6 +26,16 @@ interface RelationshipDao {
     @Query("SELECT COUNT(*) FROM relationships WHERE fromPersonId = :personId OR toPersonId = :personId")
     suspend fun edgeCount(personId: String): Int
 
+    /** Every edge directly joining two people, in either direction and of any type. */
+    @Query(
+        """
+        SELECT * FROM relationships
+        WHERE (fromPersonId = :a AND toPersonId = :b)
+           OR (fromPersonId = :b AND toPersonId = :a)
+        """
+    )
+    suspend fun edgesBetween(a: String, b: String): List<Relationship>
+
     @Query(
         """
         SELECT p.* FROM people p

--- a/app/src/main/java/com/vibethroughcode/ftree/data/RelativeKind.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/RelativeKind.kt
@@ -1,0 +1,15 @@
+package com.vibethroughcode.ftree.data
+
+/**
+ * A relationship as the user thinks of it, from one person's point of view.
+ *
+ * Distinct from [RelationshipType], which is how an edge is *stored*: "add a parent" and "add a
+ * child" both write a PARENT edge, differing only in direction. Keeping the two apart means the UI
+ * can speak in family terms while the graph stays minimal.
+ */
+enum class RelativeKind {
+    PARENT,
+    SPOUSE,
+    CHILD,
+    SIBLING,
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -8,6 +8,7 @@ import androidx.navigation.toRoute
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
 import com.vibethroughcode.ftree.ui.person.PersonDetailScreen
 import com.vibethroughcode.ftree.ui.person.PersonEditScreen
+import com.vibethroughcode.ftree.ui.relative.AddRelativeScreen
 
 @Composable
 fun FTreeApp() {
@@ -25,7 +26,15 @@ fun FTreeApp() {
             PersonDetailScreen(
                 onBack = { navController.popBackStack() },
                 onEdit = { navController.navigate(EditPersonRoute(it)) },
+                onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                onAddRelative = { anchorId, kind ->
+                    navController.navigate(AddRelativeRoute(anchorId, kind))
+                },
             )
+        }
+
+        composable<AddRelativeRoute> {
+            AddRelativeScreen(onBack = { navController.popBackStack() })
         }
 
         composable<EditPersonRoute> { entry ->

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
@@ -1,5 +1,6 @@
 package com.vibethroughcode.ftree.ui
 
+import com.vibethroughcode.ftree.data.RelativeKind
 import kotlinx.serialization.Serializable
 
 /**
@@ -17,3 +18,7 @@ data class PersonRoute(val personId: String)
 /** A null [personId] means "create someone new". */
 @Serializable
 data class EditPersonRoute(val personId: String? = null)
+
+/** Picking who to attach to [anchorPersonId] as a [kind]. */
+@Serializable
+data class AddRelativeRoute(val anchorPersonId: String, val kind: RelativeKind)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -12,6 +12,7 @@ import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.ui.people.PeopleViewModel
 import com.vibethroughcode.ftree.ui.person.PersonDetailViewModel
 import com.vibethroughcode.ftree.ui.person.PersonEditViewModel
+import com.vibethroughcode.ftree.ui.relative.AddRelativeViewModel
 
 private fun CreationExtras.repository(): FamilyRepository =
     (this[APPLICATION_KEY] as FTreeApplication).container.familyRepository
@@ -32,6 +33,10 @@ object FTreeViewModels {
         initializer {
             val handle: SavedStateHandle = createSavedStateHandle()
             PersonEditViewModel(repository(), handle.toRoute<EditPersonRoute>().personId, handle)
+        }
+        initializer {
+            val route = createSavedStateHandle().toRoute<AddRelativeRoute>()
+            AddRelativeViewModel(repository(), route.anchorPersonId, route.kind)
         }
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonRow.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonRow.kt
@@ -1,6 +1,7 @@
 package com.vibethroughcode.ftree.ui.common
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,18 +26,20 @@ import com.vibethroughcode.ftree.ui.theme.FTreeTheme
  * The name is set in the serif and the years in the mono, so a glance separates who someone is
  * from what is recorded about them, and the year column lines up down the list.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun PersonRow(
     person: Person,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     supporting: String? = null,
+    onLongClick: (() -> Unit)? = null,
 ) {
     val accents = FTreeTheme.accents
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
             // Comfortably above the 48dp minimum touch target, even at a single line.
             .defaultMinSize(minHeight = 64.dp)
             .padding(horizontal = 20.dp, vertical = 10.dp),

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/RelativeLabels.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/RelativeLabels.kt
@@ -1,0 +1,81 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.RelativeKind
+
+/**
+ * How a relationship is named to the reader.
+ *
+ * The graph stores one PARENT edge; a person reads "Father". Gender is only ever used to pick the
+ * more specific word, and falls back to the neutral one whenever it is not recorded — the label is
+ * never a guess.
+ */
+@StringRes
+fun relativeRoleLabel(kind: RelativeKind, gender: Gender): Int = when (kind) {
+    RelativeKind.PARENT -> when (gender) {
+        Gender.MALE -> R.string.role_father
+        Gender.FEMALE -> R.string.role_mother
+        else -> R.string.role_parent
+    }
+
+    RelativeKind.SPOUSE -> when (gender) {
+        Gender.MALE -> R.string.role_husband
+        Gender.FEMALE -> R.string.role_wife
+        else -> R.string.role_spouse
+    }
+
+    RelativeKind.CHILD -> when (gender) {
+        Gender.MALE -> R.string.role_son
+        Gender.FEMALE -> R.string.role_daughter
+        else -> R.string.role_child
+    }
+
+    RelativeKind.SIBLING -> when (gender) {
+        Gender.MALE -> R.string.role_brother
+        Gender.FEMALE -> R.string.role_sister
+        else -> R.string.role_sibling
+    }
+}
+
+/**
+ * The heading for a group of relatives.
+ *
+ * Spouse is the one header whose word depends on the count — someone may have had several over a
+ * lifetime — so it resolves through a plural rather than a fixed string.
+ */
+@Composable
+fun sectionTitle(kind: RelativeKind, count: Int): String = when (kind) {
+    RelativeKind.PARENT -> stringResource(R.string.section_parents)
+    RelativeKind.SPOUSE -> pluralStringResource(R.plurals.section_spouses, count.coerceAtLeast(1))
+    RelativeKind.CHILD -> stringResource(R.string.section_children)
+    RelativeKind.SIBLING -> stringResource(R.string.section_siblings)
+}
+
+@StringRes
+fun addRelativeLabel(kind: RelativeKind): Int = when (kind) {
+    RelativeKind.PARENT -> R.string.add_parent
+    RelativeKind.SPOUSE -> R.string.add_spouse
+    RelativeKind.CHILD -> R.string.add_child
+    RelativeKind.SIBLING -> R.string.add_sibling
+}
+
+@StringRes
+fun addRelativeTitle(kind: RelativeKind): Int = when (kind) {
+    RelativeKind.PARENT -> R.string.add_relative_title_parent
+    RelativeKind.SPOUSE -> R.string.add_relative_title_spouse
+    RelativeKind.CHILD -> R.string.add_relative_title_child
+    RelativeKind.SIBLING -> R.string.add_relative_title_sibling
+}
+
+@StringRes
+fun rejectionMessage(reason: com.vibethroughcode.ftree.graph.RelationshipRejection): Int = when (reason) {
+    com.vibethroughcode.ftree.graph.RelationshipRejection.SELF_REFERENCE -> R.string.rejected_self
+    com.vibethroughcode.ftree.graph.RelationshipRejection.DUPLICATE -> R.string.rejected_duplicate
+    com.vibethroughcode.ftree.graph.RelationshipRejection.ANCESTOR_CYCLE -> R.string.rejected_cycle
+    com.vibethroughcode.ftree.graph.RelationshipRejection.CONTRADICTS_EXISTING -> R.string.rejected_contradiction
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -12,14 +12,17 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,10 +41,15 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.PartialDate
 import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
 import com.vibethroughcode.ftree.ui.FTreeViewModels
 import com.vibethroughcode.ftree.ui.common.PersonAvatar
 import com.vibethroughcode.ftree.ui.common.SectionRule
+import com.vibethroughcode.ftree.ui.common.PersonRow
+import com.vibethroughcode.ftree.ui.common.addRelativeLabel
 import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
+import com.vibethroughcode.ftree.ui.common.sectionTitle
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 
@@ -54,11 +62,14 @@ const val PersonEditTag = "person-edit"
 fun PersonDetailScreen(
     onBack: () -> Unit,
     onEdit: (String) -> Unit,
+    onOpenPerson: (String) -> Unit,
+    onAddRelative: (String, RelativeKind) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PersonDetailViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var confirmingDelete by remember { mutableStateOf(false) }
+    var pendingRemoval by remember { mutableStateOf<Person?>(null) }
 
     // A person can disappear underneath this screen — deleted here, or removed by an import — so
     // leaving is driven by the data rather than assumed at the moment of the tap.
@@ -109,22 +120,57 @@ fun PersonDetailScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(padding)
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 20.dp),
+                .verticalScroll(rememberScrollState()),
         ) {
-            PersonHeader(person)
+            PersonHeader(person, Modifier.padding(horizontal = 20.dp))
+
+            RelativeKind.entries.forEach { kind ->
+                RelativeSection(
+                    kind = kind,
+                    relatives = state.of(kind),
+                    onOpen = onOpenPerson,
+                    onAdd = { onAddRelative(viewModel.personId, kind) },
+                    onRemove = { other -> pendingRemoval = other },
+                )
+            }
 
             if (!person.notes.isNullOrBlank()) {
-                SectionRule(stringResource(R.string.person_notes))
+                SectionRule(
+                    label = stringResource(R.string.person_notes),
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                )
                 Text(
                     text = person.notes!!,
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 4.dp),
                 )
             }
 
             Spacer(Modifier.height(40.dp))
         }
+    }
+
+    pendingRemoval?.let { other ->
+        val subject = other.displayName()
+        val anchor = state.person?.displayName().orEmpty()
+        AlertDialog(
+            onDismissRequest = { pendingRemoval = null },
+            title = { Text(stringResource(R.string.remove_relationship_title)) },
+            text = { Text(stringResource(R.string.remove_relationship_body, subject, anchor)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    viewModel.removeRelationshipWith(other.id)
+                    pendingRemoval = null
+                }) {
+                    Text(stringResource(R.string.remove_relationship_confirm))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingRemoval = null }) {
+                    Text(stringResource(R.string.delete_cancel))
+                }
+            },
+        )
     }
 
     if (confirmingDelete) {
@@ -141,10 +187,10 @@ fun PersonDetailScreen(
 }
 
 @Composable
-private fun PersonHeader(person: Person) {
+private fun PersonHeader(person: Person, modifier: Modifier = Modifier) {
     val accents = FTreeTheme.accents
     Row(
-        modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+        modifier = modifier.fillMaxWidth().padding(top = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(20.dp),
     ) {
@@ -191,3 +237,52 @@ private fun LifeLine(person: Person) {
         }
     }
 }
+
+/**
+ * One group of relatives, headed by a ruled label with the add action on the rule itself.
+ *
+ * A section with nobody in it is still shown, because the empty rule is what tells you the
+ * question has been asked — an absent "Parents" heading reads as "not supported", while an empty
+ * one reads as "not recorded yet", which is the whole subject of this app.
+ */
+@Composable
+private fun RelativeSection(
+    kind: RelativeKind,
+    relatives: List<Person>,
+    onOpen: (String) -> Unit,
+    onAdd: () -> Unit,
+    onRemove: (Person) -> Unit,
+) {
+    SectionRule(
+        label = sectionTitle(kind, relatives.size),
+        modifier = Modifier.padding(horizontal = 20.dp),
+        trailing = {
+            IconButton(onClick = onAdd, modifier = Modifier.testTag(addSectionTag(kind))) {
+                Icon(
+                    Icons.Default.Add,
+                    contentDescription = stringResource(addRelativeLabel(kind)),
+                )
+            }
+        },
+    )
+
+    if (relatives.isEmpty()) {
+        Text(
+            text = stringResource(addRelativeLabel(kind)),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 20.dp, bottom = 4.dp),
+        )
+    } else {
+        relatives.forEach { relative ->
+            PersonRow(
+                person = relative,
+                onClick = { onOpen(relative.id) },
+                onLongClick = { onRemove(relative) },
+                supporting = stringResource(relativeRoleLabel(kind, relative.gender)),
+            )
+        }
+    }
+}
+
+fun addSectionTag(kind: RelativeKind): String = "add-relative-" + kind.name.lowercase()

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailViewModel.kt
@@ -5,10 +5,9 @@ import androidx.lifecycle.viewModelScope
 import com.vibethroughcode.ftree.data.DeletionMode
 import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.Person
-import kotlinx.coroutines.flow.MutableStateFlow
+import com.vibethroughcode.ftree.data.RelativeKind
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -18,27 +17,58 @@ data class PersonDetailUiState(
     val person: Person? = null,
     val relationshipCount: Int = 0,
     val loaded: Boolean = false,
-)
+    val relatives: Map<RelativeKind, List<Person>> = emptyMap(),
+) {
+    fun of(kind: RelativeKind): List<Person> = relatives[kind].orEmpty()
+}
 
 class PersonDetailViewModel(
     private val repository: FamilyRepository,
     val personId: String,
 ) : ViewModel() {
 
-    private val relationshipCount = MutableStateFlow(0)
+    private val relatives = combine(
+        repository.observeParents(personId),
+        repository.observeSpouses(personId),
+        repository.observeChildren(personId),
+        repository.observeSiblings(personId),
+    ) { parents, spouses, children, siblings ->
+        mapOf(
+            RelativeKind.PARENT to parents,
+            RelativeKind.SPOUSE to spouses,
+            RelativeKind.CHILD to children,
+            RelativeKind.SIBLING to siblings,
+        )
+    }
 
     val uiState: StateFlow<PersonDetailUiState> = combine(
         repository.observePerson(personId),
         repository.observeEdgesOf(personId).map { it.size },
-    ) { person, edges ->
-        PersonDetailUiState(person = person, relationshipCount = edges, loaded = true)
+        relatives,
+    ) { person, edges, related ->
+        PersonDetailUiState(
+            person = person,
+            relationshipCount = edges,
+            loaded = true,
+            relatives = related,
+        )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
         initialValue = PersonDetailUiState(),
     )
 
-    val edgeCount: StateFlow<Int> = relationshipCount.asStateFlow()
+    /**
+     * Removes one connection without touching either person. Both stay in the tree; only the
+     * link between them goes.
+     */
+    fun removeRelationshipWith(otherPersonId: String) {
+        viewModelScope.launch {
+            repository.edgesBetween(personId, otherPersonId).forEach {
+                repository.removeRelationship(it.id)
+            }
+        }
+    }
 
     /**
      * Deletion is a two-option decision rather than a yes/no, because losing one name should not

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relative/AddRelativeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relative/AddRelativeScreen.kt
@@ -1,0 +1,213 @@
+package com.vibethroughcode.ftree.ui.relative
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.HelpOutline
+import androidx.compose.material.icons.filled.PersonAddAlt
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.ui.FTreeViewModels
+import com.vibethroughcode.ftree.ui.common.PersonRow
+import com.vibethroughcode.ftree.ui.common.SectionRule
+import com.vibethroughcode.ftree.ui.common.addRelativeTitle
+import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.rejectionMessage
+
+const val AddRelativeNameTag = "add-relative-name"
+const val AddRelativeSaveTag = "add-relative-save"
+const val AddRelativeUnknownTag = "add-relative-unknown"
+
+/**
+ * One screen to answer "who?".
+ *
+ * The three ways to answer sit together: name someone new, record someone whose name is not known,
+ * or pick a person already in the tree. Recording an unknown relative is a single tap, because the
+ * whole point is to capture a connection you know about before the details you don't.
+ */
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun AddRelativeScreen(
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: AddRelativeViewModel = viewModel(factory = FTreeViewModels.Factory),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val anchorName = state.anchor?.displayName().orEmpty()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(addRelativeTitle(viewModel.kind), anchorName)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.edit_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(bottom = 32.dp),
+        ) {
+            item {
+                Column(
+                    modifier = Modifier.padding(horizontal = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    SectionRule(stringResource(R.string.add_relative_new))
+
+                    OutlinedTextField(
+                        value = state.newName,
+                        onValueChange = viewModel::onNewNameChange,
+                        label = { Text(stringResource(R.string.add_relative_name_hint)) },
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Words,
+                        ),
+                        modifier = Modifier.fillMaxWidth().testTag(AddRelativeNameTag),
+                    )
+
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                    ) {
+                        listOf(
+                            Gender.MALE to R.string.gender_male,
+                            Gender.FEMALE to R.string.gender_female,
+                            Gender.OTHER to R.string.gender_other,
+                            Gender.UNSPECIFIED to R.string.gender_unspecified,
+                        ).forEach { (gender, label) ->
+                            FilterChip(
+                                selected = state.newGender == gender,
+                                onClick = { viewModel.onNewGenderChange(gender) },
+                                label = { Text(stringResource(label)) },
+                            )
+                        }
+                    }
+
+                    Button(
+                        onClick = { viewModel.createAndLink(onBack) },
+                        enabled = state.newName.isNotBlank(),
+                        modifier = Modifier.fillMaxWidth().testTag(AddRelativeSaveTag),
+                    ) {
+                        Icon(Icons.Default.PersonAddAlt, contentDescription = null)
+                        Text(
+                            text = stringResource(R.string.add_relative_save),
+                            modifier = Modifier.padding(start = 8.dp),
+                        )
+                    }
+
+                    UnknownPersonChoice(
+                        onClick = { viewModel.createUnknownAndLink(onBack) },
+                    )
+
+                    SectionRule(stringResource(R.string.add_relative_existing))
+
+                    if (state.candidates.isEmpty() && state.query.isBlank()) {
+                        Text(
+                            text = stringResource(R.string.add_relative_nobody_else),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    } else {
+                        OutlinedTextField(
+                            value = state.query,
+                            onValueChange = viewModel::onQueryChange,
+                            label = { Text(stringResource(R.string.people_search_hint)) },
+                            singleLine = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
+                }
+            }
+
+            items(state.candidates, key = { it.id }) { person ->
+                PersonRow(
+                    person = person,
+                    onClick = { viewModel.linkExisting(person.id, onBack) },
+                )
+            }
+        }
+    }
+
+    state.rejection?.let { reason ->
+        AlertDialog(
+            onDismissRequest = viewModel::dismissRejection,
+            text = { Text(stringResource(rejectionMessage(reason))) },
+            confirmButton = {
+                TextButton(onClick = viewModel::dismissRejection) {
+                    Text(stringResource(R.string.delete_cancel))
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun UnknownPersonChoice(onClick: () -> Unit) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().testTag(AddRelativeUnknownTag),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Icon(Icons.Default.HelpOutline, contentDescription = null)
+            Column {
+                Text(
+                    text = stringResource(R.string.add_relative_unknown),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(
+                    text = stringResource(R.string.add_relative_unknown_detail),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relative/AddRelativeViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relative/AddRelativeViewModel.kt
@@ -1,0 +1,144 @@
+package com.vibethroughcode.ftree.ui.relative
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.graph.RelationshipRejection
+import com.vibethroughcode.ftree.data.RelationshipRejectedException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class AddRelativeUiState(
+    val anchor: Person? = null,
+    val candidates: List<Person> = emptyList(),
+    val query: String = "",
+    val newName: String = "",
+    val newGender: Gender = Gender.UNSPECIFIED,
+    val rejection: RelationshipRejection? = null,
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AddRelativeViewModel(
+    private val repository: FamilyRepository,
+    private val anchorId: String,
+    val kind: RelativeKind,
+) : ViewModel() {
+
+    private val query = MutableStateFlow("")
+    private val form = MutableStateFlow(FormState())
+    private val rejection = MutableStateFlow<RelationshipRejection?>(null)
+
+    private data class FormState(val name: String = "", val gender: Gender = Gender.UNSPECIFIED)
+
+    /**
+     * People this relationship could never legally reach.
+     *
+     * Offering someone the app would then refuse is a dead end, so the anchor and anyone who would
+     * close an ancestor loop — their descendants when adding a parent, their ancestors when adding
+     * a child — are left out of the list rather than rejected after the tap. Duplicates are still
+     * shown, because "he is already your father" is clearer said out loud than by a missing row.
+     */
+    private val ineligible = flow {
+        emit(
+            buildSet {
+                add(anchorId)
+                when (kind) {
+                    RelativeKind.PARENT -> addAll(repository.descendantIdsOf(anchorId))
+                    RelativeKind.CHILD -> addAll(repository.ancestorIdsOf(anchorId))
+                    else -> Unit
+                }
+            }
+        )
+    }
+
+    private val candidates = combine(
+        query
+            .debounce { if (it.isBlank()) 0L else 180L }
+            .flatMapLatest { text ->
+                if (text.isBlank()) repository.observeAllPeople() else repository.searchPeople(text)
+            },
+        ineligible,
+    ) { people, excluded -> people.filterNot { it.id in excluded } }
+
+    val uiState: StateFlow<AddRelativeUiState> = combine(
+        repository.observePerson(anchorId),
+        candidates,
+        query,
+        form,
+        rejection,
+    ) { anchor, people, text, formState, rejected ->
+        AddRelativeUiState(
+            anchor = anchor,
+            candidates = people,
+            query = text,
+            newName = formState.name,
+            newGender = formState.gender,
+            rejection = rejected,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = AddRelativeUiState(),
+    )
+
+    val currentRejection: StateFlow<RelationshipRejection?> = rejection.asStateFlow()
+
+    fun onQueryChange(value: String) { query.value = value }
+    fun onNewNameChange(value: String) = form.update { it.copy(name = value) }
+    fun onNewGenderChange(value: Gender) = form.update { it.copy(gender = value) }
+    fun dismissRejection() { rejection.value = null }
+
+    private inline fun MutableStateFlow<FormState>.update(block: (FormState) -> FormState) {
+        value = block(value)
+    }
+
+    /** Links someone already in the tree. */
+    fun linkExisting(personId: String, onDone: () -> Unit) = attempt(onDone) {
+        repository.addRelative(anchorId, personId, kind).map { }
+    }
+
+    /** Creates a named person and links them. */
+    fun createAndLink(onDone: () -> Unit) {
+        val state = form.value
+        attempt(onDone) {
+            repository.addNewRelative(
+                anchorId = anchorId,
+                person = Person(name = state.name.trim().ifBlank { null }, gender = state.gender),
+                kind = kind,
+            ).map { }
+        }
+    }
+
+    /**
+     * Records the connection to someone whose name is not known.
+     *
+     * The placeholder is a real person in the graph, not a note on someone else, which is what
+     * lets them be named years later without rebuilding the relationship.
+     */
+    fun createUnknownAndLink(onDone: () -> Unit) = attempt(onDone) {
+        repository.addNewRelative(anchorId, Person(), kind).map { }
+    }
+
+    private fun attempt(onDone: () -> Unit, block: suspend () -> Result<Unit>) {
+        viewModelScope.launch {
+            block()
+                .onSuccess { onDone() }
+                .onFailure { failure ->
+                    rejection.value = (failure as? RelationshipRejectedException)?.reason
+                        ?: RelationshipRejection.DUPLICATE
+                }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,8 +71,63 @@
     <string name="deleted_toast">Deleted</string>
     <string name="kept_as_unknown_toast">Kept as an unknown person</string>
 
+    <!-- Relationships -->
+    <string name="section_parents">Parents</string>
+    <string name="section_children">Children</string>
+    <string name="section_siblings">Siblings</string>
+
+    <string name="role_father">Father</string>
+    <string name="role_mother">Mother</string>
+    <string name="role_parent">Parent</string>
+    <string name="role_husband">Husband</string>
+    <string name="role_wife">Wife</string>
+    <string name="role_spouse">Spouse</string>
+    <string name="role_son">Son</string>
+    <string name="role_daughter">Daughter</string>
+    <string name="role_child">Child</string>
+    <string name="role_brother">Brother</string>
+    <string name="role_sister">Sister</string>
+    <string name="role_sibling">Sibling</string>
+
+    <string name="add_parent">Add a parent</string>
+    <string name="add_spouse">Add a spouse</string>
+    <string name="add_child">Add a child</string>
+    <string name="add_sibling">Add a sibling</string>
+
+    <string name="add_relative_title_parent">Add a parent for %1$s</string>
+    <string name="add_relative_title_spouse">Add a spouse for %1$s</string>
+    <string name="add_relative_title_child">Add a child for %1$s</string>
+    <string name="add_relative_title_sibling">Add a sibling for %1$s</string>
+
+    <string name="add_relative_new">New person</string>
+    <string name="add_relative_new_detail">Add someone who isn\'t in your tree yet</string>
+    <string name="add_relative_unknown">Someone whose name I don\'t know</string>
+    <string name="add_relative_unknown_detail">Records the connection now; you can name them later</string>
+    <string name="add_relative_existing">In your tree</string>
+    <string name="add_relative_name_hint">Their name</string>
+    <string name="add_relative_save">Add</string>
+    <string name="add_relative_nobody_else">Nobody else is in your tree yet.</string>
+
+    <string name="relationship_removed">Relationship removed</string>
+    <string name="remove_relationship_title">Remove this relationship?</string>
+    <string name="remove_relationship_body">%1$s stays in your tree. Only the connection between them and %2$s is removed.</string>
+    <string name="remove_relationship_confirm">Remove</string>
+    <string name="remove_relationship_open">Open %1$s</string>
+
+    <string name="rejected_self">Someone can\'t be their own relative.</string>
+    <string name="rejected_duplicate">That relationship is already recorded.</string>
+    <string name="rejected_cycle">That would make someone their own ancestor.</string>
+    <string name="rejected_contradiction">They\'re already recorded as parent and child.</string>
+
     <!-- Shared -->
     <string name="a11y_person_avatar">Photo of %1$s</string>
     <string name="a11y_unknown_avatar">Unknown person</string>
     <string name="dash">—</string>
+
+    <!-- The only section header where the count changes the word; a person may have had
+         several spouses over their lifetime. -->
+    <plurals name="section_spouses">
+        <item quantity="one">Spouse</item>
+        <item quantity="other">Spouses</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Closes #3.

## What a person's page shows now

Parents, spouses, children and siblings, each headed by a ruled label with the add action on the
rule. **Empty sections are still shown** — an absent "Parents" heading reads as *not supported*,
an empty one reads as *not recorded yet*, which is the whole subject of this app.

Relationships are named for the reader: the graph stores one `PARENT` edge, the page says
**Father**. Gender only ever picks the more specific word and falls back to the neutral one when it
isn't recorded, so a label is never a guess.

## Adding a sibling is the interesting case

It's the one operation that isn't a single edge. If the anchor already has known parents, the new
sibling is attached to **those same parents** — which is what actually makes them siblings, keeps
half-siblings consistent, and avoids inventing a placeholder parent nobody asked for. Only when no
parents are known does an explicit `SIBLING` edge get written, because that's the one case shared
parents can't express.

## Two things I changed after testing found them

- **`addNewRelative` wasn't really atomic.** It undid a rejected relationship by deleting the person
  again by hand, which only covers the cases it remembers to — a failing *insert* would still have
  thrown. It now throws out of the transaction and lets the database roll back, so any failure
  leaves the tree byte-for-byte as it was. A test asserts exactly that.
- **The picker offered choices the rules could only refuse.** Adding a parent listed the person's own
  children, which would then be rejected as an ancestor cycle. Descendants (when adding a parent)
  and ancestors (when adding a child) are now left out. Duplicates are still offered, because
  *"he is already your father"* is clearer said out loud than by a missing row.

## Also

- **`SPOUSE` → `SPOUSES`** via a plural — the one header whose word depends on the count.
- **Debug-only seeder.** `adb shell am broadcast … --es mode family` fills the tree with a
  deliberately awkward family (unknown ancestors, two marriages, half-siblings, someone with no
  dates), so the chart and merge work ahead can be exercised without tapping through hundreds of
  forms. Absent from release builds, and `--es mode large --ei size 2000` is ready for #9.

## Verification

- 36 JVM, 51 instrumented (17 schema + 18 repository + 16 UI flows) — all green on `pixel7_api36`.
- `lintDebug` clean.
- Walked it on the emulator with the sample family; screenshots confirm role labels, the ruled
  sections, and the unknown-person treatment.