### PR TITLE
Licence the project under MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ankit Srivastava
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -277,5 +277,7 @@ framework, no networking, no analytics.
 
 ## Licence
 
-Not yet chosen. Bundled fonts (Literata, JetBrains Mono) are used under the SIL Open Font Licence
-1.1; the licence texts ship in the app and are surfaced on its About screen.
+[MIT](LICENSE) — use it, change it, ship it; just keep the copyright notice.
+
+The bundled fonts (Literata, JetBrains Mono) are separately licensed under the SIL Open Font Licence
+1.1. Their licence texts ship inside the app and are surfaced on its About screen.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,7 +179,7 @@
     <string name="about_body">A local-first family tree. Everything stays on this device: no account, no cloud, no backend. Share a tree by exporting it to a file; importing one merges it into yours instead of replacing it.</string>
     <string name="about_version">Version %1$s</string>
     <string name="about_licences">Open source licences</string>
-    <string name="about_fonts">Literata and JetBrains Mono are used under the SIL Open Font Licence 1.1.</string>
+    <string name="about_fonts">f-tree is open source under the MIT licence. Literata and JetBrains Mono are used under the SIL Open Font Licence 1.1.</string>
 
     <!-- Shared -->
     <string name="a11y_person_avatar">Photo of %1$s</string>


### PR DESCRIPTION
The repository is public, and without a licence nobody has the right to copy, modify or ship the
code — "no licence" is more restrictive than most people expect, not less.

- `LICENSE` — MIT, copyright **Ankit Srivastava**, 2026. Say the word if you'd rather it named
  `thisisankit27` or something else.
- README licence section updated.
- The About screen now states the MIT licence alongside the fonts'.

The bundled fonts stay separately licensed under the SIL OFL 1.1 — MIT covers the code, not
Literata or JetBrains Mono. Their licence texts already ship inside the app.