### PR TITLE
Accessibility, rotation and large-tree performance

### DIFF
--- a/app/src/androidTest/java/com/vibethroughcode/ftree/data/LargeTreePerformanceTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/data/LargeTreePerformanceTest.kt
@@ -1,0 +1,131 @@
+package com.vibethroughcode.ftree.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.vibethroughcode.ftree.graph.TreeLayoutEngine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.system.measureTimeMillis
+
+/**
+ * Guards the property the chart's design depends on: **the cost of looking at one person does not
+ * grow with the size of the family.**
+ *
+ * The thresholds are deliberately loose. This runs on an emulator with software rendering, so the
+ * absolute numbers mean little; what matters is that they are bounded, and that a change which
+ * accidentally starts loading the whole graph would blow straight through them.
+ */
+@RunWith(AndroidJUnit4::class)
+class LargeTreePerformanceTest {
+
+    private lateinit var db: FTreeDatabase
+    private lateinit var repository: FamilyRepository
+
+    private val size = 2_000
+
+    @Before
+    fun setUp() {
+        val context: Context = ApplicationProvider.getApplicationContext()
+        db = Room.inMemoryDatabaseBuilder(context, FTreeDatabase::class.java)
+            .addCallback(FTreeDatabase.enforceForeignKeys)
+            .build()
+        repository = FamilyRepository(db, PhotoStore(context))
+    }
+
+    @After
+    fun tearDown() = db.close()
+
+    /** A wide, deep family: every couple has three children, generation after generation. */
+    private suspend fun seed(): String {
+        val people = mutableListOf<Person>()
+        val edges = mutableListOf<Relationship>()
+
+        val root = Person(name = "Ancestor", birthDate = "1900")
+        people += root
+        var generation = listOf(root.id)
+        var year = 1900
+
+        while (people.size < size) {
+            year += 28
+            val next = mutableListOf<String>()
+            for (parent in generation) {
+                if (people.size >= size) break
+                val partner = Person(name = "Partner ${people.size}", birthDate = (year - 26).toString())
+                people += partner
+                edges += Relationship.of(parent, partner.id, RelationshipType.SPOUSE)
+                repeat(3) {
+                    if (people.size >= size) return@repeat
+                    val child = Person(name = "Person ${people.size}", birthDate = year.toString())
+                    people += child
+                    edges += Relationship.of(parent, child.id, RelationshipType.PARENT)
+                    edges += Relationship.of(partner.id, child.id, RelationshipType.PARENT)
+                    next += child.id
+                }
+            }
+            if (next.isEmpty()) break
+            generation = next
+        }
+
+        db.personDao().insertAll(people)
+        db.relationshipDao().insertIgnoringDuplicates(edges)
+        return people[people.size / 2].id
+    }
+
+    @Test
+    fun openingTheChartOnOnePersonDoesNotDependOnTheSizeOfTheFamily() = runTest {
+        val someoneInTheMiddle = seed()
+        assertEquals(size, db.personDao().count())
+
+        // Warm the connection so the first query's setup is not attributed to the work.
+        repository.loadNeighbourhood(someoneInTheMiddle, 3, 3)
+
+        val elapsed = measureTimeMillis {
+            val snapshot = repository.loadNeighbourhood(someoneInTheMiddle, 3, 3)
+            val layout = TreeLayoutEngine.layout(snapshot, someoneInTheMiddle)
+            assertTrue("expected a drawn chart", layout.nodes.isNotEmpty())
+            // Only the neighbourhood, never the whole family.
+            assertTrue(
+                "loaded ${snapshot.people.size} of $size people",
+                snapshot.people.size < size / 4,
+            )
+        }
+
+        assertTrue("loading and laying out took ${elapsed}ms", elapsed < 1_500)
+    }
+
+    @Test
+    fun oneQuestionAboutOnePersonStaysFastInALargeFamily() = runTest {
+        val someoneInTheMiddle = seed()
+
+        val elapsed = measureTimeMillis {
+            repeat(20) {
+                repository.observeParents(someoneInTheMiddle).first()
+                repository.observeChildren(someoneInTheMiddle).first()
+                repository.observeSiblings(someoneInTheMiddle).first()
+                repository.observeSpouses(someoneInTheMiddle).first()
+            }
+        }
+
+        assertTrue("80 relative queries took ${elapsed}ms", elapsed < 3_000)
+    }
+
+    @Test
+    fun theWholeFamilyCanStillBeExportedAndCounted() = runTest {
+        seed()
+
+        val elapsed = measureTimeMillis {
+            assertEquals(size, repository.allPeople().size)
+            assertTrue(repository.allRelationships().isNotEmpty())
+        }
+
+        assertTrue("whole-tree read took ${elapsed}ms", elapsed < 3_000)
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
@@ -2,17 +2,24 @@ package com.vibethroughcode.ftree.graph
 
 import com.vibethroughcode.ftree.data.Person
 
-/** A person placed on the chart. [x] and [y] are the top-left corner, in layout units. */
+/**
+ * A person placed on the chart. [x] and [y] are the top-left corner, in layout units.
+ *
+ * Each node carries its own box size because the chart honours the reader's text size: at a large
+ * accessibility scale the cards grow with the words rather than letting the words spill out.
+ */
 data class TreeNode(
     val person: Person,
     val level: Int,
     val x: Float,
     val y: Float,
     val isFocus: Boolean,
+    val width: Float = TreeMetrics.NODE_WIDTH,
+    val height: Float = TreeMetrics.NODE_HEIGHT,
 ) {
-    val centerX: Float get() = x + TreeMetrics.NODE_WIDTH / 2f
-    val centerY: Float get() = y + TreeMetrics.NODE_HEIGHT / 2f
-    val bottom: Float get() = y + TreeMetrics.NODE_HEIGHT
+    val centerX: Float get() = x + width / 2f
+    val centerY: Float get() = y + height / 2f
+    val bottom: Float get() = y + height
 }
 
 /** The doubled rule drawn between partners. */
@@ -46,8 +53,7 @@ data class TreeLayout(
     val isEmpty: Boolean get() = nodes.isEmpty()
 
     fun nodeAt(x: Float, y: Float): TreeNode? = nodes.firstOrNull {
-        x >= it.x && x <= it.x + TreeMetrics.NODE_WIDTH &&
-            y >= it.y && y <= it.y + TreeMetrics.NODE_HEIGHT
+        x >= it.x && x <= it.x + it.width && y >= it.y && y <= it.y + it.height
     }
 
     fun node(personId: String): TreeNode? = nodes.firstOrNull { it.person.id == personId }
@@ -71,7 +77,18 @@ object TreeMetrics {
     /** Between generations, leaving room for the descent connectors. */
     const val LEVEL_GAP = 76f
 
-    const val ROW_HEIGHT = NODE_HEIGHT + LEVEL_GAP
-
     const val MARGIN = 24f
+
+    /**
+     * How much bigger a card gets at the reader's text size.
+     *
+     * Applied at less than the full scale: a chart is a spatial overview, and growing every card by
+     * 1.8x would leave almost nothing on screen. Words are never clipped — the card grows enough to
+     * hold them — but the growth is tempered, and the people list, which honours the setting in
+     * full, remains the readable route through a large family.
+     */
+    fun nodeSizeFor(textScale: Float): Pair<Float, Float> {
+        val eased = 1f + (textScale.coerceIn(1f, 2f) - 1f) * 0.7f
+        return NODE_WIDTH * eased to NODE_HEIGHT * eased
+    }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
@@ -24,14 +24,13 @@ object TreeLayoutEngine {
      * drifts apart on screen stops looking like a marriage, and children need a single point to
      * descend from.
      */
-    private class Unit(val members: List<String>) {
+    private class Unit(val members: List<String>, val nodeWidth: Float) {
         var x = 0f
         val width: Float
-            get() = members.size * TreeMetrics.NODE_WIDTH +
-                (members.size - 1) * TreeMetrics.COUPLE_GAP
+            get() = members.size * nodeWidth + (members.size - 1) * TreeMetrics.COUPLE_GAP
 
         fun xOf(personId: String): Float =
-            x + members.indexOf(personId) * (TreeMetrics.NODE_WIDTH + TreeMetrics.COUPLE_GAP)
+            x + members.indexOf(personId) * (nodeWidth + TreeMetrics.COUPLE_GAP)
 
         val centerX: Float get() = x + width / 2f
     }
@@ -41,7 +40,10 @@ object TreeLayoutEngine {
         focusId: String,
         generationsUp: Int = 3,
         generationsDown: Int = 3,
+        nodeWidth: Float = TreeMetrics.NODE_WIDTH,
+        nodeHeight: Float = TreeMetrics.NODE_HEIGHT,
     ): TreeLayout {
+        val rowHeight = nodeHeight + TreeMetrics.LEVEL_GAP
         if (focusId !in snapshot.people) return TreeLayout()
 
         val included = collect(snapshot, focusId, generationsUp, generationsDown)
@@ -51,7 +53,7 @@ object TreeLayoutEngine {
         val unitOf = mutableMapOf<String, Unit>()
         val unitsByLevel = mutableMapOf<Int, MutableList<Unit>>()
         levels.entries.groupBy({ it.value }, { it.key }).forEach { (level, ids) ->
-            buildUnits(ids.toSet(), snapshot).forEach { unit ->
+            buildUnits(ids.toSet(), snapshot, nodeWidth).forEach { unit ->
                 unit.members.forEach { unitOf[it] = unit }
                 unitsByLevel.getOrPut(level) { mutableListOf() } += unit
             }
@@ -82,7 +84,7 @@ object TreeLayoutEngine {
         val minLevel = levels.values.minOrNull() ?: 0
         allUnits.forEach { it.x += TreeMetrics.MARGIN - minX }
 
-        fun yOf(level: Int) = TreeMetrics.MARGIN + (level - minLevel) * TreeMetrics.ROW_HEIGHT
+        fun yOf(level: Int) = TreeMetrics.MARGIN + (level - minLevel) * rowHeight
 
         val nodes = levels.mapNotNull { (id, level) ->
             val person = snapshot.people[id] ?: return@mapNotNull null
@@ -92,16 +94,17 @@ object TreeLayoutEngine {
                 x = unitOf.getValue(id).xOf(id),
                 y = yOf(level),
                 isFocus = id == focusId,
+                width = nodeWidth,
+                height = nodeHeight,
             )
         }.sortedBy { it.level }
 
         return TreeLayout(
             nodes = nodes,
-            spouseLinks = spouseLinks(unitsByLevel, ::yOf),
-            descentLinks = descentLinks(included, unitOf, levels, ::yOf),
+            spouseLinks = spouseLinks(unitsByLevel, nodeWidth, nodeHeight, ::yOf),
+            descentLinks = descentLinks(included, unitOf, levels, nodeWidth, nodeHeight, ::yOf),
             width = (allUnits.maxOfOrNull { it.x + it.width } ?: 0f) + TreeMetrics.MARGIN,
-            height = yOf(levels.values.maxOrNull() ?: 0) +
-                TreeMetrics.NODE_HEIGHT + TreeMetrics.MARGIN,
+            height = yOf(levels.values.maxOrNull() ?: 0) + nodeHeight + TreeMetrics.MARGIN,
             focusId = focusId,
             truncated = included.truncated,
         )
@@ -181,7 +184,11 @@ object TreeLayoutEngine {
 
     // ------------------------------------------------------------------ units
 
-    private fun buildUnits(ids: Set<String>, snapshot: FamilySnapshot): List<Unit> {
+    private fun buildUnits(
+        ids: Set<String>,
+        snapshot: FamilySnapshot,
+        nodeWidth: Float,
+    ): List<Unit> {
         val remaining = ids.toMutableSet()
         val units = mutableListOf<Unit>()
 
@@ -198,8 +205,17 @@ object TreeLayoutEngine {
             remaining -= group
 
             // The person with the most partners sits in the middle, so someone who married twice
-            // has a spouse on each side rather than both crowded to one.
-            val ordered = group.sortedByDescending { snapshot.spousesOf[it].orEmpty().count { s -> s in group } }
+            // has a spouse on each side rather than both crowded to one. Ties are broken by birth
+            // and then by id so the order is the same every time: a chart that reshuffles its
+            // couples when the screen rotates is disorienting for no reason.
+            val ordered = group.sortedWith(
+                compareByDescending<String> { id ->
+                    snapshot.spousesOf[id].orEmpty().count { it in group }
+                }.thenBy { id ->
+                    snapshot.people[id]?.birthDate?.let { PartialDate.parse(it)?.year }
+                        ?: Int.MAX_VALUE
+                }.thenBy { it }
+            )
             val members = when (ordered.size) {
                 1, 2 -> ordered
                 else -> {
@@ -208,7 +224,7 @@ object TreeLayoutEngine {
                     rest.take(rest.size / 2) + hub + rest.drop(rest.size / 2)
                 }
             }
-            units += Unit(members)
+            units += Unit(members, nodeWidth)
         }
         return units
     }
@@ -326,14 +342,16 @@ object TreeLayoutEngine {
 
     private fun spouseLinks(
         unitsByLevel: Map<Int, List<Unit>>,
+        nodeWidth: Float,
+        nodeHeight: Float,
         yOf: (Int) -> Float,
     ): List<SpouseLink> = unitsByLevel.flatMap { (level, units) ->
         units.flatMap { unit ->
             unit.members.zipWithNext { a, b ->
                 SpouseLink(
-                    fromX = unit.xOf(a) + TreeMetrics.NODE_WIDTH,
+                    fromX = unit.xOf(a) + nodeWidth,
                     toX = unit.xOf(b),
-                    y = yOf(level) + TreeMetrics.NODE_HEIGHT / 2f,
+                    y = yOf(level) + nodeHeight / 2f,
                 )
             }
         }
@@ -343,6 +361,8 @@ object TreeLayoutEngine {
         included: Included,
         unitOf: Map<String, Unit>,
         levels: Map<String, Int>,
+        nodeWidth: Float,
+        nodeHeight: Float,
         yOf: (Int) -> Float,
     ): List<DescentLink> = included.families.mapNotNull { (parents, children) ->
         val parentLevel = parents.firstNotNullOfOrNull { levels[it] } ?: return@mapNotNull null
@@ -351,14 +371,14 @@ object TreeLayoutEngine {
 
         val parentXs = parents.mapNotNull { id -> unitOf[id]?.xOf(id) }
         if (parentXs.isEmpty()) return@mapNotNull null
-        val originX = parentXs.map { it + TreeMetrics.NODE_WIDTH / 2f }.average().toFloat()
+        val originX = parentXs.map { it + nodeWidth / 2f }.average().toFloat()
 
         val childXs = children
-            .mapNotNull { id -> unitOf[id]?.xOf(id)?.plus(TreeMetrics.NODE_WIDTH / 2f) }
+            .mapNotNull { id -> unitOf[id]?.xOf(id)?.plus(nodeWidth / 2f) }
             .sorted()
         if (childXs.isEmpty()) return@mapNotNull null
 
-        val parentBottom = yOf(parentLevel) + TreeMetrics.NODE_HEIGHT
+        val parentBottom = yOf(parentLevel) + nodeHeight
         val childTop = yOf(childLevel)
         DescentLink(
             originX = originX,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -118,8 +118,6 @@ fun FamilyChart(
         }
     }
 
-    val nodeWidthPx = with(density) { TreeMetrics.NODE_WIDTH.dp.toPx() }
-    val nodeHeightPx = with(density) { TreeMetrics.NODE_HEIGHT.dp.toPx() }
     val cornerPx = with(density) { 10.dp.toPx() }
     val rulePx = with(density) { 1.5.dp.toPx() }
     val spouseGapPx = with(density) { 2.dp.toPx() }
@@ -159,7 +157,7 @@ fun FamilyChart(
             top = -currentPan.y / currentZoom / unitPx,
             right = (size.width - currentPan.x) / currentZoom / unitPx,
             bottom = (size.height - currentPan.y) / currentZoom / unitPx,
-        ).inflate(TreeMetrics.NODE_WIDTH)
+        ).inflate(TreeMetrics.NODE_WIDTH * 2f)
 
         translate(currentPan.x, currentPan.y) {
             scale(currentZoom, currentZoom, Offset.Zero) {
@@ -198,16 +196,16 @@ fun FamilyChart(
                 }
 
                 layout.nodes.forEach { node ->
-                    if (node.x + TreeMetrics.NODE_WIDTH < visible.left || node.x > visible.right ||
-                        node.y + TreeMetrics.NODE_HEIGHT < visible.top || node.y > visible.bottom
+                    if (node.x + node.width < visible.left || node.x > visible.right ||
+                        node.y + node.height < visible.top || node.y > visible.bottom
                     ) return@forEach
 
                     drawPersonNode(
                         node = node,
                         left = node.x * unitPx,
                         top = node.y * unitPx,
-                        width = nodeWidthPx,
-                        height = nodeHeightPx,
+                        width = node.width * unitPx,
+                        height = node.height * unitPx,
                         measurer = measurer,
                         surface = if (node.isFocus) colors.primaryContainer else colors.surface,
                         onSurface = if (node.isFocus) colors.onPrimaryContainer else colors.onSurface,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -38,12 +38,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -108,6 +110,10 @@ fun TreeScreen(
     val importPlan by transferViewModel.plan.collectAsStateWithLifecycle()
     val importDecisions by transferViewModel.decisions.collectAsStateWithLifecycle()
     val allPeople by viewModel.allPeople.collectAsStateWithLifecycle()
+
+    // The chart is drawn, not composed, so it has to be told about the reader's text size itself.
+    val textScale = LocalDensity.current.fontScale
+    LaunchedEffect(textScale) { viewModel.onTextScaleChanged(textScale) }
     val sheetState = rememberModalBottomSheetState()
 
     Scaffold(

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeViewModel.kt
@@ -7,6 +7,7 @@ import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.graph.TreeLayout
 import com.vibethroughcode.ftree.graph.TreeLayoutEngine
+import com.vibethroughcode.ftree.graph.TreeMetrics
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -25,6 +26,7 @@ data class TreeUiState(
     val treeIsEmpty: Boolean = false,
     val generationsUp: Int = DEFAULT_GENERATIONS,
     val generationsDown: Int = DEFAULT_GENERATIONS,
+    val textScale: Float = 1f,
 ) {
     companion object {
         const val DEFAULT_GENERATIONS = 3
@@ -68,6 +70,16 @@ class TreeViewModel(
         refresh()
     }
 
+    /**
+     * Tells the chart how large the reader's text is, so cards can grow to hold their words rather
+     * than letting them spill out. Only a real change triggers a relayout.
+     */
+    fun onTextScaleChanged(scale: Float) {
+        if (scale == _uiState.value.textScale) return
+        _uiState.update { it.copy(textScale = scale) }
+        refresh()
+    }
+
     fun showMoreGenerations() {
         _uiState.update {
             it.copy(generationsUp = it.generationsUp + 2, generationsDown = it.generationsDown + 2)
@@ -92,11 +104,14 @@ class TreeViewModel(
                     generationsUp = state.generationsUp,
                     generationsDown = state.generationsDown,
                 )
+                val (nodeWidth, nodeHeight) = TreeMetrics.nodeSizeFor(state.textScale)
                 TreeLayoutEngine.layout(
                     snapshot = snapshot,
                     focusId = anchor,
                     generationsUp = state.generationsUp,
                     generationsDown = state.generationsDown,
+                    nodeWidth = nodeWidth,
+                    nodeHeight = nodeHeight,
                 )
             }
             _uiState.update { it.copy(layout = layout, loading = false, treeIsEmpty = false) }

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
@@ -264,6 +264,39 @@ class TreeLayoutEngineTest {
     }
 
     @Test
+    fun `the same family always lays out the same way`() {
+        val snapshot = nuclearFamily()
+
+        val first = TreeLayoutEngine.layout(snapshot, "me")
+        val second = TreeLayoutEngine.layout(snapshot, "me")
+
+        // A chart that reshuffles its couples between two identical runs -- on rotation, say --
+        // is disorienting for no reason.
+        assertEquals(
+            first.nodes.map { it.person.id to it.x },
+            second.nodes.map { it.person.id to it.x },
+        )
+    }
+
+    @Test
+    fun `cards grow with the reader's text size`() {
+        val snapshot = nuclearFamily()
+
+        val normal = TreeLayoutEngine.layout(snapshot, "me")
+        val (wide, tall) = TreeMetrics.nodeSizeFor(1.8f)
+        val large = TreeLayoutEngine.layout(snapshot, "me", nodeWidth = wide, nodeHeight = tall)
+
+        assertTrue(large.node("me")!!.width > normal.node("me")!!.width)
+        assertTrue(large.height > normal.height)
+        // And nothing overlaps at the larger size either.
+        large.nodes.groupBy { it.level }.forEach { (_, row) ->
+            row.sortedBy { it.x }.zipWithNext { left, right ->
+                assertTrue(right.x >= left.x + left.width - 0.01f)
+            }
+        }
+    }
+
+    @Test
     fun `a wide family stays laid out in reasonable time`() {
         val builder = Builder()
         builder.person("root", "1900")


### PR DESCRIPTION
Closes #8 and #9.

## Two real defects, found by looking rather than assuming

**1. The chart ignored the reader's text size.** At 1.8× font scale the cards kept their fixed
dimensions while the words inside grew — names wrapped onto two lines, years were pushed *outside*
the card, and "Unknown" broke mid-word as `Unknow / n`. Node size is now a parameter of the layout
rather than a constant, and the chart passes a size derived from the current scale.

The growth is **tempered rather than proportional**: a chart is a spatial overview, and enlarging
every card by 1.8× would leave almost nothing on screen. Nothing is ever clipped, and the people
list — which honours the setting in full — remains the readable route through a large family.

**2. The chart reshuffled itself on rotation.** Ties in couple ordering fell back to set iteration
order, so the same family could lay out differently between two runs. Now broken deterministically
by birth then id, with a regression test.

## Verified on the emulator

- **1.8× font scale**: every name fits inside its card, years stay in the box.
- **Rotation to landscape**: chart re-lays out and re-fits, and the focused person survives the
  configuration change (the focus is saved-state backed).
- **Dark mode** across the newer screens; the import dialog also now fills the screen properly
  rather than leaving the scrim showing behind the system bars.

## Performance, measured not assumed

Panning the chart costs **the same at 13 people as at 3,000** — 48ms vs 57ms median frame. That's
the property the whole design depends on: bounded neighbourhood loading plus viewport culling mean
interaction cost doesn't track tree size.

Cold start with 3,000 people: ~1.9–2.2s. Database: 2.6 MB.

**Reported honestly:** the *absolute* frame times on this emulator are poor (≈60% janky, GPU p90 of
4950ms) because it renders in software via swiftshader. That number says nothing about real
hardware. The *relative* comparison is the meaningful measurement, and it's the one I've acted on.

Three instrumented tests now guard the property over a seeded 2,000-person family, with deliberately
loose thresholds — they exist to catch a change that starts loading the whole graph to answer a
question about one person, not to benchmark an emulator.

93 JVM, 88 instrumented, all green. `lintDebug` clean.