### PR TITLE
Release hardening and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,35 @@
 # f-tree
 
-A lightweight, local-first Android app for maintaining a personal family tree.
+A lightweight, local-first Android app for keeping a personal family tree.
 
-No accounts, no login, no backend, no cloud. One person maintains their own family graph on
-their own device. Trees are shared by exporting a file and importing it — and **import merges
-into your tree rather than replacing it**.
+No account, no login, no backend, no cloud. One person keeps their own family graph on their own
+device. Trees are shared by exporting a file — and **importing one merges it into yours rather than
+replacing it**.
 
-> Status: in active development. See the [issues](https://github.com/thisisankit27/f-tree/issues)
-> for the current workstreams.
+<!-- Screenshots live in docs/screenshots once a release is tagged. -->
+
+## What it does
+
+- **People, with almost nothing required.** A person needs no name, no dates, nothing. A blank
+  person is a valid *unknown person* — the grandfather's brother whose name nobody wrote down — and
+  can be named years later without disturbing a single relationship.
+- **A graph, not a tree.** Multiple spouses, children across different marriages, half-siblings,
+  adoptive and step relationships, and unknown ancestors all work without special cases.
+- **A focused genealogy chart.** One person's ancestors above and descendants below, with pan, zoom,
+  and tap-to-recentre.
+- **Export and import as a single `.ftree` file**, with merge semantics that never overwrite.
+- **Photos**, stored inside the app and carried in the export.
 
 ## Build
 
-Requires JDK 17+ and the Android SDK (platform 37, build-tools 36).
+Requires **JDK 17+** and the Android SDK (platform 37, build-tools 36).
 
 ```bash
 ./gradlew assembleDebug
 ```
+
+`assembleRelease` produces an unsigned APK unless a `keystore.properties` exists at the repo root
+(see [Releasing](#releasing)). The project always builds without it.
 
 ## Run
 
@@ -24,13 +38,217 @@ Requires JDK 17+ and the Android SDK (platform 37, build-tools 36).
 adb shell am start -n com.vibethroughcode.ftree/.MainActivity
 ```
 
+Debug builds carry a seeder for development, so the chart and the merge logic can be exercised
+without tapping through hundreds of forms:
+
+```bash
+# A deliberately awkward family: unknown ancestors, two marriages, half-siblings, missing dates.
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode family
+
+# A large tree, for performance work.
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode large --ei size 2000
+
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode clear
+```
+
+The receiver exists only in debug builds.
+
 ## Test
 
 ```bash
-./gradlew testDebugUnitTest        # JVM unit tests
-./gradlew connectedDebugAndroidTest # database + Compose UI tests (needs a device/emulator)
+./gradlew testDebugUnitTest          # pure logic: dates, graph rules, layout, matching
+./gradlew connectedDebugAndroidTest  # database, transfer, and Compose UI flows (needs a device)
 ./gradlew lintDebug
 ```
+
+## Architecture
+
+```
+data/       Room entities, DAOs, the repository, photo storage
+graph/      pure graph logic: traversal, relationship rules, chart layout
+transfer/   the .ftree format, export, import, duplicate matching
+ui/         Compose screens, one package per area
+```
+
+Two rules shape the layout of the code:
+
+1. **Anything worth reasoning about is pure.** The chart layout, the relationship rules and the
+   duplicate matcher take plain data and return plain data — no Room, no Compose. They run off the
+   main thread and are tested directly on the JVM, which is why the trickiest logic in the app is
+   also the cheapest to test.
+2. **No DI framework.** [`AppContainer`](app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt)
+   wires one repository by hand. For an app this size a compiler plugin would add indirection
+   without removing any.
+
+### Data model
+
+A **graph of people and typed edges**, because real families are not trees.
+
+`people` — every descriptive field is optional. A null name *is* the unknown-person mechanism.
+Dates are partial ISO-8601 (`1938`, `1938-04`, `1938-04-17`), so nobody has to invent a day they do
+not know, and no separate "approximate" flag is needed: the precision is the statement. Age is
+derived, never stored. `photoId` is a bare file name, never a path, so a photo survives a reinstall.
+
+`relationships` — `PARENT` (directed, parent → child), `SPOUSE` and `SIBLING` (symmetric). Symmetric
+edges are stored in canonical id order, so a **unique index on `(from, to, type)`** makes duplicate
+prevention a database guarantee rather than a race the app has to win. The type is persisted by
+*name* with an `UNKNOWN` fallback, so a new relationship kind needs no migration and a row written by
+a newer version is degraded rather than dropped.
+
+`person_origins` — where an imported person came from. This is what makes a later import recognise
+them with certainty instead of by comparing names.
+
+**Siblings are derived** from shared parents in SQL rather than stored. They stay correct when a
+parent is added later, and the graph never accumulates O(n²) redundant edges. An explicit `SIBLING`
+edge exists only for siblings whose parents are unknown — the one case derivation cannot express.
+
+### Relationship rules
+
+Rejected at the point of creation, not defended against at every read: self-reference, a duplicate
+edge, an edge that would make someone their own ancestor, and a parent who is also recorded as their
+child's spouse or sibling.
+
+### Deletion
+
+Deleting asks *what happens to the connections*, not whether you are sure:
+
+- **Keep as unknown** — clears the details but keeps the node and every edge, so losing one name does
+  not tear a hole in the family.
+- **Delete completely** — removes the person and, by cascade, their edges.
+
+### The chart
+
+Ego-centric on purpose. Laying out a whole family produces something no phone can show and no person
+can read, so the chart draws one person's ancestors above and descendants below, siblings beside
+them, and everything else is reached by re-focusing. Cousins and siblings' descendants are left out:
+they multiply width far faster than they add meaning, and they are one tap away.
+
+Only the neighbourhood is loaded, a generation at a time, one batched query per ring — so a tree of
+thousands opens as fast as a tree of ten. Everything is painted into a single `Canvas`; pan and zoom
+live in float state read *only inside the draw lambda*, so dragging re-runs the draw phase and
+nothing else, and offscreen nodes cost a bounds check each.
+
+Notation: marriage is a doubled rule, a couple's children hang from one connector while a
+half-sibling hangs from their own, and a person with no name has a dashed brass edge — the gap is in
+what the family remembers, not a fault in the record.
+
+## The `.ftree` format
+
+A ZIP. Version 1:
+
+```
+tree.json
+photos/<photoId>.jpg
+```
+
+```json
+{
+  "format": "f-tree",
+  "version": 1,
+  "exportedAt": "2026-08-31T00:00:00Z",
+  "sourceTreeId": "<uuid, stable for the life of an installation>",
+  "people": [
+    {
+      "id": "…", "name": "Ankit Kumar", "gender": "MALE",
+      "birthDate": "1990-05-01", "deathDate": null, "deceased": false,
+      "photo": "photos/….jpg", "notes": "…",
+      "origins": [{ "treeId": "…", "personId": "…" }]
+    }
+  ],
+  "relationships": [
+    { "id": "…", "from": "<parent>", "to": "<child>", "type": "PARENT", "subtype": null }
+  ]
+}
+```
+
+ZIP rather than one large JSON: base64-encoding a few hundred photographs would inflate them by a
+third and force the whole tree through memory to read one person's name.
+
+**Compatibility.** Every field but `format` and `version` is optional, and unknown keys are ignored
+on read, so a file written by a future release still opens. Those two are always written even though
+they equal their defaults, because they are how a reader knows what it is holding. A file claiming a
+*higher* version is refused rather than partly understood.
+
+`sourceTreeId` identifies the installation that wrote the file. With a person's id it forms a stable
+identity across exports; each person also carries the `origins` they were imported with, so a tree
+that has already been merged once still matches exactly on a later import.
+
+## Merge behaviour
+
+**An import adds; it never replaces.** Nothing already in the tree is deleted, and no existing value
+is overwritten. The worst an import can do is add people who turn out to be duplicates — which can
+then be merged. The opposite mistake, silently collapsing two real people into one, cannot be undone.
+Every default follows from that asymmetry.
+
+Reading and judging a file **writes nothing**; only a plan the user has confirmed is applied, in one
+transaction.
+
+| Evidence | Default |
+|---|---|
+| Provable — the file's origins name someone already held | merge, without asking |
+| Same name **and a relative already matched** | proposed **merge** |
+| Same name alone | proposed **keep separate** |
+| Dates that cannot both be true, or an unnamed person | no match at all |
+
+Matching runs in passes, so confirmed matches become evidence for their relatives: two people with
+the same name are far likelier to be the same once their father has already matched. Names are
+compared past accents, punctuation and spacing, but never abbreviations — guessing that "R. Kumar"
+is "Raj Kumar" is how a merge quietly destroys data.
+
+Applying:
+
+- Imported ids are **always remapped** to fresh local ones; an id in someone else's file may belong
+  to a different person here.
+- Merging **fills gaps only**. An empty field takes the imported value; a field that already says
+  something keeps saying it, and the disagreement is reported.
+- Existing relationships are skipped, not duplicated.
+- A **backup is written first**, to `files/backups/`, and the three most recent are kept.
+
+Re-importing the same file, or the app's own export, is a no-op.
+
+## Design decisions worth knowing
+
+| Decision | Why |
+|---|---|
+| Edges, not a GEDCOM-style family/union table | Maps directly onto "add a parent", and makes merge far simpler |
+| Siblings derived, not stored | Stays correct as parents are added; avoids O(n²) edges |
+| Partial dates, no "approximate" flag | The precision *is* the statement about what is known |
+| Enum names persisted, not ordinals | Readable in the database and in exports; stable across releases (R8 is told not to rename them) |
+| No dynamic colour | Brass means "not known" throughout, including in the chart's notation; a wallpaper-derived palette would reassign that meaning |
+| One `Canvas` for the chart | At a few hundred people, a composable per node costs far more than the drawing |
+| Backup file instead of transactional undo | A file the user can re-import is a far simpler promise, and it cannot itself go wrong |
+
+## Accessibility
+
+The person list, person pages and every form honour the system text size in full and carry content
+descriptions. The chart grows its cards with the text size so nothing is clipped.
+
+**A stated limitation:** text painted onto a canvas is invisible to a screen reader, and giving every
+node its own semantics would mean composing a node per person on every pan. The chart therefore
+describes itself and points at the people list, where each person's page spells out every
+relationship as ordinary text. That is a complete alternative route, but it is a limitation.
+
+## Releasing
+
+Signing is driven by a gitignored `keystore.properties` at the repo root:
+
+```properties
+storeFile=/absolute/path/to/f-tree-release.jks
+storePassword=…
+keyAlias=ftree
+keyPassword=…
+```
+
+```bash
+./gradlew assembleRelease
+```
+
+Release builds are minified. **Always install and exercise a release build before publishing it** —
+R8 has broken this app once already, by renaming an enum that navigation resolves by name and that
+the database persists by name. `app/proguard-rules.pro` explains what must be kept and why.
 
 ## Toolchain
 
@@ -41,10 +259,23 @@ adb shell am start -n com.vibethroughcode.ftree/.MainActivity
 | Kotlin | 2.3.21 |
 | compileSdk / targetSdk / minSdk | 37 / 36 / 26 |
 
-AGP 9 ships built-in Kotlin support, so the `org.jetbrains.kotlin.android` plugin is declared in
-the root build file with `apply false` (to pin the Kotlin version on the build classpath) and is
-never applied by a module.
+AGP 9 ships built-in Kotlin support, so `org.jetbrains.kotlin.android` is declared in the root build
+file with `apply false` — purely to pin the Kotlin version on the build classpath — and is never
+applied by a module.
+
+Dependencies are deliberately few: Compose, Room, kotlinx-serialization, Coil, Navigation. No DI
+framework, no networking, no analytics.
+
+## Not built (and why)
+
+- **Transactional undo of an import.** The backup file covers the same need far more simply.
+- **GEDCOM import/export.** A large format for a lightweight app; the documented `.ftree` schema
+  covers sharing between users of this app.
+- **Photos on chart nodes.** Needs pre-decoded bitmaps in the canvas; the chart's value does not
+  depend on it.
+- **A whole-graph chart.** Unreadable at any real family size; re-focusing is the answer.
 
 ## Licence
 
-Not yet chosen.
+Not yet chosen. Bundled fonts (Literata, JetBrains Mono) are used under the SIL Open Font Licence
+1.1; the licence texts ship in the app and are surfaced on its About screen.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,16 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
+}
+
+// Signing details live outside version control. Without them a release build is still produced,
+// just unsigned, so the project stays buildable by anyone who clones it.
+val signingProperties = rootProject.file("keystore.properties").takeIf { it.exists() }?.let {
+    Properties().apply { it.inputStream().use(::load) }
 }
 
 android {
@@ -19,8 +27,20 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        if (signingProperties != null) {
+            create("release") {
+                storeFile = file(signingProperties.getProperty("storeFile"))
+                storePassword = signingProperties.getProperty("storePassword")
+                keyAlias = signingProperties.getProperty("keyAlias")
+                keyPassword = signingProperties.getProperty("keyPassword")
+            }
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,45 @@
+# --- Enum names are data ---------------------------------------------------------------------
+#
+# Gender, RelationshipType and RelativeKind are persisted *by name*: in the database, in exported
+# .ftree files, and (for RelativeKind) inside a navigation route that Navigation resolves by fully
+# qualified class name. If R8 renames any of them, previously stored values stop matching and an
+# exported file becomes unreadable — a silent data-loss bug that only appears in release builds.
+#
+# Found the hard way: the first signed build crashed on launch with
+# "Cannot find class with name com.vibethroughcode.ftree.data.RelativeKind".
+-keep class com.vibethroughcode.ftree.data.Gender { *; }
+-keep class com.vibethroughcode.ftree.data.RelationshipType { *; }
+-keep class com.vibethroughcode.ftree.data.RelativeKind { *; }
+-keep class com.vibethroughcode.ftree.data.ParentKind { *; }
+-keep class com.vibethroughcode.ftree.data.SpouseKind { *; }
+-keep class com.vibethroughcode.ftree.data.SiblingKind { *; }
+-keep class com.vibethroughcode.ftree.data.DeletionMode { *; }
+
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+
+# --- kotlinx-serialization -------------------------------------------------------------------
+#
+# A @Serializable class gets a companion `serializer()` that is looked up reflectively. R8 cannot
+# see that use, so without these the export format would fail to serialise in a release build while
+# working perfectly in debug.
+-keepattributes *Annotation*, InnerClasses, Signature
+-dontnote kotlinx.serialization.**
+
+-if @kotlinx.serialization.Serializable class **
+-keepclassmembers class <1> {
+    static <1>$Companion Companion;
+}
+-if @kotlinx.serialization.Serializable class ** {
+    static **$* *;
+}
+-keepclassmembers class <2>$<3> {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# The export document and the navigation routes are both serialized by type.
+-keep class com.vibethroughcode.ftree.transfer.** { *; }
+-keep class com.vibethroughcode.ftree.ui.*Route { *; }
+-keep class com.vibethroughcode.ftree.ui.*Route$* { *; }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/Counts.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/Counts.kt
@@ -1,0 +1,21 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.pluralStringResource
+import com.vibethroughcode.ftree.R
+
+/*
+ * Counts are read out loud in this app — "2 people and 1 connection" — so they are composed from
+ * pluralised fragments rather than interpolated as bare numbers. A tree of one should never say
+ * "1 people".
+ */
+
+@Composable
+fun peopleCount(count: Int): String = pluralStringResource(R.plurals.person_count, count, count)
+
+@Composable
+fun connectionCount(count: Int): String =
+    pluralStringResource(R.plurals.connection_count, count, count)
+
+@Composable
+fun photoCount(count: Int): String = pluralStringResource(R.plurals.photo_count, count, count)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
@@ -44,6 +44,7 @@ import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.ui.FTreeViewModels
 import com.vibethroughcode.ftree.ui.common.EmptyState
 import com.vibethroughcode.ftree.ui.common.PersonRow
+import com.vibethroughcode.ftree.ui.common.peopleCount
 import com.vibethroughcode.ftree.ui.common.TreeGlyph
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 
@@ -152,7 +153,7 @@ fun PeopleScreen(
                     }
                     item {
                         Text(
-                            text = stringResource(R.string.people_count, state.people.size),
+                            text = stringResource(R.string.people_count, peopleCount(state.people.size)),
                             style = FTreeText.recordSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             modifier = Modifier.fillMaxWidth().padding(20.dp),

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/ImportReviewScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/ImportReviewScreen.kt
@@ -38,6 +38,8 @@ import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.transfer.ImportPlan
 import com.vibethroughcode.ftree.transfer.PersonMatch
 import com.vibethroughcode.ftree.transfer.PersonRecord
+import com.vibethroughcode.ftree.ui.common.connectionCount
+import com.vibethroughcode.ftree.ui.common.peopleCount
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 
 const val ImportConfirmTag = "import-confirm"
@@ -94,26 +96,26 @@ fun ImportReviewScreen(
                     Text(
                         text = stringResource(
                             R.string.import_summary,
-                            plan.document.people.size,
-                            plan.document.relationships.size,
+                            peopleCount(plan.document.people.size),
+                            connectionCount(plan.document.relationships.size),
                         ),
                         style = MaterialTheme.typography.bodyLarge,
                     )
                     Text(
-                        text = stringResource(R.string.import_adds, adding),
+                        text = stringResource(R.string.import_adds, peopleCount(adding)),
                         style = FTreeText.record,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     if (merging > 0) {
                         Text(
-                            text = stringResource(R.string.import_merges, merging),
+                            text = stringResource(R.string.import_merges, peopleCount(merging)),
                             style = FTreeText.record,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                     if (plan.certainMatches > 0) {
                         Text(
-                            text = stringResource(R.string.import_recognised, plan.certainMatches),
+                            text = stringResource(R.string.import_recognised, peopleCount(plan.certainMatches)),
                             style = FTreeText.record,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
@@ -10,6 +10,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.transfer.ImportProblem
+import com.vibethroughcode.ftree.ui.common.connectionCount
+import com.vibethroughcode.ftree.ui.common.peopleCount
+import com.vibethroughcode.ftree.ui.common.photoCount
 import java.time.LocalDate
 
 /**
@@ -42,12 +45,16 @@ fun TransferMessages(
             if (summary.photos > 0) {
                 stringResource(
                     R.string.export_done_photos,
-                    summary.people,
-                    summary.relationships,
-                    summary.photos,
+                    peopleCount(summary.people),
+                    connectionCount(summary.relationships),
+                    photoCount(summary.photos),
                 )
             } else {
-                stringResource(R.string.export_done, summary.people, summary.relationships)
+                stringResource(
+                    R.string.export_done,
+                    peopleCount(summary.people),
+                    connectionCount(summary.relationships),
+                )
             }
         }
 
@@ -58,12 +65,16 @@ fun TransferMessages(
             val base = if (result.peopleMerged > 0) {
                 stringResource(
                     R.string.import_done_merged,
-                    result.peopleAdded,
+                    peopleCount(result.peopleAdded),
                     result.peopleMerged,
-                    result.relationshipsAdded,
+                    connectionCount(result.relationshipsAdded),
                 )
             } else {
-                stringResource(R.string.import_done, result.peopleAdded, result.relationshipsAdded)
+                stringResource(
+                    R.string.import_done,
+                    peopleCount(result.peopleAdded),
+                    connectionCount(result.relationshipsAdded),
+                )
             }
             // Conflicts are reported rather than hidden: the user should know something in the
             // file disagreed with what they had, even though their own value was kept.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="people_search_open">Search</string>
     <string name="people_search_close">Close search</string>
     <string name="people_add">Add a person</string>
-    <string name="people_count">%1$d in your tree</string>
+    <string name="people_count">%1$s in your tree</string>
     <string name="people_no_matches">No one matches “%1$s”.</string>
 
     <!-- Empty state -->
@@ -143,16 +143,16 @@
     <string name="menu_more">More</string>
     <string name="export_tree">Export your tree</string>
     <string name="export_default_name">family-tree-%1$s.ftree</string>
-    <string name="export_done">Exported %1$d people and %2$d connections.</string>
-    <string name="export_done_photos">Exported %1$d people, %2$d connections and %3$d photos.</string>
+    <string name="export_done">Exported %1$s and %2$s.</string>
+    <string name="export_done_photos">Exported %1$s, %2$s and %3$s.</string>
     <string name="export_failed">Couldn\'t write that file. Try somewhere else.</string>
     <string name="export_empty">There is nobody in your tree to export yet.</string>
     <string name="import_tree">Import a tree</string>
     <string name="import_title">Import this tree?</string>
-    <string name="import_summary">%1$d people and %2$d connections are in this file.</string>
-    <string name="import_adds">%1$d will be added</string>
-    <string name="import_merges">%1$d will be merged into people you already have</string>
-    <string name="import_recognised">%1$d were recognised outright</string>
+    <string name="import_summary">%1$s and %2$s are in this file.</string>
+    <string name="import_adds">%1$s will be added</string>
+    <string name="import_merges">%1$s will be merged into someone you already have</string>
+    <string name="import_recognised">%1$s recognised outright</string>
     <string name="import_reassurance">Nothing already in your tree is removed or overwritten. A backup is saved first.</string>
     <string name="import_review_title">Possible duplicates</string>
     <string name="import_review_body">These people share a name with someone in your tree. Choose whether each is the same person.</string>
@@ -164,8 +164,8 @@
     <string name="import_evidence_name">name matches</string>
     <string name="import_confirm">Import</string>
     <string name="import_cancel">Cancel</string>
-    <string name="import_done">Added %1$d people and %2$d connections.</string>
-    <string name="import_done_merged">Added %1$d people, merged %2$d, and added %3$d connections.</string>
+    <string name="import_done">Added %1$s and %2$s.</string>
+    <string name="import_done_merged">Added %1$s, merged %2$d, and added %3$s.</string>
     <string name="import_conflicts">%1$d details differed; yours were kept.</string>
     <string name="import_failed_not_archive">That file isn\'t a family tree export.</string>
     <string name="import_failed_not_tree">That file isn\'t a family tree export.</string>
@@ -191,5 +191,19 @@
     <plurals name="section_spouses">
         <item quantity="one">Spouse</item>
         <item quantity="other">Spouses</item>
+    </plurals>
+
+    <!-- Counts are composed from these so a tree of one never reads "1 people". -->
+    <plurals name="person_count">
+        <item quantity="one">%d person</item>
+        <item quantity="other">%d people</item>
+    </plurals>
+    <plurals name="connection_count">
+        <item quantity="one">%d connection</item>
+        <item quantity="other">%d connections</item>
+    </plurals>
+    <plurals name="photo_count">
+        <item quantity="one">%d photo</item>
+        <item quantity="other">%d photos</item>
     </plurals>
 </resources>

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,50 @@
+# Data model reference
+
+Generated schema JSON lives in [`app/schemas/`](../app/schemas) and is committed, so migrations can
+be written against a checked-in history.
+
+## `people`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | TEXT PK | UUID |
+| `name` | TEXT? | **null means unknown** — the placeholder mechanism |
+| `gender` | TEXT | `MALE`/`FEMALE`/`OTHER`/`UNSPECIFIED`; only ever used to choose a word |
+| `birthDate` | TEXT? | partial ISO-8601: `1938`, `1938-04`, `1938-04-17` |
+| `deathDate` | TEXT? | same |
+| `deceased` | INT | someone can be known dead on an unknown date, so this is not derived |
+| `photoId` | TEXT? | file name within `files/photos/`, never a path |
+| `notes` | TEXT? | |
+| `createdAt`, `updatedAt` | INT | |
+
+Indexed on `name` for search.
+
+## `relationships`
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | TEXT PK | |
+| `fromPersonId` | TEXT | for `PARENT`, the parent |
+| `toPersonId` | TEXT | for `PARENT`, the child |
+| `type` | TEXT | `PARENT` / `SPOUSE` / `SIBLING`, with an `UNKNOWN` read fallback |
+| `subtype` | TEXT? | `BIOLOGICAL`/`ADOPTIVE`/`STEP`/`FOSTER`, `MARRIED`/`PARTNER`/`DIVORCED`, `FULL`/`HALF` |
+| `createdAt` | INT | |
+
+- **UNIQUE** `(fromPersonId, toPersonId, type)` — with symmetric edges stored in canonical id order,
+  this makes duplicate prevention a database guarantee.
+- Indexed on `(fromPersonId, type)` and `(toPersonId, type)`.
+- Foreign keys to `people` with `ON DELETE CASCADE`. Foreign keys are enabled explicitly on open;
+  SQLite leaves them off by default, and the cascade is what stops a hard delete orphaning an edge.
+
+## `person_origins`
+
+`(personId, sourceTreeId, sourcePersonId)`, primary key over all three; a person accumulates origins
+as they are merged from several sources. Indexed on `(sourceTreeId, sourcePersonId)` for the lookup
+an import does.
+
+## Adding a relationship kind
+
+1. Add the constant to `RelationshipType`.
+2. Add a keep rule if it must survive R8 — enum names are persisted.
+3. Nothing else. The column is TEXT, unrecognised values read back as `UNKNOWN`, and older releases
+   degrade the row rather than dropping it.


### PR DESCRIPTION
Closes #11.

## R8 nearly caused silent data loss

The first signed release build **crashed on launch**:

```
Cannot find class with name "com.vibethroughcode.ftree.data.RelativeKind".
```

R8 had renamed the enum that Navigation resolves by fully qualified name. Chasing that turned up a
**worse latent bug in the same shape**: `Gender` and `RelationshipType` are persisted *by name* — in
the database and inside exported `.ftree` files. A rename would have made previously stored values
unreadable and exports unopenable. That's silent data loss, visible only in release builds, on
exactly the data this app exists to protect.

Every persisted enum is now kept explicitly, with the reasoning written next to the rules.
kotlinx-serialization's reflective serializer lookup is kept too — without it the export format
fails in release while working perfectly in debug.

**This is why the release build gets exercised, not just built.** The README now says so.

## Verified on the emulator, in the signed release build

| Step | Result |
|---|---|
| Install and launch | ✅ (previously crashed) |
| Add a person | ✅ |
| Add a parent — the flow that crashed | ✅ "Add a parent for Ankit Kumar" |
| Export | ✅ *"Exported 2 people and 1 connection."* |
| Import back | ✅ *"0 will be added, 2 merged, 2 recognised outright"* |
| Crashes throughout | 0 |

APK: **2.0 MB** signed and minified (250 KB of that is the two subset fonts).

## Also

- **"1 connections" → "1 connection".** Counts are read out loud on the transfer screens, so they're
  composed from pluralised fragments rather than interpolated as bare numbers.
- **README rewritten** for somebody opening the repo cold: what it does, build/run/seed/test, the
  data model and why it's shaped that way, the `.ftree` schema with its compatibility promises, the
  merge rules as a table, and a decisions table with the reasoning attached. Plus
  [`docs/data-model.md`](docs/data-model.md) as a column-level reference.
- Written down honestly: the chart's screen-reader limitation and the route around it, and the four
  things deliberately **not** built.

Signing is driven by a gitignored `keystore.properties`; without it `assembleRelease` still produces
an unsigned APK, so the project stays buildable by anyone who clones it. The keystore itself lives
outside the repo.

93 JVM, 93 instrumented, all green. `lintDebug` clean.