### PR TITLE
Photos

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
 
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.coil.compose)
+    implementation(libs.androidx.exifinterface)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyRepositoryTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/data/FamilyRepositoryTest.kt
@@ -27,7 +27,7 @@ class FamilyRepositoryTest {
         db = Room.inMemoryDatabaseBuilder(context, FTreeDatabase::class.java)
             .addCallback(FTreeDatabase.enforceForeignKeys)
             .build()
-        repository = FamilyRepository(db)
+        repository = FamilyRepository(db, PhotoStore(context))
     }
 
     @After

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/data/PhotoStoreTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/data/PhotoStoreTest.kt
@@ -1,0 +1,115 @@
+package com.vibethroughcode.ftree.data
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class PhotoStoreTest {
+
+    private lateinit var store: PhotoStore
+    private lateinit var directory: File
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        store = PhotoStore(context)
+        directory = File(context.filesDir, PhotoStore.DIRECTORY)
+        directory.deleteRecursively()
+    }
+
+    @After
+    fun tearDown() {
+        directory.deleteRecursively()
+    }
+
+    private fun jpegBytes(width: Int, height: Int): ByteArray {
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        return ByteArrayOutputStream().use {
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, it)
+            it.toByteArray()
+        }
+    }
+
+    @Test
+    fun storingAnImageReturnsAnIdThatResolvesToAFile() = runTest {
+        val id = store.saveBytes(jpegBytes(200, 200))
+
+        assertNotNull(id)
+        assertTrue(store.exists(id))
+        assertTrue(store.file(id!!).length() > 0)
+    }
+
+    @Test
+    fun aLargeImageIsScaledDownOnTheWayIn() = runTest {
+        val id = store.saveBytes(jpegBytes(4000, 3000))!!
+
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(store.file(id).absolutePath, bounds)
+
+        // A family of a thousand should not be carrying a thousand camera-resolution originals.
+        assertTrue(
+            "stored at ${bounds.outWidth}x${bounds.outHeight}",
+            maxOf(bounds.outWidth, bounds.outHeight) <= 1024,
+        )
+    }
+
+    @Test
+    fun theStoredIdIsAFileNameAndNotAPath() = runTest {
+        val id = store.saveBytes(jpegBytes(100, 100))!!
+
+        // A path would break on reinstall or on a restore to another device.
+        assertFalse(id.contains('/'))
+        assertEquals(id, File(id).name)
+    }
+
+    @Test
+    fun deletingRemovesTheFile() = runTest {
+        val id = store.saveBytes(jpegBytes(100, 100))!!
+
+        store.delete(id)
+
+        assertFalse(store.exists(id))
+    }
+
+    @Test
+    fun deletingSomethingThatIsNotThereIsHarmless() = runTest {
+        store.delete(null)
+        store.delete("does-not-exist.jpg")
+    }
+
+    @Test
+    fun unreadableBytesYieldNothingRatherThanACrash() = runTest {
+        assertNull(store.saveBytes("not an image".toByteArray()))
+    }
+
+    @Test
+    fun missingPhotosAreReportable() = runTest {
+        val present = store.saveBytes(jpegBytes(50, 50))!!
+
+        val missing = store.missing(listOf(present, "gone.jpg"))
+
+        assertEquals(listOf("gone.jpg"), missing)
+    }
+
+    @Test
+    fun anImportedPhotoCanKeepTheIdItArrivedWith() = runTest {
+        val id = store.saveBytes(jpegBytes(100, 100), preferredId = "from-an-export.jpg")
+
+        assertEquals("from-an-export.jpg", id)
+        assertTrue(store.exists(id))
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
@@ -3,6 +3,7 @@ package com.vibethroughcode.ftree
 import android.content.Context
 import com.vibethroughcode.ftree.data.FTreeDatabase
 import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.PhotoStore
 
 /**
  * Hand-rolled dependency wiring.
@@ -14,5 +15,6 @@ import com.vibethroughcode.ftree.data.FamilyRepository
 class AppContainer(context: Context) {
     /** Public so instrumented tests can call `clearAllTables()` between runs. */
     val database: FTreeDatabase by lazy { FTreeDatabase.build(context) }
-    val familyRepository: FamilyRepository by lazy { FamilyRepository(database) }
+    val familyRepository: FamilyRepository by lazy { FamilyRepository(database, photoStore) }
+    val photoStore: PhotoStore by lazy { PhotoStore(context.applicationContext) }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
@@ -27,6 +27,7 @@ enum class DeletionMode {
  */
 class FamilyRepository(
     private val db: FTreeDatabase,
+    private val photos: PhotoStore,
     private val people: PersonDao = db.personDao(),
     private val relationships: RelationshipDao = db.relationshipDao(),
     private val origins: PersonOriginDao = db.personOriginDao(),
@@ -75,11 +76,17 @@ class FamilyRepository(
         people.update(person.copy(updatedAt = System.currentTimeMillis()))
     }
 
-    suspend fun deletePerson(id: String, mode: DeletionMode) = db.withTransaction {
-        when (mode) {
-            DeletionMode.KEEP_AS_UNKNOWN -> people.clearDetails(id)
-            DeletionMode.DELETE_COMPLETELY -> people.deleteById(id)
+    suspend fun deletePerson(id: String, mode: DeletionMode) {
+        // Read the photo before the row goes, so the file can be cleaned up afterwards rather
+        // than being left behind as an orphan nothing will ever reference again.
+        val photoId = people.findById(id)?.photoId
+        db.withTransaction {
+            when (mode) {
+                DeletionMode.KEEP_AS_UNKNOWN -> people.clearDetails(id)
+                DeletionMode.DELETE_COMPLETELY -> people.deleteById(id)
+            }
         }
+        photos.delete(photoId)
     }
 
     /**

--- a/app/src/main/java/com/vibethroughcode/ftree/data/PhotoStore.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/PhotoStore.kt
@@ -1,0 +1,124 @@
+package com.vibethroughcode.ftree.data
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+import android.graphics.Matrix
+import java.io.File
+import java.io.InputStream
+import java.util.UUID
+import kotlin.math.max
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Photos, kept inside the app's own storage.
+ *
+ * A picked image is *copied* rather than referenced. A content URI granted by the photo picker is
+ * revoked the moment the app restarts, and a file path in the gallery can be moved or deleted by
+ * anything, so either would leave the tree full of pictures that silently stop loading. The
+ * database records only the file name, never a path, so the reference survives a reinstall or a
+ * restore onto a different device.
+ *
+ * Images are downscaled on the way in: a family of a thousand should not carry a thousand
+ * camera-resolution originals, and nothing here is ever shown larger than a phone screen.
+ */
+class PhotoStore(private val context: Context) {
+
+    private val directory: File
+        get() = File(context.filesDir, DIRECTORY).apply { mkdirs() }
+
+    fun file(photoId: String): File = File(directory, photoId)
+
+    fun exists(photoId: String?): Boolean =
+        photoId != null && file(photoId).exists()
+
+    /** Copies and downscales a picked image. Returns the new photo id, or null if unreadable. */
+    suspend fun save(source: Uri): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val bytes = context.contentResolver.openInputStream(source)?.use { it.readBytes() }
+                ?: return@runCatching null
+            val bitmap = decodeScaled(bytes) ?: return@runCatching null
+            val oriented = context.contentResolver.openInputStream(source)?.use { orient(bitmap, it) }
+                ?: bitmap
+            write(oriented)
+        }.getOrNull()
+    }
+
+    /**
+     * Stores bytes that already are an image — used when importing a tree that carries photos.
+     *
+     * Downscaled by the same rule as a picked image: an export made by someone whose phone takes
+     * enormous photos should not be able to bloat this device's storage.
+     */
+    suspend fun saveBytes(bytes: ByteArray, preferredId: String? = null): String? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                val bitmap = decodeScaled(bytes) ?: return@runCatching null
+                write(bitmap, preferredId)
+            }.getOrNull()
+        }
+
+    suspend fun delete(photoId: String?) = withContext(Dispatchers.IO) {
+        if (photoId != null) file(photoId).delete()
+        Unit
+    }
+
+    /** Photo ids with no file behind them, so a caller can tell what an export will be missing. */
+    fun missing(photoIds: Collection<String>): List<String> = photoIds.filterNot { exists(it) }
+
+    private fun write(bitmap: Bitmap, preferredId: String? = null): String {
+        val id = preferredId ?: "${UUID.randomUUID()}.jpg"
+        file(id).outputStream().use { bitmap.compress(Bitmap.CompressFormat.JPEG, QUALITY, it) }
+        return id
+    }
+
+    /**
+     * Decodes at roughly the size we intend to keep rather than decoding full size and shrinking,
+     * so a 50-megapixel photo never has to fit in memory at all.
+     */
+    private fun decodeScaled(bytes: ByteArray): Bitmap? {
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
+
+        val longest = max(bounds.outWidth, bounds.outHeight)
+        var sample = 1
+        while (longest / sample > MAX_EDGE * 2) sample *= 2
+
+        val options = BitmapFactory.Options().apply { inSampleSize = sample }
+        val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options) ?: return null
+
+        val edge = max(decoded.width, decoded.height)
+        if (edge <= MAX_EDGE) return decoded
+        val ratio = MAX_EDGE.toFloat() / edge
+        return Bitmap.createScaledBitmap(
+            decoded,
+            (decoded.width * ratio).toInt().coerceAtLeast(1),
+            (decoded.height * ratio).toInt().coerceAtLeast(1),
+            true,
+        )
+    }
+
+    /** Phones record rotation in EXIF rather than in the pixels; without this, faces come in sideways. */
+    private fun orient(bitmap: Bitmap, stream: InputStream): Bitmap {
+        val degrees = when (ExifInterface(stream).getAttributeInt(
+            ExifInterface.TAG_ORIENTATION,
+            ExifInterface.ORIENTATION_NORMAL,
+        )) {
+            ExifInterface.ORIENTATION_ROTATE_90 -> 90f
+            ExifInterface.ORIENTATION_ROTATE_180 -> 180f
+            ExifInterface.ORIENTATION_ROTATE_270 -> 270f
+            else -> return bitmap
+        }
+        val matrix = Matrix().apply { postRotate(degrees) }
+        return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+    }
+
+    companion object {
+        const val DIRECTORY = "photos"
+        private const val MAX_EDGE = 1024
+        private const val QUALITY = 85
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.toRoute
 import com.vibethroughcode.ftree.FTreeApplication
 import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.PhotoStore
 import com.vibethroughcode.ftree.ui.people.PeopleViewModel
 import com.vibethroughcode.ftree.ui.person.PersonDetailViewModel
 import com.vibethroughcode.ftree.ui.person.PersonEditViewModel
@@ -17,6 +18,9 @@ import com.vibethroughcode.ftree.ui.tree.TreeViewModel
 
 private fun CreationExtras.repository(): FamilyRepository =
     (this[APPLICATION_KEY] as FTreeApplication).container.familyRepository
+
+private fun CreationExtras.photos(): PhotoStore =
+    (this[APPLICATION_KEY] as FTreeApplication).container.photoStore
 
 /**
  * Wires view models by hand.
@@ -34,7 +38,12 @@ object FTreeViewModels {
         }
         initializer {
             val handle: SavedStateHandle = createSavedStateHandle()
-            PersonEditViewModel(repository(), handle.toRoute<EditPersonRoute>().personId, handle)
+            PersonEditViewModel(
+                repository = repository(),
+                photos = photos(),
+                personId = handle.toRoute<EditPersonRoute>().personId,
+                savedStateHandle = handle,
+            )
         }
         initializer {
             val route = createSavedStateHandle().toRoute<AddRelativeRoute>()

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonAvatar.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonAvatar.kt
@@ -20,6 +20,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil3.compose.AsyncImage
+import com.vibethroughcode.ftree.data.PhotoStore
+import java.io.File
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
@@ -42,6 +47,22 @@ fun PersonAvatar(
         stringResource(R.string.a11y_unknown_avatar)
     } else {
         stringResource(R.string.a11y_person_avatar, person.name!!)
+    }
+
+    val photo = person.photoId
+    if (photo != null) {
+        // Coil decodes lazily and caches, so a long list of faces costs one decode each rather
+        // than a bitmap per row held in memory.
+        AsyncImage(
+            model = LocalContext.current.photoFile(photo),
+            contentDescription = description,
+            contentScale = ContentScale.Crop,
+            modifier = modifier
+                .size(diameter)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceContainerHigh),
+        )
+        return
     }
 
     if (person.isUnnamed) {
@@ -92,3 +113,13 @@ fun PersonAvatar(
         }
     }
 }
+
+
+/**
+ * Resolves a stored photo id to a file.
+ *
+ * The database holds only the file name, so the path is rebuilt here rather than persisted —
+ * which is what lets photos survive a reinstall or a restore onto another device.
+ */
+internal fun android.content.Context.photoFile(photoId: String): File =
+    File(File(filesDir, PhotoStore.DIRECTORY), photoId)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditScreen.kt
@@ -1,6 +1,21 @@
 package com.vibethroughcode.ftree.ui.person
 
+import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.filled.AddAPhoto
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import coil3.compose.AsyncImage
+import com.vibethroughcode.ftree.ui.common.photoFile
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -53,6 +68,8 @@ const val EditBornFieldTag = "edit-born"
 const val EditDiedFieldTag = "edit-died"
 const val EditNotesFieldTag = "edit-notes"
 const val EditSaveTag = "edit-save"
+const val EditPhotoTag = "edit-photo"
+const val EditPhotoRemoveTag = "edit-photo-remove"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -103,6 +120,12 @@ fun PersonEditScreen(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             Spacer(Modifier.height(4.dp))
+
+            PhotoField(
+                photoId = state.photoId,
+                onPick = viewModel::onPhotoPicked,
+                onRemove = viewModel::onPhotoRemoved,
+            )
 
             OutlinedTextField(
                 value = state.name,
@@ -242,6 +265,81 @@ private fun GenderChips(selected: Gender, onSelect: (Gender) -> Unit) {
                     onClick = { onSelect(gender) },
                     label = { Text(stringResource(label)) },
                 )
+            }
+        }
+    }
+}
+
+/**
+ * The photo control.
+ *
+ * Uses the system photo picker, which hands back one image the user chose and nothing else — so
+ * the app never asks for permission to read the gallery, and there is no permission prompt to
+ * explain or to have denied.
+ */
+@Composable
+private fun PhotoField(
+    photoId: String?,
+    onPick: (Uri) -> Unit,
+    onRemove: () -> Unit,
+) {
+    val picker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+    ) { uri -> uri?.let(onPick) }
+
+    fun launch() = picker.launch(
+        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+    )
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        if (photoId != null) {
+            AsyncImage(
+                model = LocalContext.current.photoFile(photoId),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .clickable(onClick = ::launch)
+                    .testTag(EditPhotoTag),
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(80.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                    .clickable(onClick = ::launch)
+                    .testTag(EditPhotoTag),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    Icons.Default.AddAPhoto,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        Column {
+            TextButton(onClick = ::launch) {
+                Text(
+                    stringResource(
+                        if (photoId == null) R.string.photo_add else R.string.photo_change
+                    )
+                )
+            }
+            if (photoId != null) {
+                TextButton(onClick = onRemove, modifier = Modifier.testTag(EditPhotoRemoveTag)) {
+                    Text(
+                        text = stringResource(R.string.photo_remove),
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditViewModel.kt
@@ -1,5 +1,6 @@
 package com.vibethroughcode.ftree.ui.person
 
+import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -7,6 +8,7 @@ import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.Gender
 import com.vibethroughcode.ftree.data.PartialDate
 import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.PhotoStore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,6 +25,7 @@ data class PersonEditUiState(
     val deathDate: String = "",
     val deceased: Boolean = false,
     val notes: String = "",
+    val photoId: String? = null,
     val isNew: Boolean = true,
     val loaded: Boolean = false,
     val birthProblem: DateProblem? = null,
@@ -38,6 +41,7 @@ data class PersonEditUiState(
 
 class PersonEditViewModel(
     private val repository: FamilyRepository,
+    private val photos: PhotoStore,
     private val personId: String?,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
@@ -64,6 +68,7 @@ class PersonEditViewModel(
                             deathDate = person.deathDate.orEmpty(),
                             deceased = person.deceased,
                             notes = person.notes.orEmpty(),
+                            photoId = person.photoId,
                             isNew = false,
                             loaded = true,
                         )
@@ -76,6 +81,26 @@ class PersonEditViewModel(
     }
 
     fun onNameChange(value: String) = _uiState.update { it.copy(name = value, dirty = true) }
+
+    /**
+     * Copies a picked image into the app's own storage.
+     *
+     * The old photo is removed only after the new one is written, so a failed import never leaves
+     * the person with no picture at all.
+     */
+    fun onPhotoPicked(uri: Uri) {
+        viewModelScope.launch {
+            val saved = photos.save(uri) ?: return@launch
+            val previous = _uiState.value.photoId
+            _uiState.update { it.copy(photoId = saved, dirty = true) }
+            if (previous != null && previous != saved) photos.delete(previous)
+        }
+    }
+
+    fun onPhotoRemoved() {
+        // The file is not deleted until the change is saved, so backing out leaves it intact.
+        _uiState.update { it.copy(photoId = null, dirty = true) }
+    }
     fun onGenderChange(value: Gender) = _uiState.update { it.copy(gender = value, dirty = true) }
     fun onNotesChange(value: String) = _uiState.update { it.copy(notes = value, dirty = true) }
 
@@ -130,9 +155,15 @@ class PersonEditViewModel(
                 deathDate = state.deathDate.trim().ifBlank { null },
                 deceased = state.deceased,
                 notes = state.notes.trim().ifBlank { null },
+                photoId = state.photoId,
                 updatedAt = System.currentTimeMillis(),
             )
             if (original == null) repository.addPerson(updated) else repository.updatePerson(updated)
+
+            // Only now is a discarded photo actually removed from disk.
+            val removed = original?.photoId
+            if (removed != null && removed != state.photoId) photos.delete(removed)
+
             onSaved(updated.id)
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,11 @@
     <string name="tree_loading">Laying out your family</string>
     <string name="a11y_chart">Family tree chart, centred on %1$s, showing %2$d people. Use the people list for a readable list of everyone and their relationships.</string>
 
+    <!-- Photos -->
+    <string name="photo_add">Add a photo</string>
+    <string name="photo_change">Change photo</string>
+    <string name="photo_remove">Remove photo</string>
+
     <!-- Shared -->
     <string name="a11y_person_avatar">Photo of %1$s</string>
     <string name="a11y_unknown_avatar">Unknown person</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ navigation = "2.10.0"
 room = "2.8.4"
 serialization = "1.11.0"
 coil = "3.6.0"
+exifinterface = "1.4.1"
 junit = "4.13.2"
 coroutines = "1.10.2"
 androidxJunit = "1.3.0"
@@ -38,6 +39,7 @@ androidx-room-testing = { group = "androidx.room", name = "room-testing", versio
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+androidx-exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }


### PR DESCRIPTION
Closes #5.

## Copied, not referenced

A picked image is copied into the app's own storage. The content URI the picker hands back is
revoked when the app restarts, and a gallery path can be moved or deleted by anything else on the
device — either would leave the tree full of pictures that silently stop loading.

**The database records only the file name, never a path.** That's what lets a photo survive a
reinstall or a restore onto a different device, and it's what makes the export format portable.

## Details that matter

- **Downscaled to 1024px on the way in**, and decoded at roughly that size rather than decoded whole
  and then shrunk — a fifty-megapixel photo never has to fit in memory at all.
- **EXIF rotation applied.** Phones record rotation beside the pixels rather than in them; without
  this, faces arrive sideways.
- **No storage permission, ever.** The system photo picker gives the app exactly one image. The
  emulator confirms it: *"f-tree will only have access to the photos you select."*
- **Deleting a person removes their photo file.** A photo replaced during an edit is only deleted
  once the edit is saved, so backing out leaves the original intact.

## A gap the tests caught

The scaling test failed first time: `saveBytes` — the path an **import** uses — wrote bytes straight
to disk with no downscaling. An export from a phone with a good camera could have bloated the
importing device's storage. Both paths now share one decode.

## Verification

- 55 JVM, 64 instrumented (8 new) — green on `pixel7_api36`. `lintDebug` clean.
- Walked the whole flow on the emulator with a pushed test image: picker opens → image selected →
  saved → renders as the avatar on the person page. Confirmed on device that the file lands in
  `files/photos/<uuid>.jpg` inside app storage.

Photos are not drawn on the chart nodes yet — decoding bitmaps inside the canvas needs pre-loaded
`ImageBitmap`s, and the chart's value doesn't depend on it. Noted as a possible follow-up.