### PR TITLE
Family tree visualisation

### DIFF
--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PersonFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PersonFlowTest.kt
@@ -24,6 +24,7 @@ import com.vibethroughcode.ftree.ui.person.EditNameFieldTag
 import com.vibethroughcode.ftree.ui.person.EditSaveTag
 import com.vibethroughcode.ftree.ui.person.PersonDeleteTag
 import com.vibethroughcode.ftree.ui.person.PersonEditTag
+import com.vibethroughcode.ftree.ui.tree.TreePeopleButtonTag
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -64,6 +65,12 @@ class PersonFlowTest {
 
     private fun goBack() {
         rule.onNodeWithContentDescription("Back").performClick()
+        rule.waitForIdle()
+    }
+
+    /** Home is the chart; the list of everyone is one tap away from it. */
+    private fun openPeopleList() {
+        rule.onNodeWithTag(TreePeopleButtonTag).performClick()
         rule.waitForIdle()
     }
 
@@ -137,6 +144,7 @@ class PersonFlowTest {
     fun peopleAreListedAndSearchable() {
         addFirstPerson("Ankit Kumar")
         goBack()
+        openPeopleList()
 
         rule.onNodeWithTag(PeopleAddFabTag).performClick()
         rule.waitForIdle()
@@ -177,10 +185,14 @@ class PersonFlowTest {
     fun dataSurvivesTheScreenBeingRecreated() {
         addFirstPerson("Ankit Kumar", "1990")
         goBack()
+        openPeopleList()
 
         rule.activity.runOnUiThread { rule.activity.recreate() }
         rule.waitForIdle()
 
+        // The list is asserted rather than the chart because chart text is painted onto a canvas
+        // and carries no semantics of its own. The navigation state survives recreation, so the
+        // list is still the screen in front of us.
         rule.onNodeWithText("Ankit Kumar").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationshipFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationshipFlowTest.kt
@@ -53,7 +53,8 @@ class RelationshipFlowTest {
 
     /** Adds a named relative of [kind] to whoever's page is open. */
     private fun addRelative(kind: RelativeKind, name: String) {
-        rule.onNodeWithTag(addSectionTag(kind)).performScrollTo().performClick()
+        rule.onNodeWithTag(addSectionTag(kind), useUnmergedTree = true)
+            .performScrollTo().performClick()
         rule.waitForIdle()
         rule.onNodeWithTag(AddRelativeNameTag).performTextInput(name)
         rule.onNodeWithTag(AddRelativeSaveTag).performScrollTo().performClick()
@@ -73,7 +74,8 @@ class RelationshipFlowTest {
 
     @Test
     fun aRelativeIsLabelledByTheRoleTheyPlay() {
-        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT), useUnmergedTree = true)
+            .performScrollTo().performClick()
         rule.waitForIdle()
         rule.onNodeWithTag(AddRelativeNameTag).performTextInput("Raj Kumar")
         rule.onNodeWithText("Male").performClick()
@@ -86,7 +88,8 @@ class RelationshipFlowTest {
 
     @Test
     fun aRelativeWhoseNameIsUnknownIsStillARealPerson() {
-        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT), useUnmergedTree = true)
+            .performScrollTo().performClick()
         rule.waitForIdle()
         rule.onNodeWithTag(AddRelativeUnknownTag).performScrollTo().performClick()
         rule.waitForIdle()
@@ -96,7 +99,8 @@ class RelationshipFlowTest {
 
     @Test
     fun anUnknownRelativeCanBeNamedLaterWithoutLosingTheConnection() {
-        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT), useUnmergedTree = true)
+            .performScrollTo().performClick()
         rule.waitForIdle()
         rule.onNodeWithTag(AddRelativeUnknownTag).performScrollTo().performClick()
         rule.waitForIdle()
@@ -148,7 +152,8 @@ class RelationshipFlowTest {
     fun aDescendantIsNotOfferedAsAPossibleParent() {
         addRelative(RelativeKind.CHILD, "Aarav")
 
-        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT), useUnmergedTree = true)
+            .performScrollTo().performClick()
         rule.waitForIdle()
 
         // Aarav could only ever be refused as a parent, so he is not offered at all.
@@ -160,7 +165,8 @@ class RelationshipFlowTest {
         addRelative(RelativeKind.PARENT, "Raj Kumar")
 
         // Try to add the same person as a parent a second time.
-        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+        rule.onNodeWithTag(addSectionTag(RelativeKind.PARENT), useUnmergedTree = true)
+            .performScrollTo().performClick()
         rule.waitForIdle()
         rule.onNodeWithText("Raj Kumar").performScrollTo().performClick()
         rule.waitForIdle()

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/TreeFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/TreeFlowTest.kt
@@ -1,0 +1,123 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.ui.person.EditNameFieldTag
+import com.vibethroughcode.ftree.ui.person.EditSaveTag
+import com.vibethroughcode.ftree.ui.tree.FamilyChartTag
+import com.vibethroughcode.ftree.ui.tree.TreePeopleButtonTag
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** The chart: what it shows, and how the rest of the family stays reachable from it. */
+@RunWith(AndroidJUnit4::class)
+class TreeFlowTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    @Before
+    fun emptyTheTree() {
+        app.container.database.clearAllTables()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Build your family tree").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun seedFamily() {
+        val repository = app.container.familyRepository
+        runBlocking {
+            val me = Person(name = "Ankit Kumar", birthDate = "1990")
+            val father = Person(name = "Vinod Kumar", birthDate = "1962")
+            val child = Person(name = "Aarav Kumar", birthDate = "2020")
+            listOf(me, father, child).forEach { repository.addPerson(it) }
+            repository.addRelative(me.id, father.id, RelativeKind.PARENT)
+            repository.addRelative(me.id, child.id, RelativeKind.CHILD)
+        }
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun anEmptyTreeShowsTheInvitationRatherThanABlankChart() {
+        rule.onNodeWithText("Build your family tree").assertIsDisplayed()
+    }
+
+    @Test
+    fun theChartAppearsOnceSomebodyIsInTheTree() {
+        seedFamily()
+        rule.onNodeWithTag(FamilyChartTag).assertIsDisplayed()
+    }
+
+    @Test
+    fun tappingSomebodyOnTheChartOpensTheirActions() {
+        // One person only: the chart fits, so it is centred and the single node sits under the
+        // middle of the canvas, which makes the tap deterministic.
+        rule.onNodeWithText("Add your first person").performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(EditNameFieldTag).performTextInput("Ankit Kumar")
+        rule.onNodeWithTag(EditSaveTag).performScrollTo().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithContentDescription("Back").performClick()
+        rule.waitForIdle()
+
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(FamilyChartTag).performTouchInput { click(center) }
+        rule.waitForIdle()
+
+        // "Centre the tree here" is deliberately absent: they are already the focus, so it would
+        // be an action that does nothing.
+        rule.onNodeWithText("Open Ankit Kumar").assertIsDisplayed()
+        assertTrue(
+            rule.onAllNodesWithText("Centre the tree here").fetchSemanticsNodes().isEmpty()
+        )
+    }
+
+    @Test
+    fun thePeopleListIsReachableFromTheChart() {
+        seedFamily()
+
+        rule.onNodeWithTag(TreePeopleButtonTag).performClick()
+        rule.waitForIdle()
+
+        rule.onNodeWithText("Vinod Kumar").assertIsDisplayed()
+        rule.onNodeWithText("Aarav Kumar").assertIsDisplayed()
+    }
+
+    @Test
+    fun theChartDescribesItselfForAScreenReader() {
+        seedFamily()
+
+        // Canvas text is invisible to accessibility services, so the chart carries a description
+        // and points at the list, which is the readable route to the same information.
+        rule.onNodeWithTag(FamilyChartTag).assertIsDisplayed()
+        rule.onAllNodesWithText("Family tree").fetchSemanticsNodes().isNotEmpty()
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
@@ -44,9 +44,21 @@ class FamilyRepository(
     fun observeEdgesOf(id: String): Flow<List<Relationship>> = relationships.observeEdgesOf(id)
 
     suspend fun person(id: String): Person? = people.findById(id)
+
+    /** Who the chart should open on when the user has not chosen. */
+    suspend fun mostConnectedPersonId(): String? = people.mostConnectedPersonId()
     suspend fun relationshipCount(id: String): Int = relationships.edgeCount(id)
 
     suspend fun edgesBetween(a: String, b: String): List<Relationship> = relationships.edgesBetween(a, b)
+
+    private val neighbourhood = NeighbourhoodLoader(people, relationships)
+
+    /** The bounded slice of the tree the chart draws. */
+    suspend fun loadNeighbourhood(
+        focusId: String,
+        generationsUp: Int,
+        generationsDown: Int,
+    ) = neighbourhood.load(focusId, generationsUp, generationsDown)
 
     suspend fun ancestorIdsOf(personId: String): Set<String> =
         FamilyGraph.ancestorsOf(personId) { relationships.parentIdsOf(it) }

--- a/app/src/main/java/com/vibethroughcode/ftree/data/NeighbourhoodLoader.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/NeighbourhoodLoader.kt
@@ -1,0 +1,76 @@
+package com.vibethroughcode.ftree.data
+
+import com.vibethroughcode.ftree.graph.FamilySnapshot
+
+/**
+ * Loads the slice of the tree the chart needs, and no more.
+ *
+ * Walks outwards from one person a generation at a time, asking for each ring in a single batched
+ * query. The cost is proportional to what will be drawn rather than to the size of the family, so a
+ * tree of thousands opens as fast as a tree of ten.
+ */
+class NeighbourhoodLoader(
+    private val people: PersonDao,
+    private val relationships: RelationshipDao,
+) {
+
+    suspend fun load(focusId: String, generationsUp: Int, generationsDown: Int): FamilySnapshot {
+        if (people.findById(focusId) == null) return FamilySnapshot.Empty
+
+        val ids = linkedSetOf(focusId)
+
+        // Upwards. One extra ring is walked so the focus's siblings can be found through the
+        // parents they share.
+        var frontier = listOf(focusId)
+        val parentsOfFocus = chunked(frontier) { relationships.parentIdsOfAll(it) }
+        repeat(generationsUp) {
+            if (frontier.isEmpty()) return@repeat
+            val parents = chunked(frontier) { relationships.parentIdsOfAll(it) }
+            ids += parents
+            frontier = parents.filterNot { it == focusId }
+        }
+
+        // The focus's siblings share the row, so they come from the parents just found.
+        if (parentsOfFocus.isNotEmpty()) {
+            ids += chunked(parentsOfFocus) { relationships.childIdsOfAll(it) }
+        }
+
+        // Downwards, from the focus alone.
+        frontier = listOf(focusId)
+        repeat(generationsDown) {
+            if (frontier.isEmpty()) return@repeat
+            val children = chunked(frontier) { relationships.childIdsOfAll(it) }
+            ids += children
+            frontier = children
+        }
+
+        // Partners of everyone on the chart.
+        ids += chunked(ids.toList()) { relationships.spouseIdsOfAll(it) }
+
+        val loaded = chunked(ids.toList()) { people.findByIds(it) }.associateBy { it.id }
+        val edges = chunked(ids.toList()) { relationships.edgesAmong(it) }
+            .distinctBy { it.id }
+            .filter { it.fromPersonId in loaded && it.toPersonId in loaded }
+
+        return FamilySnapshot(
+            people = loaded,
+            parentEdges = edges.filter { it.type == RelationshipType.PARENT }
+                .map { it.fromPersonId to it.toPersonId },
+            spouseEdges = edges.filter { it.type == RelationshipType.SPOUSE }
+                .map { it.fromPersonId to it.toPersonId },
+            siblingEdges = edges.filter { it.type == RelationshipType.SIBLING }
+                .map { it.fromPersonId to it.toPersonId },
+        )
+    }
+
+    /**
+     * SQLite caps how many values an `IN` clause can bind, so large id sets are queried in slices.
+     */
+    private suspend fun <T> chunked(ids: List<String>, query: suspend (List<String>) -> List<T>): List<T> =
+        if (ids.size <= CHUNK) query(ids)
+        else ids.chunked(CHUNK).flatMap { query(it) }
+
+    private companion object {
+        const val CHUNK = 900
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/PersonDao.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/PersonDao.kt
@@ -50,6 +50,25 @@ interface PersonDao {
     @Query("SELECT * FROM people")
     suspend fun allPeople(): List<Person>
 
+    /**
+     * The best person to open the chart on when nothing has been chosen yet.
+     *
+     * The most connected person is almost always the one who built the tree, or the ancestor they
+     * built it around — either way a far more useful first view than whoever happens to sort first,
+     * which tends to be a leaf with nothing above or below them.
+     */
+    @Query(
+        """
+        SELECT p.id FROM people p
+        LEFT JOIN relationships r
+          ON r.fromPersonId = p.id OR r.toPersonId = p.id
+        GROUP BY p.id
+        ORDER BY COUNT(r.id) DESC, p.createdAt ASC
+        LIMIT 1
+        """
+    )
+    suspend fun mostConnectedPersonId(): String?
+
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insert(person: Person)
 

--- a/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/RelationshipDao.kt
@@ -95,6 +95,35 @@ interface RelationshipDao {
     @Query("SELECT toPersonId FROM relationships WHERE fromPersonId = :personId AND type = 'PARENT'")
     suspend fun childIdsOf(personId: String): List<String>
 
+    @Query("SELECT DISTINCT fromPersonId FROM relationships WHERE toPersonId IN (:ids) AND type = 'PARENT'")
+    suspend fun parentIdsOfAll(ids: List<String>): List<String>
+
+    @Query("SELECT DISTINCT toPersonId FROM relationships WHERE fromPersonId IN (:ids) AND type = 'PARENT'")
+    suspend fun childIdsOfAll(ids: List<String>): List<String>
+
+    @Query(
+        """
+        SELECT DISTINCT CASE WHEN fromPersonId IN (:ids) THEN toPersonId ELSE fromPersonId END
+        FROM relationships
+        WHERE type = 'SPOUSE' AND (fromPersonId IN (:ids) OR toPersonId IN (:ids))
+        """
+    )
+    suspend fun spouseIdsOfAll(ids: List<String>): List<String>
+
+    /**
+     * Every edge whose *both* ends are in the given set.
+     *
+     * Deliberately not "every edge touching these people": the chart only draws connections between
+     * people it is already showing, and asking for the rest would pull in the whole tree.
+     */
+    @Query(
+        """
+        SELECT * FROM relationships
+        WHERE fromPersonId IN (:ids) AND toPersonId IN (:ids)
+        """
+    )
+    suspend fun edgesAmong(ids: List<String>): List<Relationship>
+
     @Query("SELECT fromPersonId FROM relationships WHERE toPersonId = :personId AND type = 'PARENT'")
     suspend fun parentIdsOf(personId: String): List<String>
 

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/FamilySnapshot.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/FamilySnapshot.kt
@@ -1,0 +1,49 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.Person
+
+/**
+ * A bounded slice of the family graph, already loaded.
+ *
+ * The chart never asks for the whole tree — it asks for the people within a few generations of one
+ * person. Holding that slice as plain data keeps the layout a pure function of its input, which is
+ * what makes it testable on the JVM and safe to run off the main thread.
+ */
+data class FamilySnapshot(
+    val people: Map<String, Person>,
+    /** parent id to child id. */
+    val parentEdges: List<Pair<String, String>>,
+    val spouseEdges: List<Pair<String, String>>,
+    val siblingEdges: List<Pair<String, String>>,
+) {
+    val parentsOf: Map<String, List<String>> =
+        parentEdges.groupBy({ it.second }, { it.first })
+
+    val childrenOf: Map<String, List<String>> =
+        parentEdges.groupBy({ it.first }, { it.second })
+
+    val spousesOf: Map<String, List<String>> =
+        (spouseEdges + spouseEdges.map { it.second to it.first })
+            .groupBy({ it.first }, { it.second })
+            .mapValues { (_, v) -> v.distinct() }
+
+    /**
+     * Siblings, derived from shared parents and unioned with any explicit edges — the same rule the
+     * database uses, so the chart and the person page never disagree.
+     */
+    val siblingsOf: Map<String, List<String>> = buildMap<String, MutableSet<String>> {
+        childrenOf.values.forEach { children ->
+            children.forEach { child ->
+                getOrPut(child) { mutableSetOf() }.addAll(children.filter { it != child })
+            }
+        }
+        siblingEdges.forEach { (a, b) ->
+            getOrPut(a) { mutableSetOf() }.add(b)
+            getOrPut(b) { mutableSetOf() }.add(a)
+        }
+    }.mapValues { (_, v) -> v.toList() }
+
+    companion object {
+        val Empty = FamilySnapshot(emptyMap(), emptyList(), emptyList(), emptyList())
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
@@ -1,0 +1,77 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.Person
+
+/** A person placed on the chart. [x] and [y] are the top-left corner, in layout units. */
+data class TreeNode(
+    val person: Person,
+    val level: Int,
+    val x: Float,
+    val y: Float,
+    val isFocus: Boolean,
+) {
+    val centerX: Float get() = x + TreeMetrics.NODE_WIDTH / 2f
+    val centerY: Float get() = y + TreeMetrics.NODE_HEIGHT / 2f
+    val bottom: Float get() = y + TreeMetrics.NODE_HEIGHT
+}
+
+/** The doubled rule drawn between partners. */
+data class SpouseLink(val fromX: Float, val toX: Float, val y: Float)
+
+/**
+ * One family's descent: a drop from the parents, a bar across the children, and a drop to each.
+ *
+ * Grouped by *parent set* rather than by individual parent, so a couple's children hang from one
+ * connector while a half-sibling hangs from their own — which is what makes a second marriage
+ * legible instead of a tangle of crossing lines.
+ */
+data class DescentLink(
+    val originX: Float,
+    val originY: Float,
+    val busY: Float,
+    val childXs: List<Float>,
+    val childTopY: Float,
+)
+
+data class TreeLayout(
+    val nodes: List<TreeNode> = emptyList(),
+    val spouseLinks: List<SpouseLink> = emptyList(),
+    val descentLinks: List<DescentLink> = emptyList(),
+    val width: Float = 0f,
+    val height: Float = 0f,
+    val focusId: String? = null,
+    /** True when people were left out because they sit beyond the loaded generations. */
+    val truncated: Boolean = false,
+) {
+    val isEmpty: Boolean get() = nodes.isEmpty()
+
+    fun nodeAt(x: Float, y: Float): TreeNode? = nodes.firstOrNull {
+        x >= it.x && x <= it.x + TreeMetrics.NODE_WIDTH &&
+            y >= it.y && y <= it.y + TreeMetrics.NODE_HEIGHT
+    }
+
+    fun node(personId: String): TreeNode? = nodes.firstOrNull { it.person.id == personId }
+}
+
+/** Chart geometry, in dp-equivalent layout units. */
+object TreeMetrics {
+    const val NODE_WIDTH = 132f
+    const val NODE_HEIGHT = 56f
+
+    /**
+     * Between unrelated nodes on the same row. Deliberately much wider than [COUPLE_GAP]: the
+     * difference in spacing is what tells you at a glance that two adjacent cards are a couple
+     * rather than just neighbours.
+     */
+    const val SIBLING_GAP = 36f
+
+    /** Between partners, kept tight so a couple reads as one block. */
+    const val COUPLE_GAP = 12f
+
+    /** Between generations, leaving room for the descent connectors. */
+    const val LEVEL_GAP = 76f
+
+    const val ROW_HEIGHT = NODE_HEIGHT + LEVEL_GAP
+
+    const val MARGIN = 24f
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
@@ -1,0 +1,371 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.PartialDate
+import com.vibethroughcode.ftree.data.Person
+import kotlin.math.max
+
+/**
+ * Arranges a slice of the family graph into a readable genealogical chart.
+ *
+ * The chart is ego-centric on purpose. Laying out an entire family produces something no phone can
+ * show and no person can read, so this draws one person's ancestors above and descendants below,
+ * with their siblings beside them, and everyone else is reached by re-focusing. That also keeps the
+ * work proportional to what is on screen rather than to the size of the tree.
+ *
+ * Pure: it takes a loaded [FamilySnapshot] and returns coordinates. No database, no Compose, so it
+ * runs off the main thread and is tested directly on the JVM.
+ */
+object TreeLayoutEngine {
+
+    /**
+     * A person drawn together with their partners.
+     *
+     * Couples are laid out as one block rather than as independent nodes, because a marriage that
+     * drifts apart on screen stops looking like a marriage, and children need a single point to
+     * descend from.
+     */
+    private class Unit(val members: List<String>) {
+        var x = 0f
+        val width: Float
+            get() = members.size * TreeMetrics.NODE_WIDTH +
+                (members.size - 1) * TreeMetrics.COUPLE_GAP
+
+        fun xOf(personId: String): Float =
+            x + members.indexOf(personId) * (TreeMetrics.NODE_WIDTH + TreeMetrics.COUPLE_GAP)
+
+        val centerX: Float get() = x + width / 2f
+    }
+
+    fun layout(
+        snapshot: FamilySnapshot,
+        focusId: String,
+        generationsUp: Int = 3,
+        generationsDown: Int = 3,
+    ): TreeLayout {
+        if (focusId !in snapshot.people) return TreeLayout()
+
+        val included = collect(snapshot, focusId, generationsUp, generationsDown)
+        val levels = included.levels
+
+        // --- Build the units, one per person-and-partners group, per level. ---
+        val unitOf = mutableMapOf<String, Unit>()
+        val unitsByLevel = mutableMapOf<Int, MutableList<Unit>>()
+        levels.entries.groupBy({ it.value }, { it.key }).forEach { (level, ids) ->
+            buildUnits(ids.toSet(), snapshot).forEach { unit ->
+                unit.members.forEach { unitOf[it] = unit }
+                unitsByLevel.getOrPut(level) { mutableListOf() } += unit
+            }
+        }
+
+        val focusUnit = unitOf[focusId] ?: return TreeLayout()
+
+        // --- Level 0: the focus and their siblings, in birth order. ---
+        val row0 = unitsByLevel[0] ?: mutableListOf()
+        orderByBirth(row0, snapshot)
+
+        // Siblings sit directly beside the focus. Their own descendants are not drawn (see
+        // `collect`), so the focus's subtree can spread out on the rows below without ever
+        // colliding with them — reserving the subtree's whole width up here would only shove the
+        // siblings, and the ancestors centred above them, far off to one side.
+        var cursor = 0f
+        row0.forEach { unit ->
+            unit.x = cursor
+            cursor += unit.width + TreeMetrics.SIBLING_GAP
+        }
+
+        placeDescendants(focusUnit, unitOf, unitsByLevel, snapshot, included)
+        placeAncestors(row0, unitOf, unitsByLevel, snapshot, included)
+
+        // --- Normalise so the chart starts at the margin. ---
+        val allUnits = unitsByLevel.values.flatten()
+        val minX = allUnits.minOfOrNull { it.x } ?: 0f
+        val minLevel = levels.values.minOrNull() ?: 0
+        allUnits.forEach { it.x += TreeMetrics.MARGIN - minX }
+
+        fun yOf(level: Int) = TreeMetrics.MARGIN + (level - minLevel) * TreeMetrics.ROW_HEIGHT
+
+        val nodes = levels.mapNotNull { (id, level) ->
+            val person = snapshot.people[id] ?: return@mapNotNull null
+            TreeNode(
+                person = person,
+                level = level,
+                x = unitOf.getValue(id).xOf(id),
+                y = yOf(level),
+                isFocus = id == focusId,
+            )
+        }.sortedBy { it.level }
+
+        return TreeLayout(
+            nodes = nodes,
+            spouseLinks = spouseLinks(unitsByLevel, ::yOf),
+            descentLinks = descentLinks(included, unitOf, levels, ::yOf),
+            width = (allUnits.maxOfOrNull { it.x + it.width } ?: 0f) + TreeMetrics.MARGIN,
+            height = yOf(levels.values.maxOrNull() ?: 0) +
+                TreeMetrics.NODE_HEIGHT + TreeMetrics.MARGIN,
+            focusId = focusId,
+            truncated = included.truncated,
+        )
+    }
+
+    // ------------------------------------------------------------------ selection
+
+    private class Included(
+        val levels: Map<String, Int>,
+        /** Child ids grouped by the exact set of parents they descend from. */
+        val families: Map<Set<String>, List<String>>,
+        val truncated: Boolean,
+    )
+
+    /**
+     * Chooses who appears.
+     *
+     * Ancestors and descendants of the focus, the focus's own siblings, and the partners of all of
+     * them. Deliberately *not* included: the descendants of siblings and of ancestors' siblings.
+     * Cousins and nieces multiply a chart's width far faster than they add to what it tells you,
+     * and they are one tap away by re-focusing.
+     */
+    private fun collect(
+        snapshot: FamilySnapshot,
+        focusId: String,
+        up: Int,
+        down: Int,
+    ): Included {
+        val levels = mutableMapOf(focusId to 0)
+        var truncated = false
+
+        fun addPartners(id: String, level: Int) {
+            snapshot.spousesOf[id].orEmpty().forEach { levels.putIfAbsent(it, level) }
+        }
+
+        // The focus's siblings share the row.
+        snapshot.siblingsOf[focusId].orEmpty().forEach { levels.putIfAbsent(it, 0) }
+        levels.keys.toList().forEach { addPartners(it, 0) }
+
+        // Upwards.
+        var frontier = (snapshot.siblingsOf[focusId].orEmpty() + focusId).toSet()
+        for (generation in 1..up) {
+            val parents = frontier.flatMap { snapshot.parentsOf[it].orEmpty() }.toSet()
+            if (parents.isEmpty()) break
+            parents.forEach { levels.putIfAbsent(it, -generation) }
+            parents.forEach { addPartners(it, -generation) }
+            frontier = parents
+            if (generation == up && parents.any { snapshot.parentsOf[it].orEmpty().isNotEmpty() }) {
+                truncated = true
+            }
+        }
+
+        // Downwards from the focus only.
+        frontier = setOf(focusId)
+        for (generation in 1..down) {
+            val children = frontier.flatMap { snapshot.childrenOf[it].orEmpty() }.toSet()
+            if (children.isEmpty()) break
+            children.forEach { levels.putIfAbsent(it, generation) }
+            children.forEach { addPartners(it, generation) }
+            frontier = children
+            if (generation == down && children.any { snapshot.childrenOf[it].orEmpty().isNotEmpty() }) {
+                truncated = true
+            }
+        }
+
+        // Group children by the exact parent set that is on screen, so each couple's children hang
+        // from their own connector and half-siblings do not share one.
+        val families = levels.keys
+            .mapNotNull { child ->
+                val parents = snapshot.parentsOf[child].orEmpty().filter { it in levels }.toSet()
+                if (parents.isEmpty()) null else parents to child
+            }
+            .groupBy({ it.first }, { it.second })
+
+        return Included(levels, families, truncated)
+    }
+
+    // ------------------------------------------------------------------ units
+
+    private fun buildUnits(ids: Set<String>, snapshot: FamilySnapshot): List<Unit> {
+        val remaining = ids.toMutableSet()
+        val units = mutableListOf<Unit>()
+
+        while (remaining.isNotEmpty()) {
+            val seed = remaining.first()
+            val group = mutableSetOf(seed)
+            val queue = ArrayDeque(listOf(seed))
+            while (queue.isNotEmpty()) {
+                val next = queue.removeFirst()
+                snapshot.spousesOf[next].orEmpty()
+                    .filter { it in remaining && group.add(it) }
+                    .forEach { queue += it }
+            }
+            remaining -= group
+
+            // The person with the most partners sits in the middle, so someone who married twice
+            // has a spouse on each side rather than both crowded to one.
+            val ordered = group.sortedByDescending { snapshot.spousesOf[it].orEmpty().count { s -> s in group } }
+            val members = when (ordered.size) {
+                1, 2 -> ordered
+                else -> {
+                    val hub = ordered.first()
+                    val rest = ordered.drop(1)
+                    rest.take(rest.size / 2) + hub + rest.drop(rest.size / 2)
+                }
+            }
+            units += Unit(members)
+        }
+        return units
+    }
+
+    private fun orderByBirth(units: MutableList<Unit>, snapshot: FamilySnapshot) {
+        units.sortBy { unit ->
+            unit.members.minOfOrNull { id ->
+                snapshot.people[id]?.birthDate?.let { PartialDate.parse(it)?.year } ?: Int.MAX_VALUE
+            } ?: Int.MAX_VALUE
+        }
+    }
+
+    // ------------------------------------------------------------------ placement
+
+    private fun childUnitsOf(
+        unit: Unit,
+        unitOf: Map<String, Unit>,
+        snapshot: FamilySnapshot,
+        included: Included,
+    ): List<Unit> = unit.members
+        .flatMap { snapshot.childrenOf[it].orEmpty() }
+        .filter { included.levels.containsKey(it) }
+        .mapNotNull { unitOf[it] }
+        .distinct()
+
+    /** Width the focus's descendants will need, before anything is positioned. */
+    private fun measureDescendants(
+        unit: Unit,
+        unitOf: Map<String, Unit>,
+        unitsByLevel: Map<Int, List<Unit>>,
+        snapshot: FamilySnapshot,
+        included: Included,
+    ): Float {
+        val children = childUnitsOf(unit, unitOf, snapshot, included)
+        if (children.isEmpty()) return unit.width
+        val childrenWidth = children.sumOf {
+            measureDescendants(it, unitOf, unitsByLevel, snapshot, included).toDouble()
+        }.toFloat() + (children.size - 1) * TreeMetrics.SIBLING_GAP
+        return max(unit.width, childrenWidth)
+    }
+
+    /** Packs each generation of children beneath and centred on their parents. */
+    private fun placeDescendants(
+        unit: Unit,
+        unitOf: Map<String, Unit>,
+        unitsByLevel: Map<Int, List<Unit>>,
+        snapshot: FamilySnapshot,
+        included: Included,
+    ) {
+        val children = childUnitsOf(unit, unitOf, snapshot, included).toMutableList()
+        if (children.isEmpty()) return
+        orderByBirth(children, snapshot)
+
+        val widths = children.map {
+            measureDescendants(it, unitOf, unitsByLevel, snapshot, included)
+        }
+        val total = widths.sum() + (children.size - 1) * TreeMetrics.SIBLING_GAP
+        var cursor = unit.centerX - total / 2f
+
+        children.forEachIndexed { index, child ->
+            child.x = cursor + (widths[index] - child.width) / 2f
+            cursor += widths[index] + TreeMetrics.SIBLING_GAP
+            placeDescendants(child, unitOf, unitsByLevel, snapshot, included)
+        }
+    }
+
+    /**
+     * Places each generation of parents above and centred on their children, then pushes apart any
+     * that collide. Ancestors fan out faster than descendants, so the separation sweep matters more
+     * here than the centring does.
+     */
+    private fun placeAncestors(
+        row0: List<Unit>,
+        unitOf: Map<String, Unit>,
+        unitsByLevel: Map<Int, MutableList<Unit>>,
+        snapshot: FamilySnapshot,
+        included: Included,
+    ) {
+        val minLevel = included.levels.values.minOrNull() ?: 0
+        var childRow = row0
+
+        for (level in -1 downTo minLevel) {
+            val row = unitsByLevel[level].orEmpty()
+            if (row.isEmpty()) continue
+
+            row.forEach { unit ->
+                val theirChildren = unit.members
+                    .flatMap { snapshot.childrenOf[it].orEmpty() }
+                    .filter { included.levels[it] == level + 1 }
+                    .mapNotNull { unitOf[it] }
+                    .distinct()
+                unit.x = if (theirChildren.isEmpty()) {
+                    childRow.firstOrNull()?.centerX?.minus(unit.width / 2f) ?: 0f
+                } else {
+                    theirChildren.map { it.centerX }.average().toFloat() - unit.width / 2f
+                }
+            }
+
+            separate(row)
+            childRow = row
+        }
+    }
+
+    /** Sweeps a row left to right, shifting anything that overlaps its neighbour. */
+    private fun separate(row: List<Unit>) {
+        val sorted = row.sortedBy { it.x }
+        for (i in 1 until sorted.size) {
+            val previous = sorted[i - 1]
+            val minimum = previous.x + previous.width + TreeMetrics.SIBLING_GAP
+            if (sorted[i].x < minimum) sorted[i].x = minimum
+        }
+    }
+
+    // ------------------------------------------------------------------ connectors
+
+    private fun spouseLinks(
+        unitsByLevel: Map<Int, List<Unit>>,
+        yOf: (Int) -> Float,
+    ): List<SpouseLink> = unitsByLevel.flatMap { (level, units) ->
+        units.flatMap { unit ->
+            unit.members.zipWithNext { a, b ->
+                SpouseLink(
+                    fromX = unit.xOf(a) + TreeMetrics.NODE_WIDTH,
+                    toX = unit.xOf(b),
+                    y = yOf(level) + TreeMetrics.NODE_HEIGHT / 2f,
+                )
+            }
+        }
+    }
+
+    private fun descentLinks(
+        included: Included,
+        unitOf: Map<String, Unit>,
+        levels: Map<String, Int>,
+        yOf: (Int) -> Float,
+    ): List<DescentLink> = included.families.mapNotNull { (parents, children) ->
+        val parentLevel = parents.firstNotNullOfOrNull { levels[it] } ?: return@mapNotNull null
+        val childLevel = children.firstNotNullOfOrNull { levels[it] } ?: return@mapNotNull null
+        if (childLevel != parentLevel + 1) return@mapNotNull null
+
+        val parentXs = parents.mapNotNull { id -> unitOf[id]?.xOf(id) }
+        if (parentXs.isEmpty()) return@mapNotNull null
+        val originX = parentXs.map { it + TreeMetrics.NODE_WIDTH / 2f }.average().toFloat()
+
+        val childXs = children
+            .mapNotNull { id -> unitOf[id]?.xOf(id)?.plus(TreeMetrics.NODE_WIDTH / 2f) }
+            .sorted()
+        if (childXs.isEmpty()) return@mapNotNull null
+
+        val parentBottom = yOf(parentLevel) + TreeMetrics.NODE_HEIGHT
+        val childTop = yOf(childLevel)
+        DescentLink(
+            originX = originX,
+            originY = parentBottom,
+            busY = parentBottom + (childTop - parentBottom) / 2f,
+            childXs = childXs,
+            childTopY = childTop,
+        )
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -8,13 +8,25 @@ import androidx.navigation.toRoute
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
 import com.vibethroughcode.ftree.ui.person.PersonDetailScreen
 import com.vibethroughcode.ftree.ui.person.PersonEditScreen
+import com.vibethroughcode.ftree.ui.tree.TreeScreen
 import com.vibethroughcode.ftree.ui.relative.AddRelativeScreen
 
 @Composable
 fun FTreeApp() {
     val navController = rememberNavController()
 
-    NavHost(navController = navController, startDestination = PeopleRoute) {
+    NavHost(navController = navController, startDestination = TreeRoute) {
+        composable<TreeRoute> {
+            TreeScreen(
+                onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                onOpenPeople = { navController.navigate(PeopleRoute) },
+                onAddPerson = { navController.navigate(EditPersonRoute()) },
+                onAddRelative = { anchorId, kind ->
+                    navController.navigate(AddRelativeRoute(anchorId, kind))
+                },
+            )
+        }
+
         composable<PeopleRoute> {
             PeopleScreen(
                 onOpenPerson = { navController.navigate(PersonRoute(it)) },
@@ -44,9 +56,11 @@ fun FTreeApp() {
                 onSaved = { personId ->
                     if (route.personId == null) {
                         // A newly added person opens straight onto their own page, which is where
-                        // the next thing you want to do — add a relative — will live.
+                        // the next thing you want to do — add a relative — lives. Only the form is
+                        // dropped from the back stack, so going back returns to wherever the add
+                        // started rather than always to the chart.
                         navController.navigate(PersonRoute(personId)) {
-                            popUpTo(PeopleRoute)
+                            popUpTo<EditPersonRoute> { inclusive = true }
                         }
                     } else {
                         navController.popBackStack()

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
@@ -9,6 +9,10 @@ import kotlinx.serialization.Serializable
  * Serializable objects rather than string templates, so a missing or misspelled argument is a
  * compile error instead of a crash on a device.
  */
+/** The chart is home; it is what the app is for. */
+@Serializable
+data object TreeRoute
+
 @Serializable
 data object PeopleRoute
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -13,6 +13,7 @@ import com.vibethroughcode.ftree.ui.people.PeopleViewModel
 import com.vibethroughcode.ftree.ui.person.PersonDetailViewModel
 import com.vibethroughcode.ftree.ui.person.PersonEditViewModel
 import com.vibethroughcode.ftree.ui.relative.AddRelativeViewModel
+import com.vibethroughcode.ftree.ui.tree.TreeViewModel
 
 private fun CreationExtras.repository(): FamilyRepository =
     (this[APPLICATION_KEY] as FTreeApplication).container.familyRepository
@@ -26,6 +27,7 @@ private fun CreationExtras.repository(): FamilyRepository =
 object FTreeViewModels {
     val Factory = viewModelFactory {
         initializer { PeopleViewModel(repository()) }
+        initializer { TreeViewModel(repository(), createSavedStateHandle()) }
         initializer {
             val handle: SavedStateHandle = createSavedStateHandle()
             PersonDetailViewModel(repository(), handle.toRoute<PersonRoute>().personId)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/RelativeLabels.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/RelativeLabels.kt
@@ -64,6 +64,15 @@ fun addRelativeLabel(kind: RelativeKind): Int = when (kind) {
     RelativeKind.SIBLING -> R.string.add_sibling
 }
 
+/** The bare word for a relationship kind, for use in a chip or a menu. */
+@StringRes
+fun relativeKindLabel(kind: RelativeKind): Int = when (kind) {
+    RelativeKind.PARENT -> R.string.kind_parent
+    RelativeKind.SPOUSE -> R.string.kind_spouse
+    RelativeKind.CHILD -> R.string.kind_child
+    RelativeKind.SIBLING -> R.string.kind_sibling
+}
+
 @StringRes
 fun addRelativeTitle(kind: RelativeKind): Int = when (kind) {
     RelativeKind.PARENT -> R.string.add_relative_title_parent

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -1,0 +1,312 @@
+package com.vibethroughcode.ftree.ui.tree
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.PartialDate
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.graph.TreeLayout
+import com.vibethroughcode.ftree.graph.TreeMetrics
+import com.vibethroughcode.ftree.graph.TreeNode
+import com.vibethroughcode.ftree.ui.theme.FTreeText
+import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import kotlin.math.max
+
+const val FamilyChartTag = "family-chart"
+
+/**
+ * The family chart.
+ *
+ * Everything is drawn into one `Canvas` rather than composed as a node per person: at a few hundred
+ * people, a composable per node costs far more in layout and recomposition than the drawing does.
+ *
+ * Pan and zoom live in plain float state read *only inside the draw lambda*, so dragging re-runs
+ * the draw phase and nothing else — no recomposition, no relayout, however large the family. Only
+ * nodes intersecting the viewport are drawn, so an off-screen thousand cost a bounds check each.
+ */
+@Composable
+fun FamilyChart(
+    layout: TreeLayout,
+    onSelect: (Person) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Text painted onto a canvas is invisible to a screen reader, and giving every node its own
+    // semantics would mean composing one per person on every pan. The chart therefore describes
+    // itself and points at the fully accessible route to the same information: the people list,
+    // where each person's page spells out every relationship as ordinary text.
+    val chartDescription = stringResource(
+        R.string.a11y_chart,
+        layout.focusId?.let { id -> layout.node(id)?.person?.name } ?: stringResource(R.string.person_unknown),
+        layout.nodes.size,
+    )
+    val density = LocalDensity.current
+    val measurer = rememberTextMeasurer()
+    val colors = MaterialTheme.colorScheme
+    val accents = FTreeTheme.accents
+
+    var zoom by remember { mutableFloatStateOf(1f) }
+    var pan by remember { mutableStateOf(Offset.Zero) }
+    var viewport by remember { mutableStateOf(IntSize.Zero) }
+
+    // Framing, whenever the chart changes. Done as an effect, never during composition or draw,
+    // so it cannot loop.
+    //
+    // A family that fits is shown whole, because seeing the shape of it is the point. Only when it
+    // does not fit does the view fall back to centring the focused person, who is then the thing
+    // you are most likely to be looking for.
+    LaunchedEffect(layout.focusId, layout.nodes.size, viewport) {
+        if (viewport == IntSize.Zero || layout.isEmpty) return@LaunchedEffect
+        with(density) {
+            val chartWidth = layout.width.dp.toPx()
+            val chartHeight = layout.height.dp.toPx()
+            val toFit = minOf(viewport.width / chartWidth, viewport.height / chartHeight, 1f)
+
+            if (toFit >= MIN_ZOOM) {
+                // Zooming out to show the whole family is the better opening move: the shape of it
+                // is most of what the chart has to say, and anything closer can be pinched to.
+                zoom = toFit
+                pan = Offset(
+                    x = (viewport.width - chartWidth * toFit) / 2f,
+                    y = (viewport.height - chartHeight * toFit) / 2f,
+                )
+            } else {
+                // Too large to shrink and stay legible, so open on the focused person instead.
+                val focus = layout.focusId?.let { layout.node(it) } ?: return@LaunchedEffect
+                zoom = 1f
+                pan = Offset(
+                    x = viewport.width / 2f - focus.centerX.dp.toPx(),
+                    y = viewport.height / 2f - focus.centerY.dp.toPx(),
+                )
+            }
+        }
+    }
+
+    val nodeWidthPx = with(density) { TreeMetrics.NODE_WIDTH.dp.toPx() }
+    val nodeHeightPx = with(density) { TreeMetrics.NODE_HEIGHT.dp.toPx() }
+    val cornerPx = with(density) { 10.dp.toPx() }
+    val rulePx = with(density) { 1.5.dp.toPx() }
+    val spouseGapPx = with(density) { 2.dp.toPx() }
+    val unitPx = with(density) { 1.dp.toPx() }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(FamilyChartTag)
+            .semantics { contentDescription = chartDescription }
+            .onSizeChanged { viewport = it }
+            .pointerInput(Unit) {
+                detectTransformGestures { centroid, panChange, zoomChange, _ ->
+                    val next = (zoom * zoomChange).coerceIn(MIN_ZOOM, MAX_ZOOM)
+                    // Scale about the pinch centre, so the chart grows around what the fingers
+                    // are on rather than around the corner of the screen.
+                    val factor = next / zoom
+                    pan = (pan - centroid) * factor + centroid + panChange
+                    zoom = next
+                }
+            }
+            .pointerInput(layout) {
+                detectTapGestures { tap ->
+                    val x = (tap.x - pan.x) / zoom / unitPx
+                    val y = (tap.y - pan.y) / zoom / unitPx
+                    layout.nodeAt(x, y)?.let { onSelect(it.person) }
+                }
+            },
+    ) {
+        val currentZoom = zoom
+        val currentPan = pan
+
+        // In layout units, the region currently on screen, padded by a node so partially visible
+        // cards are not clipped away.
+        val visible = Rect(
+            left = -currentPan.x / currentZoom / unitPx,
+            top = -currentPan.y / currentZoom / unitPx,
+            right = (size.width - currentPan.x) / currentZoom / unitPx,
+            bottom = (size.height - currentPan.y) / currentZoom / unitPx,
+        ).inflate(TreeMetrics.NODE_WIDTH)
+
+        translate(currentPan.x, currentPan.y) {
+            scale(currentZoom, currentZoom, Offset.Zero) {
+                layout.descentLinks.forEach { link ->
+                    val originX = link.originX * unitPx
+                    val busY = link.busY * unitPx
+                    val xs = link.childXs.map { it * unitPx }
+
+                    drawLine(
+                        accents.rule,
+                        Offset(originX, link.originY * unitPx),
+                        Offset(originX, busY),
+                        rulePx,
+                    )
+                    if (xs.size > 1) {
+                        drawLine(accents.rule, Offset(xs.first(), busY), Offset(xs.last(), busY), rulePx)
+                    } else {
+                        drawLine(accents.rule, Offset(originX, busY), Offset(xs.first(), busY), rulePx)
+                    }
+                    xs.forEach { x ->
+                        drawLine(accents.rule, Offset(x, busY), Offset(x, link.childTopY * unitPx), rulePx)
+                    }
+                }
+
+                // Marriage is the doubled rule, as on a drawn pedigree.
+                layout.spouseLinks.forEach { link ->
+                    val y = link.y * unitPx
+                    listOf(-spouseGapPx, spouseGapPx).forEach { dy ->
+                        drawLine(
+                            color = accents.spouseLink,
+                            start = Offset(link.fromX * unitPx, y + dy),
+                            end = Offset(link.toX * unitPx, y + dy),
+                            strokeWidth = rulePx,
+                        )
+                    }
+                }
+
+                layout.nodes.forEach { node ->
+                    if (node.x + TreeMetrics.NODE_WIDTH < visible.left || node.x > visible.right ||
+                        node.y + TreeMetrics.NODE_HEIGHT < visible.top || node.y > visible.bottom
+                    ) return@forEach
+
+                    drawPersonNode(
+                        node = node,
+                        left = node.x * unitPx,
+                        top = node.y * unitPx,
+                        width = nodeWidthPx,
+                        height = nodeHeightPx,
+                        measurer = measurer,
+                        surface = if (node.isFocus) colors.primaryContainer else colors.surface,
+                        onSurface = if (node.isFocus) colors.onPrimaryContainer else colors.onSurface,
+                        muted = colors.onSurfaceVariant,
+                        outline = when {
+                            node.isFocus -> colors.primary
+                            node.person.isUnnamed -> accents.unknown
+                            else -> accents.rule
+                        },
+                        unknownColor = accents.unknown,
+                        cornerPx = cornerPx,
+                        rulePx = rulePx,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private const val MIN_ZOOM = 0.35f
+private const val MAX_ZOOM = 2.5f
+
+private fun DrawScope.drawPersonNode(
+    node: TreeNode,
+    left: Float,
+    top: Float,
+    width: Float,
+    height: Float,
+    measurer: TextMeasurer,
+    surface: Color,
+    onSurface: Color,
+    muted: Color,
+    outline: Color,
+    unknownColor: Color,
+    cornerPx: Float,
+    rulePx: Float,
+) {
+    val path = Path().apply {
+        addRoundRect(
+            RoundRect(
+                Rect(left, top, left + width, top + height),
+                CornerRadius(cornerPx, cornerPx),
+            )
+        )
+    }
+    drawPath(path, surface)
+
+    // A person with no name gets a dashed edge: the gap is in what the family remembers, not a
+    // fault in the record, so it should read as open rather than broken.
+    drawPath(
+        path = path,
+        color = outline,
+        style = if (node.person.isUnnamed) {
+            Stroke(width = rulePx, pathEffect = PathEffect.dashPathEffect(floatArrayOf(rulePx * 4, rulePx * 3)))
+        } else {
+            Stroke(width = if (node.isFocus) rulePx * 1.8f else rulePx)
+        },
+    )
+
+    val textWidth = (width - cornerPx * 2).toInt().coerceAtLeast(1)
+    val name = node.person.name?.trim()?.takeIf { it.isNotEmpty() }
+    val nameResult = measurer.measure(
+        text = name ?: "Unknown",
+        style = FTreeText.nodeName.copy(
+            color = if (name == null) unknownColor else onSurface,
+            textAlign = TextAlign.Center,
+        ),
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis,
+        constraints = Constraints(maxWidth = textWidth),
+    )
+
+    val yearsResult = node.person.lifespan()?.let {
+        measurer.measure(
+            text = it,
+            style = FTreeText.nodeYears.copy(color = muted, textAlign = TextAlign.Center),
+            maxLines = 1,
+            constraints = Constraints(maxWidth = textWidth),
+        )
+    }
+
+    val block = nameResult.size.height + (yearsResult?.size?.height ?: 0)
+    var y = top + max(0f, (height - block) / 2f)
+    drawText(nameResult, topLeft = Offset(left + (width - nameResult.size.width) / 2f, y))
+    y += nameResult.size.height
+    yearsResult?.let {
+        drawText(it, topLeft = Offset(left + (width - it.size.width) / 2f, y))
+    }
+}
+
+/** Years only — a node has room for a span, not a date. */
+private fun Person.lifespan(): String? {
+    val born = PartialDate.parse(birthDate)?.year
+    val died = PartialDate.parse(deathDate)?.year
+    return when {
+        born != null && died != null -> "$born–$died"
+        born != null && deceased -> "$born–"
+        born != null -> born.toString()
+        died != null -> "–$died"
+        else -> null
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -1,0 +1,242 @@
+package com.vibethroughcode.ftree.ui.tree
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CenterFocusStrong
+import androidx.compose.material.icons.filled.PersonAddAlt
+import androidx.compose.material.icons.filled.UnfoldMore
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.ui.FTreeViewModels
+import com.vibethroughcode.ftree.ui.common.EmptyState
+import com.vibethroughcode.ftree.ui.common.PersonRow
+import com.vibethroughcode.ftree.ui.common.TreeGlyph
+import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.relativeKindLabel
+
+const val TreePeopleButtonTag = "tree-people"
+const val TreeAddButtonTag = "tree-add"
+const val TreeFocusHereTag = "tree-focus-here"
+const val TreeOpenPersonTag = "tree-open-person"
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TreeScreen(
+    onOpenPerson: (String) -> Unit,
+    onOpenPeople: () -> Unit,
+    onAddPerson: () -> Unit,
+    onAddRelative: (String, RelativeKind) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: TreeViewModel = viewModel(factory = FTreeViewModels.Factory),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    var selected by remember { mutableStateOf<Person?>(null) }
+    val sheetState = rememberModalBottomSheetState()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text(stringResource(R.string.tree_title)) },
+                actions = {
+                    if (state.layout.truncated) {
+                        IconButton(onClick = viewModel::showMoreGenerations) {
+                            Icon(
+                                Icons.Default.UnfoldMore,
+                                contentDescription = stringResource(R.string.tree_more_generations),
+                            )
+                        }
+                    }
+                    IconButton(
+                        onClick = onOpenPeople,
+                        modifier = Modifier.testTag(TreePeopleButtonTag),
+                    ) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.List,
+                            contentDescription = stringResource(R.string.tree_people),
+                        )
+                    }
+                },
+            )
+        },
+        floatingActionButton = {
+            if (!state.treeIsEmpty) {
+                FloatingActionButton(
+                    onClick = onAddPerson,
+                    modifier = Modifier.testTag(TreeAddButtonTag),
+                ) {
+                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.people_add))
+                }
+            }
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                state.treeIsEmpty -> EmptyState(
+                    title = stringResource(R.string.empty_title),
+                    body = stringResource(R.string.empty_body),
+                    actionLabel = stringResource(R.string.empty_action),
+                    onAction = onAddPerson,
+                    illustration = { TreeGlyph() },
+                )
+
+                else -> FamilyChart(
+                    layout = state.layout,
+                    onSelect = { selected = it },
+                )
+            }
+        }
+    }
+
+    selected?.let { person ->
+        ModalBottomSheet(
+            onDismissRequest = { selected = null },
+            sheetState = sheetState,
+        ) {
+            PersonActions(
+                person = person,
+                isFocus = person.id == state.layout.focusId,
+                onOpen = {
+                    selected = null
+                    onOpenPerson(person.id)
+                },
+                onFocus = {
+                    selected = null
+                    viewModel.focusOn(person.id)
+                },
+                onAddRelative = { kind ->
+                    selected = null
+                    onAddRelative(person.id, kind)
+                },
+            )
+        }
+    }
+}
+
+/**
+ * What you can do with the person you tapped.
+ *
+ * "Centre the tree here" is the important one: it is how the rest of a family that does not fit on
+ * one chart stays reachable, so it sits above opening their page.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun PersonActions(
+    person: Person,
+    isFocus: Boolean,
+    onOpen: () -> Unit,
+    onFocus: () -> Unit,
+    onAddRelative: (RelativeKind) -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth().navigationBarsPadding().padding(bottom = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        PersonRow(person = person, onClick = onOpen)
+
+        if (!isFocus) {
+            SheetAction(
+                icon = { Icon(Icons.Default.CenterFocusStrong, contentDescription = null) },
+                label = stringResource(R.string.tree_focus_here),
+                tag = TreeFocusHereTag,
+                onClick = onFocus,
+            )
+        }
+        SheetAction(
+            icon = { Icon(Icons.AutoMirrored.Filled.List, contentDescription = null) },
+            label = stringResource(R.string.tree_open_person, person.displayName()),
+            tag = TreeOpenPersonTag,
+            onClick = onOpen,
+        )
+        // Naming the four kinds outright is one tap either way, and avoids the sheet quietly
+        // choosing "parent" on the user's behalf.
+        Text(
+            text = stringResource(R.string.tree_add_relative),
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(start = 24.dp, top = 12.dp, bottom = 4.dp),
+        )
+        FlowRow(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            RelativeKind.entries.forEach { kind ->
+                AssistChip(
+                    onClick = { onAddRelative(kind) },
+                    label = { Text(stringResource(relativeKindLabel(kind))) },
+                    leadingIcon = {
+                        Icon(
+                            Icons.Default.PersonAddAlt,
+                            contentDescription = null,
+                            modifier = Modifier.size(18.dp),
+                        )
+                    },
+                    modifier = Modifier.testTag("tree-add-" + kind.name.lowercase()),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SheetAction(
+    icon: @Composable () -> Unit,
+    label: String,
+    tag: String,
+    onClick: () -> Unit,
+) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp).testTag(tag),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            icon()
+            Text(text = label, style = MaterialTheme.typography.bodyLarge)
+        }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeViewModel.kt
@@ -1,0 +1,109 @@
+package com.vibethroughcode.ftree.ui.tree
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.graph.TreeLayout
+import com.vibethroughcode.ftree.graph.TreeLayoutEngine
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+data class TreeUiState(
+    val layout: TreeLayout = TreeLayout(),
+    val loading: Boolean = true,
+    /** No people at all, as opposed to a focus that could not be resolved. */
+    val treeIsEmpty: Boolean = false,
+    val generationsUp: Int = DEFAULT_GENERATIONS,
+    val generationsDown: Int = DEFAULT_GENERATIONS,
+) {
+    companion object {
+        const val DEFAULT_GENERATIONS = 3
+    }
+}
+
+class TreeViewModel(
+    private val repository: FamilyRepository,
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TreeUiState())
+    val uiState: StateFlow<TreeUiState> = _uiState.asStateFlow()
+
+    /**
+     * Survives process death, so returning to the app puts you back where you were looking rather
+     * than at whoever happens to sort first.
+     */
+    var focusId: String?
+        get() = savedStateHandle[FOCUS_KEY]
+        private set(value) { savedStateHandle[FOCUS_KEY] = value }
+
+    init {
+        refresh()
+        // The chart is a projection of the whole graph, so any change anywhere can move it.
+        viewModelScope.launch {
+            repository.observePersonCount().collect { refresh() }
+        }
+    }
+
+    fun focusOn(personId: String) {
+        focusId = personId
+        refresh()
+    }
+
+    fun showMoreGenerations() {
+        _uiState.update {
+            it.copy(generationsUp = it.generationsUp + 2, generationsDown = it.generationsDown + 2)
+        }
+        refresh()
+    }
+
+    fun refresh() {
+        viewModelScope.launch {
+            val state = _uiState.value
+            val anchor = resolveFocus()
+            if (anchor == null) {
+                _uiState.update { it.copy(loading = false, treeIsEmpty = true, layout = TreeLayout()) }
+                return@launch
+            }
+
+            // Loading and laying out are both off the main thread; a large family should never
+            // stutter the chart it is being drawn into.
+            val layout = withContext(Dispatchers.Default) {
+                val snapshot = repository.loadNeighbourhood(
+                    focusId = anchor,
+                    generationsUp = state.generationsUp,
+                    generationsDown = state.generationsDown,
+                )
+                TreeLayoutEngine.layout(
+                    snapshot = snapshot,
+                    focusId = anchor,
+                    generationsUp = state.generationsUp,
+                    generationsDown = state.generationsDown,
+                )
+            }
+            _uiState.update { it.copy(layout = layout, loading = false, treeIsEmpty = false) }
+        }
+    }
+
+    /**
+     * Falls back to the first person in the tree when nothing is focused, or when the focused
+     * person has been deleted underneath us.
+     */
+    private suspend fun resolveFocus(): String? {
+        val current = focusId
+        if (current != null && repository.person(current) != null) return current
+        val best = repository.mostConnectedPersonId()
+        focusId = best
+        return best
+    }
+
+    private companion object {
+        const val FOCUS_KEY = "tree-focus"
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,21 @@
     <string name="rejected_cycle">That would make someone their own ancestor.</string>
     <string name="rejected_contradiction">They\'re already recorded as parent and child.</string>
 
+    <!-- Tree -->
+    <string name="tree_title">Family tree</string>
+    <string name="tree_people">All people</string>
+    <string name="tree_open_person">Open %1$s</string>
+    <string name="tree_focus_here">Centre the tree here</string>
+    <string name="tree_add_relative">Add a relative</string>
+    <string name="kind_parent">Parent</string>
+    <string name="kind_spouse">Spouse</string>
+    <string name="kind_child">Child</string>
+    <string name="kind_sibling">Sibling</string>
+    <string name="tree_more_generations">Show more generations</string>
+    <string name="tree_truncated">More generations exist beyond this view.</string>
+    <string name="tree_loading">Laying out your family</string>
+    <string name="a11y_chart">Family tree chart, centred on %1$s, showing %2$d people. Use the people list for a readable list of everyone and their relationships.</string>
+
     <!-- Shared -->
     <string name="a11y_person_avatar">Photo of %1$s</string>
     <string name="a11y_unknown_avatar">Unknown person</string>

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
@@ -1,0 +1,300 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.Person
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.math.abs
+
+class TreeLayoutEngineTest {
+
+    /** Builds a snapshot from a compact description of a family. */
+    private class Builder {
+        val people = mutableMapOf<String, Person>()
+        val parents = mutableListOf<Pair<String, String>>()
+        val spouses = mutableListOf<Pair<String, String>>()
+        val siblings = mutableListOf<Pair<String, String>>()
+
+        fun person(id: String, born: String? = null) = apply {
+            people[id] = Person(id = id, name = id, birthDate = born)
+        }
+
+        fun parentOf(parent: String, child: String) = apply { parents += parent to child }
+        fun married(a: String, b: String) = apply { spouses += a to b }
+        fun siblingOf(a: String, b: String) = apply { siblings += a to b }
+
+        fun build() = FamilySnapshot(people, parents, spouses, siblings)
+    }
+
+    private fun TreeLayout.levelOf(id: String) = node(id)?.level
+    private fun TreeLayout.xOf(id: String) = node(id)!!.centerX
+
+    private fun nuclearFamily() = Builder()
+        .person("father", "1962").person("mother", "1965")
+        .person("me", "1990").person("sister", "1993")
+        .person("wife", "1992").person("child", "2020")
+        .married("father", "mother")
+        .married("me", "wife")
+        .parentOf("father", "me").parentOf("mother", "me")
+        .parentOf("father", "sister").parentOf("mother", "sister")
+        .parentOf("me", "child").parentOf("wife", "child")
+        .build()
+
+    @Test
+    fun `an unknown focus lays out nothing rather than throwing`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "nobody")
+        assertTrue(layout.isEmpty)
+    }
+
+    @Test
+    fun `a lone person is a chart of one`() {
+        val snapshot = Builder().person("me").build()
+        val layout = TreeLayoutEngine.layout(snapshot, "me")
+
+        assertEquals(1, layout.nodes.size)
+        assertEquals(0, layout.levelOf("me"))
+        assertTrue(layout.width > 0f && layout.height > 0f)
+    }
+
+    @Test
+    fun `generations sit on their own rows above and below the focus`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+
+        assertEquals(-1, layout.levelOf("father"))
+        assertEquals(-1, layout.levelOf("mother"))
+        assertEquals(0, layout.levelOf("me"))
+        assertEquals(0, layout.levelOf("sister"))
+        assertEquals(0, layout.levelOf("wife"))
+        assertEquals(1, layout.levelOf("child"))
+    }
+
+    @Test
+    fun `a row shares one y and rows are ordered top to bottom`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+
+        assertEquals(layout.node("father")!!.y, layout.node("mother")!!.y, 0.01f)
+        assertTrue(layout.node("father")!!.y < layout.node("me")!!.y)
+        assertTrue(layout.node("me")!!.y < layout.node("child")!!.y)
+    }
+
+    @Test
+    fun `partners are placed side by side`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+
+        val gap = abs(layout.xOf("me") - layout.xOf("wife"))
+        assertEquals(TreeMetrics.NODE_WIDTH + TreeMetrics.COUPLE_GAP, gap, 0.01f)
+    }
+
+    @Test
+    fun `no two people on the same row overlap`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+
+        layout.nodes.groupBy { it.level }.forEach { (_, row) ->
+            row.sortedBy { it.x }.zipWithNext { left, right ->
+                assertTrue(
+                    "${left.person.id} overlaps ${right.person.id}",
+                    right.x >= left.x + TreeMetrics.NODE_WIDTH - 0.01f,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `a couple's children hang from one connector`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+
+        // father+mother -> me, sister is one family; me+wife -> child is another.
+        val toSiblings = layout.descentLinks.first { it.childXs.size == 2 }
+        assertEquals(2, toSiblings.childXs.size)
+        // The drop starts between the two parents.
+        val between = layout.xOf("father") to layout.xOf("mother")
+        assertTrue(toSiblings.originX > minOf(between.first, between.second))
+        assertTrue(toSiblings.originX < maxOf(between.first, between.second))
+    }
+
+    @Test
+    fun `half-siblings hang from different connectors`() {
+        val snapshot = Builder()
+            .person("father").person("first").person("second")
+            .person("a", "2010").person("b", "2015")
+            .married("father", "first").married("father", "second")
+            .parentOf("father", "a").parentOf("first", "a")
+            .parentOf("father", "b").parentOf("second", "b")
+            .build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "father")
+
+        // Two separate descents, not one bar spanning both children.
+        val descents = layout.descentLinks.filter { it.childTopY > it.originY }
+        assertEquals(2, descents.size)
+        assertTrue(descents.all { it.childXs.size == 1 })
+    }
+
+    @Test
+    fun `someone who married twice sits between their partners`() {
+        val snapshot = Builder()
+            .person("me").person("first").person("second")
+            .married("me", "first").married("me", "second")
+            .build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "me")
+
+        val me = layout.xOf("me")
+        val a = layout.xOf("first")
+        val b = layout.xOf("second")
+        assertTrue("expected $me between $a and $b", me > minOf(a, b) && me < maxOf(a, b))
+    }
+
+    @Test
+    fun `siblings are ordered by birth`() {
+        val snapshot = Builder()
+            .person("father").person("eldest", "1985").person("me", "1990").person("youngest", "1995")
+            .parentOf("father", "eldest").parentOf("father", "me").parentOf("father", "youngest")
+            .build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "me")
+
+        assertTrue(layout.xOf("eldest") < layout.xOf("me"))
+        assertTrue(layout.xOf("me") < layout.xOf("youngest"))
+    }
+
+    @Test
+    fun `a person with no dates still gets a place`() {
+        val snapshot = Builder()
+            .person("father").person("me", "1990").person("unknownSibling")
+            .parentOf("father", "me").parentOf("father", "unknownSibling")
+            .build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "me")
+        assertNotNull(layout.node("unknownSibling"))
+        assertEquals(0, layout.levelOf("unknownSibling"))
+    }
+
+    @Test
+    fun `an unnamed ancestor is a node like any other`() {
+        val snapshot = Builder()
+            .person("me", "1990").person("father", "1962")
+            .parentOf("father", "me")
+            .apply { people["unknown"] = Person(id = "unknown") }
+            .parentOf("unknown", "father")
+            .build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "me")
+
+        assertEquals(-2, layout.levelOf("unknown"))
+        assertTrue(layout.node("unknown")!!.person.isUnnamed)
+    }
+
+    @Test
+    fun `siblings joined only by an explicit edge still share the row`() {
+        val snapshot = Builder()
+            .person("me", "1990").person("brother", "1992")
+            .siblingOf("me", "brother")
+            .build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "me")
+        assertEquals(0, layout.levelOf("brother"))
+    }
+
+    @Test
+    fun `the generation limit bounds how far the chart reaches`() {
+        val builder = Builder()
+        // A ten-generation line of descent.
+        (0..10).forEach { builder.person("g$it", (1900 + it * 25).toString()) }
+        (0 until 10).forEach { builder.parentOf("g$it", "g${it + 1}") }
+        val snapshot = builder.build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "g5", generationsUp = 2, generationsDown = 2)
+
+        assertNotNull(layout.node("g3"))
+        assertNotNull(layout.node("g7"))
+        assertNull(layout.node("g2"))
+        assertNull(layout.node("g8"))
+        assertTrue("more generations exist, so the chart says so", layout.truncated)
+    }
+
+    @Test
+    fun `a fully shown family is not marked truncated`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+        assertFalse(layout.truncated)
+    }
+
+    @Test
+    fun `cousins are left out because re-focusing reaches them`() {
+        val snapshot = Builder()
+            .person("grandfather").person("father").person("uncle")
+            .person("me").person("cousin")
+            .parentOf("grandfather", "father").parentOf("grandfather", "uncle")
+            .parentOf("father", "me").parentOf("uncle", "cousin")
+            .build()
+
+        val layout = TreeLayoutEngine.layout(snapshot, "me")
+
+        assertNotNull(layout.node("grandfather"))
+        assertNotNull(layout.node("father"))
+        // The uncle's line would multiply the width without adding to what the chart says.
+        assertNull(layout.node("cousin"))
+    }
+
+    @Test
+    fun `hit testing finds the person under a point and nobody under a gap`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+        val me = layout.node("me")!!
+
+        assertEquals("me", layout.nodeAt(me.centerX, me.centerY)?.person?.id)
+        assertNull(layout.nodeAt(me.x - 10f, me.centerY))
+        assertNull(layout.nodeAt(me.centerX, me.y - 20f))
+    }
+
+    @Test
+    fun `re-focusing on a relative re-centres the chart on them`() {
+        val snapshot = nuclearFamily()
+
+        val onMe = TreeLayoutEngine.layout(snapshot, "me")
+        val onFather = TreeLayoutEngine.layout(snapshot, "father")
+
+        assertEquals(0, onFather.levelOf("father"))
+        assertEquals(1, onFather.levelOf("me"))
+        // The father's grandchild is now two generations down and still on the chart.
+        assertEquals(2, onFather.levelOf("child"))
+        assertEquals(-1, onMe.levelOf("father"))
+    }
+
+    @Test
+    fun `a wide family stays laid out in reasonable time`() {
+        val builder = Builder()
+        builder.person("root", "1900")
+        var previous = listOf("root")
+        var id = 0
+        repeat(4) { generation ->
+            val next = mutableListOf<String>()
+            previous.forEach { parent ->
+                repeat(4) {
+                    val child = "p${id++}"
+                    builder.person(child, (1925 + generation * 25).toString())
+                    builder.parentOf(parent, child)
+                    next += child
+                }
+            }
+            previous = next
+        }
+
+        val snapshot = builder.build()
+        val started = System.nanoTime()
+        val layout = TreeLayoutEngine.layout(snapshot, "root", generationsDown = 4)
+        val millis = (System.nanoTime() - started) / 1_000_000
+
+        assertEquals(1 + 4 + 16 + 64 + 256, layout.nodes.size)
+        assertTrue("layout took ${millis}ms", millis < 1_000)
+
+        // Still no overlaps at 256 nodes on the bottom row.
+        layout.nodes.groupBy { it.level }.forEach { (_, row) ->
+            row.sortedBy { it.x }.zipWithNext { left, right ->
+                assertTrue(right.x >= left.x + TreeMetrics.NODE_WIDTH - 0.01f)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #4. The chart is now the home screen, with the people list one tap away.

## Ego-centric on purpose

Laying out a whole family produces something no phone can show and no person can read. This draws
**one person's ancestors above and descendants below**, siblings beside them, and everyone else is
reached by re-focusing — which also keeps the work proportional to what's on screen rather than to
the size of the family.

Cousins and siblings' descendants are deliberately left out. They multiply a chart's width far
faster than they add to what it says, and they're one tap away.

## Three decisions carrying the weight

1. **The layout is a pure function** from a loaded snapshot to coordinates — no database, no
   Compose. It runs off the main thread and is tested directly on the JVM, including that nothing
   overlaps at 341 nodes.
2. **Only the neighbourhood is loaded**, a generation at a time, one batched query per ring. A tree
   of thousands opens as fast as a tree of ten.
3. **One Canvas, not a composable per node.** At a few hundred people a node per person costs far
   more than the drawing. Pan/zoom live in float state read *only inside the draw lambda*, so
   dragging re-runs the draw phase and nothing else; offscreen nodes cost a bounds check each.

## Notation, continuous with the launcher glyph

Marriage is a doubled rule. A couple's children hang from one connector while a half-sibling hangs
from their own. Someone with no name gets a **dashed brass edge** — the gap is in what the family
remembers, not a fault in the record.

## Defects found and fixed while testing on the emulator

- **It opened on whoever sorted first alphabetically** — usually a leaf with nothing above or below.
  Now opens on the most connected person, who is almost always whoever built the tree.
- **Siblings were shoved past the entire descendant subtree**, dragging the ancestors off-screen to
  one side. Siblings' descendants aren't drawn, so that width reservation was never needed.
- **The sibling gap was nearly the couple gap**, so an unrelated neighbour read like a partner.
- **The bottom sheet's "Add a relative" silently chose *parent*.** Replaced with four explicit chips.
- **Saving a new person popped back to the chart**, losing the list you'd started from.

## Accessibility — a stated limitation

Canvas text is invisible to a screen reader, and per-node semantics would mean composing a node per
person on every pan. The chart therefore **describes itself** and points at the people list, where
each person's page spells out every relationship as ordinary text. That's a real, complete
alternative route rather than a fig leaf, but it is a limitation and it's documented as one.

## Verification

- 55 JVM (19 new, layout engine) and 56 instrumented — all green on `pixel7_api36`. `lintDebug` clean.
- Walked on the emulator with the sample family: fit-to-view, tap → sheet, re-focus, and back.
- **2,000-person smoke test** via the debug seeder: cold start to a drawn chart in ~2.4s, falls back
  to focus-centring as designed. Closer measurement belongs to #9.