### PR TITLE
Export to a portable .ftree file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     packaging {

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/transfer/TreeExporterTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/transfer/TreeExporterTest.kt
@@ -1,0 +1,184 @@
+package com.vibethroughcode.ftree.transfer
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vibethroughcode.ftree.data.FTreeDatabase
+import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.PhotoStore
+import com.vibethroughcode.ftree.data.RelativeKind
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.util.zip.ZipInputStream
+
+@RunWith(AndroidJUnit4::class)
+class TreeExporterTest {
+
+    private lateinit var db: FTreeDatabase
+    private lateinit var repository: FamilyRepository
+    private lateinit var photos: PhotoStore
+    private lateinit var exporter: TreeExporter
+    private lateinit var photoDirectory: File
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, FTreeDatabase::class.java)
+            .addCallback(FTreeDatabase.enforceForeignKeys)
+            .build()
+        photos = PhotoStore(context)
+        photoDirectory = File(context.filesDir, PhotoStore.DIRECTORY)
+        photoDirectory.deleteRecursively()
+        repository = FamilyRepository(db, photos)
+        exporter = TreeExporter(repository, photos, TreeIdentity(context))
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+        photoDirectory.deleteRecursively()
+    }
+
+    private fun jpeg(): ByteArray {
+        val bitmap = Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888)
+        return ByteArrayOutputStream().use {
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, it)
+            it.toByteArray()
+        }
+    }
+
+    /** Reads an archive back into its entries. */
+    private fun entriesOf(bytes: ByteArray): Map<String, ByteArray> = buildMap {
+        ZipInputStream(bytes.inputStream()).use { zip ->
+            while (true) {
+                val entry = zip.nextEntry ?: break
+                put(entry.name, zip.readBytes())
+                zip.closeEntry()
+            }
+        }
+    }
+
+    private suspend fun export(): Pair<ExportSummary, Map<String, ByteArray>> {
+        val out = ByteArrayOutputStream()
+        val summary = exporter.exportTo(out)
+        return summary to entriesOf(out.toByteArray())
+    }
+
+    private fun document(entries: Map<String, ByteArray>): TreeDocument =
+        ExportJson.decodeFromString(String(entries.getValue(TreeDocument.ENTRY_JSON)))
+
+    @Test
+    fun anEmptyTreeStillProducesAValidArchive() = runTest {
+        val (summary, entries) = export()
+
+        assertEquals(0, summary.people)
+        val parsed = document(entries)
+        assertEquals(TreeDocument.FORMAT, parsed.format)
+        assertEquals(TreeDocument.VERSION, parsed.version)
+        assertTrue(parsed.people.isEmpty())
+    }
+
+    @Test
+    fun everyPersonAndConnectionIsCarried() = runTest {
+        val me = Person(name = "Ankit Kumar", gender = Gender.MALE, birthDate = "1990-05-01")
+        val father = Person(name = "Raj Kumar", birthDate = "1938", deathDate = "2010", deceased = true)
+        val unknown = Person()
+        listOf(me, father, unknown).forEach { repository.addPerson(it) }
+        repository.addRelative(me.id, father.id, RelativeKind.PARENT)
+        repository.addRelative(me.id, unknown.id, RelativeKind.PARENT)
+
+        val (summary, entries) = export()
+        val parsed = document(entries)
+
+        assertEquals(3, summary.people)
+        assertEquals(2, summary.relationships)
+        assertEquals(3, parsed.people.size)
+        assertEquals(2, parsed.relationships.size)
+
+        val exportedFather = parsed.people.single { it.id == father.id }
+        assertEquals("Raj Kumar", exportedFather.name)
+        assertEquals("1938", exportedFather.birthDate)
+        assertEquals("2010", exportedFather.deathDate)
+        assertTrue(exportedFather.deceased)
+
+        // The person nobody could name is exported as a real record, not dropped.
+        val exportedUnknown = parsed.people.single { it.id == unknown.id }
+        assertNull(exportedUnknown.name)
+    }
+
+    @Test
+    fun photosTravelInsideTheArchive() = runTest {
+        val photoId = photos.saveBytes(jpeg())!!
+        repository.addPerson(Person(name = "Ankit", photoId = photoId))
+
+        val (summary, entries) = export()
+
+        assertEquals(1, summary.photos)
+        assertEquals(0, summary.missingPhotos)
+        assertTrue(entries.containsKey(TreeDocument.ENTRY_PHOTOS + photoId))
+        assertEquals(
+            TreeDocument.ENTRY_PHOTOS + photoId,
+            document(entries).people.single().photo,
+        )
+    }
+
+    @Test
+    fun aPhotoWhoseFileHasGoneIsOmittedRatherThanPromised() = runTest {
+        repository.addPerson(Person(name = "Ankit", photoId = "vanished.jpg"))
+
+        val (summary, entries) = export()
+
+        assertEquals(1, summary.missingPhotos)
+        assertEquals(0, summary.photos)
+        // An import must never meet a photo entry that is not in the archive.
+        assertNull(document(entries).people.single().photo)
+    }
+
+    @Test
+    fun theExportClaimsThisInstallationAsItsOrigin() = runTest {
+        repository.addPerson(Person(name = "Ankit"))
+
+        val parsed = document(export().second)
+
+        assertNotNull(parsed.sourceTreeId)
+        assertTrue(parsed.sourceTreeId.isNotBlank())
+        assertTrue(parsed.exportedAt.isNotBlank())
+    }
+
+    @Test
+    fun theTreeIdIsStableAcrossExports() = runTest {
+        repository.addPerson(Person(name = "Ankit"))
+
+        val first = document(export().second).sourceTreeId
+        val second = document(export().second).sourceTreeId
+
+        // Without this, re-importing the app's own export could not be recognised as its own.
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun symmetricRelationshipsAreExportedOnce() = runTest {
+        val a = Person(name = "Ankit")
+        val b = Person(name = "Priya")
+        listOf(a, b).forEach { repository.addPerson(it) }
+        repository.addRelative(a.id, b.id, RelativeKind.SPOUSE)
+
+        val parsed = document(export().second)
+
+        assertEquals(1, parsed.relationships.size)
+        assertEquals("SPOUSE", parsed.relationships.single().type)
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.vibethroughcode.ftree.data.FTreeDatabase
 import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.PhotoStore
+import com.vibethroughcode.ftree.transfer.TreeExporter
+import com.vibethroughcode.ftree.transfer.TreeIdentity
 
 /**
  * Hand-rolled dependency wiring.
@@ -17,4 +19,6 @@ class AppContainer(context: Context) {
     val database: FTreeDatabase by lazy { FTreeDatabase.build(context) }
     val familyRepository: FamilyRepository by lazy { FamilyRepository(database, photoStore) }
     val photoStore: PhotoStore by lazy { PhotoStore(context.applicationContext) }
+    val treeIdentity: TreeIdentity by lazy { TreeIdentity(context.applicationContext) }
+    val exporter: TreeExporter by lazy { TreeExporter(familyRepository, photoStore, treeIdentity) }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
@@ -189,6 +189,10 @@ class FamilyRepository(
     }
 
     suspend fun originsOf(personIds: List<String>): List<PersonOrigin> = origins.originsOf(personIds)
+
+    /** Whole-tree reads, used only by export. Everything else asks a narrower question. */
+    suspend fun allPeople(): List<Person> = people.allPeople()
+    suspend fun allRelationships(): List<Relationship> = relationships.allRelationships()
 }
 
 class RelationshipRejectedException(val reason: RelationshipRejection) :

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeDocument.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeDocument.kt
@@ -1,0 +1,82 @@
+package com.vibethroughcode.ftree.transfer
+
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * The on-disk shape of an exported family tree.
+ *
+ * A `.ftree` file is a ZIP holding `tree.json` in this shape plus a `photos/` directory. ZIP rather
+ * than one big JSON because base64-encoding a few hundred photographs would triple their size and
+ * force the whole tree through memory to read one person's name.
+ *
+ * Every field except [format] and [version] is optional or defaulted, so a file written by a newer
+ * release still parses here; unknown keys are ignored rather than fatal. That, plus [version],
+ * is what lets the format grow without stranding files people already have.
+ */
+@Serializable
+data class TreeDocument(
+    // Always written, even though they equal their defaults: these two fields are how a reader
+    // knows what it is holding and whether it can understand it, so omitting them to save eleven
+    // bytes would make the file unidentifiable.
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS) val format: String = FORMAT,
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS) val version: Int = VERSION,
+    val exportedAt: String = "",
+    /**
+     * Identifies the installation that produced this file.
+     *
+     * Together with a person's id it forms a stable identity across exports, which is what turns
+     * "is this the same person?" from a name-matching guess into a fact when the file is imported
+     * — including re-importing a file derived from one this device produced.
+     */
+    val sourceTreeId: String = "",
+    val people: List<PersonRecord> = emptyList(),
+    val relationships: List<RelationshipRecord> = emptyList(),
+) {
+    companion object {
+        const val FORMAT = "f-tree"
+        const val VERSION = 1
+        const val ENTRY_JSON = "tree.json"
+        const val ENTRY_PHOTOS = "photos/"
+        const val FILE_EXTENSION = "ftree"
+        /**
+     * Deliberately not `application/zip`: the system file picker appends an extension matching the
+     * type, which turned a `.ftree` file into `.ftree.zip`. An opaque type leaves the name alone.
+     */
+    const val MIME_TYPE = "application/octet-stream"
+    }
+}
+
+@Serializable
+data class PersonRecord(
+    val id: String,
+    val name: String? = null,
+    val gender: String? = null,
+    val birthDate: String? = null,
+    val deathDate: String? = null,
+    val deceased: Boolean = false,
+    /** Path within the archive, e.g. `photos/abc.jpg`. Absent when there is no photo. */
+    val photo: String? = null,
+    val notes: String? = null,
+    /**
+     * Where this person came from before this export, carried forward so a tree that has already
+     * been merged once still matches exactly on a later import.
+     */
+    val origins: List<OriginRecord> = emptyList(),
+)
+
+@Serializable
+data class OriginRecord(
+    @SerialName("treeId") val treeId: String,
+    @SerialName("personId") val personId: String,
+)
+
+@Serializable
+data class RelationshipRecord(
+    val id: String,
+    val from: String,
+    val to: String,
+    val type: String,
+    val subtype: String? = null,
+)

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeExporter.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeExporter.kt
@@ -1,0 +1,107 @@
+package com.vibethroughcode.ftree.transfer
+
+import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.PhotoStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import java.io.OutputStream
+import java.time.Instant
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+data class ExportSummary(
+    val people: Int,
+    val relationships: Int,
+    val photos: Int,
+    /** Photos referenced by a person whose file is gone; the export simply omits them. */
+    val missingPhotos: Int,
+)
+
+/**
+ * Writes the whole tree to a `.ftree` archive.
+ *
+ * Streams straight into the destination rather than building the file in memory, so exporting a
+ * large family with photographs costs no more memory than exporting a small one.
+ */
+class TreeExporter(
+    private val repository: FamilyRepository,
+    private val photos: PhotoStore,
+    private val identity: TreeIdentity,
+    private val json: Json = ExportJson,
+) {
+
+    suspend fun exportTo(destination: OutputStream): ExportSummary = withContext(Dispatchers.IO) {
+        val people = repository.allPeople()
+        val relationships = repository.allRelationships()
+        val origins = repository.originsOf(people.map { it.id }).groupBy { it.personId }
+
+        val referenced = people.mapNotNull { it.photoId }
+        val missing = photos.missing(referenced).toSet()
+        val exportable = referenced.filterNot { it in missing }
+
+        val document = TreeDocument(
+            exportedAt = Instant.now().toString(),
+            sourceTreeId = identity.treeId,
+            people = people.map { person ->
+                PersonRecord(
+                    id = person.id,
+                    name = person.name,
+                    gender = person.gender.name,
+                    birthDate = person.birthDate,
+                    deathDate = person.deathDate,
+                    deceased = person.deceased,
+                    // A photo whose file has gone is dropped rather than promised, so an import
+                    // never has to cope with an entry that is not in the archive.
+                    photo = person.photoId?.takeIf { it !in missing }
+                        ?.let { TreeDocument.ENTRY_PHOTOS + it },
+                    notes = person.notes,
+                    origins = origins[person.id].orEmpty()
+                        .map { OriginRecord(it.sourceTreeId, it.sourcePersonId) },
+                )
+            },
+            relationships = relationships.map {
+                RelationshipRecord(
+                    id = it.id,
+                    from = it.fromPersonId,
+                    to = it.toPersonId,
+                    type = it.type.name,
+                    subtype = it.subtype,
+                )
+            },
+        )
+
+        ZipOutputStream(destination.buffered()).use { zip ->
+            zip.putNextEntry(ZipEntry(TreeDocument.ENTRY_JSON))
+            zip.write(json.encodeToString(document).toByteArray())
+            zip.closeEntry()
+
+            exportable.forEach { photoId ->
+                val file = photos.file(photoId)
+                if (!file.exists()) return@forEach
+                zip.putNextEntry(ZipEntry(TreeDocument.ENTRY_PHOTOS + photoId))
+                file.inputStream().use { it.copyTo(zip) }
+                zip.closeEntry()
+            }
+        }
+
+        ExportSummary(
+            people = people.size,
+            relationships = relationships.size,
+            photos = exportable.size,
+            missingPhotos = missing.size,
+        )
+    }
+}
+
+/**
+ * Lenient on the way in, tidy on the way out.
+ *
+ * [ignoreUnknownKeys] is what lets a file written by a future release still open here rather than
+ * failing outright, and defaults are not written so the archive stays small and readable.
+ */
+val ExportJson: Json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = false
+    prettyPrint = false
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeIdentity.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeIdentity.kt
@@ -1,0 +1,25 @@
+package com.vibethroughcode.ftree.transfer
+
+import android.content.Context
+import java.util.UUID
+
+/**
+ * This installation's stable id.
+ *
+ * Generated once and never changed, so every export this device produces claims the same origin
+ * and a re-import can recognise its own people with certainty rather than by comparing names.
+ */
+class TreeIdentity(context: Context) {
+
+    private val preferences =
+        context.applicationContext.getSharedPreferences("f-tree", Context.MODE_PRIVATE)
+
+    val treeId: String
+        get() = preferences.getString(KEY, null) ?: UUID.randomUUID().toString().also {
+            preferences.edit().putString(KEY, it).apply()
+        }
+
+    private companion object {
+        const val KEY = "source-tree-id"
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -8,6 +8,7 @@ import androidx.navigation.toRoute
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
 import com.vibethroughcode.ftree.ui.person.PersonDetailScreen
 import com.vibethroughcode.ftree.ui.person.PersonEditScreen
+import com.vibethroughcode.ftree.ui.transfer.AboutScreen
 import com.vibethroughcode.ftree.ui.tree.TreeScreen
 import com.vibethroughcode.ftree.ui.relative.AddRelativeScreen
 
@@ -24,7 +25,12 @@ fun FTreeApp() {
                 onAddRelative = { anchorId, kind ->
                     navController.navigate(AddRelativeRoute(anchorId, kind))
                 },
+                onAbout = { navController.navigate(AboutRoute) },
             )
+        }
+
+        composable<AboutRoute> {
+            AboutScreen(onBack = { navController.popBackStack() })
         }
 
         composable<PeopleRoute> {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
@@ -23,6 +23,9 @@ data class PersonRoute(val personId: String)
 @Serializable
 data class EditPersonRoute(val personId: String? = null)
 
+@Serializable
+data object AboutRoute
+
 /** Picking who to attach to [anchorPersonId] as a [kind]. */
 @Serializable
 data class AddRelativeRoute(val anchorPersonId: String, val kind: RelativeKind)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -14,6 +14,7 @@ import com.vibethroughcode.ftree.ui.people.PeopleViewModel
 import com.vibethroughcode.ftree.ui.person.PersonDetailViewModel
 import com.vibethroughcode.ftree.ui.person.PersonEditViewModel
 import com.vibethroughcode.ftree.ui.relative.AddRelativeViewModel
+import com.vibethroughcode.ftree.ui.transfer.TransferViewModel
 import com.vibethroughcode.ftree.ui.tree.TreeViewModel
 
 private fun CreationExtras.repository(): FamilyRepository =
@@ -32,6 +33,10 @@ object FTreeViewModels {
     val Factory = viewModelFactory {
         initializer { PeopleViewModel(repository()) }
         initializer { TreeViewModel(repository(), createSavedStateHandle()) }
+        initializer {
+            val app = this[APPLICATION_KEY] as FTreeApplication
+            TransferViewModel(app.container.exporter, app.contentResolver)
+        }
         initializer {
             val handle: SavedStateHandle = createSavedStateHandle()
             PersonDetailViewModel(repository(), handle.toRoute<PersonRoute>().personId)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/AboutScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/AboutScreen.kt
@@ -1,0 +1,78 @@
+package com.vibethroughcode.ftree.ui.transfer
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.vibethroughcode.ftree.BuildConfig
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.ui.common.SectionRule
+import com.vibethroughcode.ftree.ui.common.TreeGlyph
+import com.vibethroughcode.ftree.ui.theme.FTreeText
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AboutScreen(onBack: () -> Unit, modifier: Modifier = Modifier) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.about)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.edit_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            TreeGlyph(Modifier.padding(top = 16.dp))
+
+            Text(
+                text = stringResource(R.string.about_body),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 16.dp),
+            )
+
+            Text(
+                text = stringResource(R.string.about_version, BuildConfig.VERSION_NAME),
+                style = FTreeText.record,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+
+            SectionRule(stringResource(R.string.about_licences))
+            Text(
+                text = stringResource(R.string.about_fonts),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 40.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vibethroughcode.ftree.R
 import java.time.LocalDate
@@ -22,6 +22,10 @@ fun defaultExportName(today: LocalDate = LocalDate.now()): String = "family-tree
  *
  * Success is stated in terms of what was written, because "exported" alone gives no way to tell a
  * complete file from an empty one.
+ *
+ * The message is resolved during composition rather than inside the effect, so it follows the
+ * current configuration — a language or locale change while the snackbar is up re-reads the right
+ * string instead of showing a stale one.
  */
 @Composable
 fun TransferMessages(
@@ -29,32 +33,29 @@ fun TransferMessages(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
 ) {
     val outcome by viewModel.outcome.collectAsStateWithLifecycle()
-    val context = LocalContext.current
 
-    LaunchedEffect(outcome) {
-        val current = outcome ?: return@LaunchedEffect
-        val message = when (current) {
-            is TransferOutcome.Exported -> {
-                val summary = current.summary
-                if (summary.photos > 0) {
-                    context.getString(
-                        R.string.export_done_photos,
-                        summary.people,
-                        summary.relationships,
-                        summary.photos,
-                    )
-                } else {
-                    context.getString(R.string.export_done, summary.people, summary.relationships)
-                }
+    val message: String? = when (val current = outcome) {
+        null -> null
+        is TransferOutcome.Exported -> {
+            val summary = current.summary
+            if (summary.photos > 0) {
+                stringResource(
+                    R.string.export_done_photos,
+                    summary.people,
+                    summary.relationships,
+                    summary.photos,
+                )
+            } else {
+                stringResource(R.string.export_done, summary.people, summary.relationships)
             }
-
-            TransferOutcome.ExportFailed -> context.getString(R.string.export_failed)
         }
-        snackbarHostState.showMessage(message)
+
+        TransferOutcome.ExportFailed -> stringResource(R.string.export_failed)
+    }
+
+    LaunchedEffect(message) {
+        if (message == null) return@LaunchedEffect
+        snackbarHostState.showSnackbar(message = message, duration = SnackbarDuration.Long)
         viewModel.clearOutcome()
     }
-}
-
-private suspend fun SnackbarHostState.showMessage(message: String) {
-    showSnackbar(message = message, duration = SnackbarDuration.Long)
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
@@ -1,0 +1,60 @@
+package com.vibethroughcode.ftree.ui.transfer
+
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.vibethroughcode.ftree.R
+import java.time.LocalDate
+
+/**
+ * A sensible file name, so the export lands in the user's files as something recognisable rather
+ * than as `document.zip`.
+ */
+fun defaultExportName(today: LocalDate = LocalDate.now()): String = "family-tree-$today.ftree"
+
+/**
+ * Reports the result of an export.
+ *
+ * Success is stated in terms of what was written, because "exported" alone gives no way to tell a
+ * complete file from an empty one.
+ */
+@Composable
+fun TransferMessages(
+    viewModel: TransferViewModel,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+) {
+    val outcome by viewModel.outcome.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(outcome) {
+        val current = outcome ?: return@LaunchedEffect
+        val message = when (current) {
+            is TransferOutcome.Exported -> {
+                val summary = current.summary
+                if (summary.photos > 0) {
+                    context.getString(
+                        R.string.export_done_photos,
+                        summary.people,
+                        summary.relationships,
+                        summary.photos,
+                    )
+                } else {
+                    context.getString(R.string.export_done, summary.people, summary.relationships)
+                }
+            }
+
+            TransferOutcome.ExportFailed -> context.getString(R.string.export_failed)
+        }
+        snackbarHostState.showMessage(message)
+        viewModel.clearOutcome()
+    }
+}
+
+private suspend fun SnackbarHostState.showMessage(message: String) {
+    showSnackbar(message = message, duration = SnackbarDuration.Long)
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferViewModel.kt
@@ -1,0 +1,50 @@
+package com.vibethroughcode.ftree.ui.transfer
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vibethroughcode.ftree.transfer.ExportSummary
+import com.vibethroughcode.ftree.transfer.TreeExporter
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/** What just happened, for the message shown to the user. */
+sealed interface TransferOutcome {
+    data class Exported(val summary: ExportSummary) : TransferOutcome
+    data object ExportFailed : TransferOutcome
+}
+
+class TransferViewModel(
+    private val exporter: TreeExporter,
+    private val contentResolver: ContentResolver,
+) : ViewModel() {
+
+    private val _outcome = MutableStateFlow<TransferOutcome?>(null)
+    val outcome: StateFlow<TransferOutcome?> = _outcome.asStateFlow()
+
+    private val _busy = MutableStateFlow(false)
+    val busy: StateFlow<Boolean> = _busy.asStateFlow()
+
+    fun export(destination: Uri) {
+        viewModelScope.launch {
+            _busy.value = true
+            _outcome.value = runCatching {
+                contentResolver.openOutputStream(destination)?.use { exporter.exportTo(it) }
+            }.fold(
+                onSuccess = { summary ->
+                    if (summary == null) TransferOutcome.ExportFailed
+                    else TransferOutcome.Exported(summary)
+                },
+                // The user picked the destination, so a failure here is a storage problem rather
+                // than anything about their tree; say so plainly and leave the data untouched.
+                onFailure = { TransferOutcome.ExportFailed },
+            )
+            _busy.value = false
+        }
+    }
+
+    fun clearOutcome() { _outcome.value = null }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -1,5 +1,7 @@
 package com.vibethroughcode.ftree.ui.tree
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,11 +17,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CenterFocusStrong
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PersonAddAlt
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -27,6 +32,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -51,9 +58,15 @@ import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.TreeGlyph
 import com.vibethroughcode.ftree.ui.common.displayName
 import com.vibethroughcode.ftree.ui.common.relativeKindLabel
+import com.vibethroughcode.ftree.transfer.TreeDocument
+import com.vibethroughcode.ftree.ui.transfer.TransferMessages
+import com.vibethroughcode.ftree.ui.transfer.TransferViewModel
+import com.vibethroughcode.ftree.ui.transfer.defaultExportName
 
 const val TreePeopleButtonTag = "tree-people"
 const val TreeAddButtonTag = "tree-add"
+const val TreeMenuTag = "tree-menu"
+const val TreeExportTag = "tree-export"
 const val TreeFocusHereTag = "tree-focus-here"
 const val TreeOpenPersonTag = "tree-open-person"
 
@@ -64,15 +77,27 @@ fun TreeScreen(
     onOpenPeople: () -> Unit,
     onAddPerson: () -> Unit,
     onAddRelative: (String, RelativeKind) -> Unit,
+    onAbout: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: TreeViewModel = viewModel(factory = FTreeViewModels.Factory),
+    transferViewModel: TransferViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     var selected by remember { mutableStateOf<Person?>(null) }
+    var menuOpen by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // Export owns its result message, so the snackbar host lives on the screen that shows it.
+    val exportPicker = rememberLauncherForActivityResult(
+        ActivityResultContracts.CreateDocument(TreeDocument.MIME_TYPE)
+    ) { uri -> uri?.let(transferViewModel::export) }
+
+    TransferMessages(transferViewModel, snackbarHostState)
     val sheetState = rememberModalBottomSheetState()
 
     Scaffold(
         modifier = modifier,
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text(stringResource(R.string.tree_title)) },
@@ -92,6 +117,26 @@ fun TreeScreen(
                         Icon(
                             Icons.AutoMirrored.Filled.List,
                             contentDescription = stringResource(R.string.tree_people),
+                        )
+                    }
+                    IconButton(
+                        onClick = { menuOpen = true },
+                        modifier = Modifier.testTag(TreeMenuTag),
+                    ) {
+                        Icon(
+                            Icons.Default.MoreVert,
+                            contentDescription = stringResource(R.string.menu_more),
+                        )
+                    }
+                    DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.export_tree)) },
+                            onClick = { menuOpen = false; exportPicker.launch(defaultExportName()) },
+                            modifier = Modifier.testTag(TreeExportTag),
+                        )
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.about)) },
+                            onClick = { menuOpen = false; onAbout() },
                         )
                     }
                 },

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,20 @@
     <string name="photo_change">Change photo</string>
     <string name="photo_remove">Remove photo</string>
 
+    <!-- Import and export -->
+    <string name="menu_more">More</string>
+    <string name="export_tree">Export your tree</string>
+    <string name="export_default_name">family-tree-%1$s.ftree</string>
+    <string name="export_done">Exported %1$d people and %2$d connections.</string>
+    <string name="export_done_photos">Exported %1$d people, %2$d connections and %3$d photos.</string>
+    <string name="export_failed">Couldn\'t write that file. Try somewhere else.</string>
+    <string name="export_empty">There is nobody in your tree to export yet.</string>
+    <string name="about">About f-tree</string>
+    <string name="about_body">A local-first family tree. Everything stays on this device: no account, no cloud, no backend. Share a tree by exporting it to a file; importing one merges it into yours instead of replacing it.</string>
+    <string name="about_version">Version %1$s</string>
+    <string name="about_licences">Open source licences</string>
+    <string name="about_fonts">Literata and JetBrains Mono are used under the SIL Open Font Licence 1.1.</string>
+
     <!-- Shared -->
     <string name="a11y_person_avatar">Photo of %1$s</string>
     <string name="a11y_unknown_avatar">Unknown person</string>

--- a/app/src/test/java/com/vibethroughcode/ftree/transfer/TreeDocumentTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/transfer/TreeDocumentTest.kt
@@ -1,0 +1,113 @@
+package com.vibethroughcode.ftree.transfer
+
+import kotlinx.serialization.json.Json
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The format's compatibility promises, which are what stop a future release from stranding files
+ * people already have.
+ */
+class TreeDocumentTest {
+
+    private val json: Json = ExportJson
+
+    private fun document() = TreeDocument(
+        exportedAt = "2026-08-31T00:00:00Z",
+        sourceTreeId = "tree-a",
+        people = listOf(
+            PersonRecord(
+                id = "p1",
+                name = "Ankit Kumar",
+                gender = "MALE",
+                birthDate = "1990-05-01",
+                photo = "photos/a.jpg",
+                origins = listOf(OriginRecord("tree-z", "old-1")),
+            ),
+            PersonRecord(id = "p2"),
+        ),
+        relationships = listOf(RelationshipRecord("r1", "p2", "p1", "PARENT")),
+    )
+
+    @Test
+    fun `a document survives a round trip unchanged`() {
+        val original = document()
+        val restored = json.decodeFromString<TreeDocument>(json.encodeToString(original))
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun `a person with nothing recorded round trips`() {
+        val restored = json.decodeFromString<TreeDocument>(json.encodeToString(document()))
+        val unknown = restored.people.single { it.id == "p2" }
+
+        assertNull(unknown.name)
+        assertNull(unknown.birthDate)
+        assertFalse(unknown.deceased)
+    }
+
+    @Test
+    fun `defaults are left out so the file stays small`() {
+        val encoded = json.encodeToString(document())
+
+        // p2 has nothing set, so it should encode as little more than its id.
+        assertFalse(encoded.contains("\"deceased\":false"))
+        assertTrue(encoded.contains("\"p2\""))
+    }
+
+    @Test
+    fun `a file from a newer version still opens`() {
+        // A future release adds fields and a new relationship type; neither should be fatal.
+        val fromTheFuture = """
+            {
+              "format": "f-tree",
+              "version": 1,
+              "sourceTreeId": "tree-b",
+              "burialPlace": "somewhere",
+              "people": [
+                {"id": "p1", "name": "Ankit", "nickname": "Anki", "pronouns": "he/him"}
+              ],
+              "relationships": [
+                {"id": "r1", "from": "p1", "to": "p2", "type": "GODPARENT", "certainty": "high"}
+              ]
+            }
+        """.trimIndent()
+
+        val parsed = json.decodeFromString<TreeDocument>(fromTheFuture)
+
+        assertEquals("Ankit", parsed.people.single().name)
+        assertEquals("GODPARENT", parsed.relationships.single().type)
+    }
+
+    @Test
+    fun `origins are carried so a re-import can match exactly`() {
+        val restored = json.decodeFromString<TreeDocument>(json.encodeToString(document()))
+        val origin = restored.people.first { it.id == "p1" }.origins.single()
+
+        assertEquals("tree-z", origin.treeId)
+        assertEquals("old-1", origin.personId)
+    }
+
+    @Test
+    fun `the format and version are written into the file itself`() {
+        val encoded = json.encodeToString(document())
+
+        // Asserting on the encoded text, not on a decoded object: decoding would fall back to the
+        // defaults and quietly hide their absence, which is exactly the bug this guards against.
+        assertTrue(encoded, encoded.contains("\"format\":\"f-tree\""))
+        assertTrue(encoded, encoded.contains("\"version\":1"))
+    }
+
+    @Test
+    fun `a file with no format or version is still readable as version one`() {
+        val bare = """{"people":[{"id":"p1","name":"Ankit"}]}"""
+
+        val parsed = json.decodeFromString<TreeDocument>(bare)
+
+        assertEquals("f-tree", parsed.format)
+        assertEquals(1, parsed.version)
+    }
+}


### PR DESCRIPTION
Closes #6. Also adds the overflow menu and an About screen (the bundled fonts' OFL licence needs to
be surfaced somewhere).

## The format

A `.ftree` file is a **ZIP** holding `tree.json` plus a `photos/` directory. ZIP rather than one
large JSON because base64-encoding a few hundred photographs would inflate them by a third and
force the whole tree through memory just to read one person's name. The archive is **streamed**
into the destination, so exporting a large family costs no more memory than a small one.

```json
{"format":"f-tree","version":1,"exportedAt":"…","sourceTreeId":"…","people":[…],"relationships":[…]}
```

Written through SAF — the user picks where it goes and the app writes only there, so no storage
permission is involved.

## Compatibility, deliberately

Every field but `format` and `version` is optional, and unknown keys are ignored on read, so a file
written by a future release still opens here. Each person carries the `origins` they were imported
with — together with this installation's stable `sourceTreeId`, that's what will let **#7** recognise
people with certainty rather than by comparing names.

## Three defects found while verifying on the emulator

1. **`format` and `version` weren't in the file at all.** They equal their defaults, and defaults
   were being omitted to keep files small. My first test decoded the document and asserted on the
   result — which fell back to those same defaults and hid the bug completely. The test now asserts
   on the *encoded text*. Without this, an exported file was unidentifiable to anything but this
   exact build.
2. **SAF appended `.zip`**, so `family-tree-….ftree` was saved as `family-tree-….ftree.zip`. The
   picker appends an extension matching the declared MIME type; an opaque type leaves the name alone.
3. **Lint caught a real one**: export messages were resolved through `LocalContext` inside an effect,
   which isn't configuration-aware. Now resolved during composition.

A photo whose file has gone missing is dropped from the document rather than promised, so an import
never meets an entry that isn't in the archive.

## Verification

- 61 JVM, 71 instrumented — green on `pixel7_api36`. `lintDebug` clean.
- Full flow on the emulator: menu → SAF → save → snackbar *"Exported 13 people and 19 connections."*
  Pulled the file off the device and confirmed it's a valid ZIP whose `tree.json` starts with
  `{"format":"f-tree","version":1,…}`.