### PR TITLE
Build and publish signed releases from a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+# Cutting a release is: bump versionName, tag it, push the tag. Everything below is automatic.
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      # Installs cmdline-tools and accepts the SDK licences; AGP resolves the platform itself.
+      - uses: android-actions/setup-android@v3
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # A tag that disagrees with the app's own version produces an APK whose file name lies about
+      # what is inside it, and an update users cannot install over the previous one. Fail early.
+      - name: Check the tag matches the app's version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version=$(grep -oP 'versionName = "\K[^"]+' app/build.gradle.kts)
+          if [ "$tag" != "$version" ]; then
+            echo "::error::Tag v$tag does not match versionName $version in app/build.gradle.kts"
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_ENV"
+
+      # A release that fails its own tests should not be published.
+      - name: Unit tests and lint
+        run: ./gradlew testDebugUnitTest lintDebug
+
+      - name: Restore the signing key
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          # Written outside the workspace so it can never be picked up by a build artefact.
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+          cat > keystore.properties <<EOF
+          storeFile=$RUNNER_TEMP/release.jks
+          storePassword=$KEYSTORE_PASSWORD
+          keyAlias=$KEY_ALIAS
+          keyPassword=$KEY_PASSWORD
+          EOF
+
+      - name: Build the release APK
+        run: ./gradlew assembleRelease
+
+      # Gradle produces an unsigned APK rather than failing when signing is not configured, so an
+      # unsigned build would otherwise sail through and be published as a release.
+      - name: Verify it is actually signed
+        run: |
+          apksigner=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
+          "$apksigner" verify --print-certs app/build/outputs/apk/release/app-release.apk
+          cp app/build/outputs/apk/release/app-release.apk "f-tree-${{ env.version }}.apk"
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          apk="f-tree-${{ env.version }}.apk"
+          # Attach to a release written by hand if there is one; otherwise create it.
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "$apk" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "$apk" \
+              --title "f-tree ${{ env.version }}" \
+              --generate-notes
+          fi
+
+      - name: Remove the signing key
+        if: always()
+        run: rm -f keystore.properties "$RUNNER_TEMP/release.jks"

--- a/README.md
+++ b/README.md
@@ -246,6 +246,21 @@ keyPassword=…
 ./gradlew assembleRelease
 ```
 
+**Or let CI do it.** Bump `versionName` in `app/build.gradle.kts`, tag it, push the tag:
+
+```bash
+git tag -a v0.2.0 -m "f-tree 0.2.0" && git push origin v0.2.0
+```
+
+[`.github/workflows/release.yml`](.github/workflows/release.yml) checks the tag matches the app's
+version, runs the tests, builds a signed APK from the keystore held in repository secrets
+(`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`), verifies the signature, and
+attaches it to the release. Write the release notes by hand first if you want them; the workflow
+attaches to an existing release rather than replacing it.
+
+Note that the secrets are a *deployment* mechanism, not a backup — a secret can never be read back
+out. Keep the keystore file itself somewhere safe: losing it means no in-place updates, ever.
+
 Release builds are minified. **Always install and exercise a release build before publishing it** —
 R8 has broken this app once already, by renaming an enum that navigation resolves by name and that
 the database persists by name. `app/proguard-rules.pro` explains what must be kept and why.


### PR DESCRIPTION
Makes the four secrets you just set actually do something. Cutting a release becomes: bump
`versionName`, tag, push the tag.

## Two guards worth the lines

1. **Tag must match `versionName`.** Otherwise the APK's file name lies about what's inside it, and
   the build users get can't install over the previous one. Easy mistake, awkward to undo once
   published.
2. **The signature is verified before publishing.** This is the important one — Gradle produces an
   *unsigned* APK rather than failing when signing isn't configured, so a mis-set secret would
   otherwise sail straight through and publish an uninstallable release. The workflow runs
   `apksigner verify` and fails if it isn't signed.

Unit tests and lint run before the build, so a release that fails its own tests isn't published.

## Handling of the key

Decoded to `$RUNNER_TEMP`, outside the workspace, so it can't be swept into a build artefact.
`keystore.properties` and the key are removed in an `if: always()` step.

## Release notes

If a release for the tag already exists, the APK is attached to it and your notes are left alone.
If not, one is created with `--generate-notes`. So you can write the notes by hand first, or let it
generate them.

Instrumented tests are deliberately not run here — they need an emulator, which is slow enough on
hosted runners to make tagging a chore. They run locally against `pixel7_api36`.

Next: I'll verify this end-to-end by cutting **v0.1.1**, which is genuinely due — `main` is ahead of
v0.1.0 by the MIT licence and the plural fixes.