### PR TITLE
Take the key alias out of secrets and check it early

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 permissions:
   contents: write
 
+env:
+  # Not a secret — an alias is just a label on a key inside the keystore, and it is useless without
+  # the keystore and its password. Keeping it here rather than in a secret makes it visible and
+  # editable, and removes a way for the build to fail with an unhelpful message.
+  KEY_ALIAS: ftree
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -44,11 +50,19 @@ jobs:
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           # Written outside the workspace so it can never be picked up by a build artefact.
           printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.jks"
+
+          # Fail here, with a message that says what is wrong, rather than several minutes later
+          # inside Gradle with "No key with alias '***' found".
+          if ! keytool -list -keystore "$RUNNER_TEMP/release.jks" \
+               -storepass "$KEYSTORE_PASSWORD" -alias "$KEY_ALIAS" >/dev/null 2>&1; then
+            echo "::error::No key '$KEY_ALIAS' in the keystore, or KEYSTORE_PASSWORD is wrong."
+            exit 1
+          fi
+
           cat > keystore.properties <<EOF
           storeFile=$RUNNER_TEMP/release.jks
           storePassword=$KEYSTORE_PASSWORD

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ git tag -a v0.2.0 -m "f-tree 0.2.0" && git push origin v0.2.0
 
 [`.github/workflows/release.yml`](.github/workflows/release.yml) checks the tag matches the app's
 version, runs the tests, builds a signed APK from the keystore held in repository secrets
-(`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`), verifies the signature, and
+(`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_PASSWORD`; the key alias is not secret and lives in the workflow), verifies the signature, and
 attaches it to the release. Write the release notes by hand first if you want them; the workflow
 attaches to an existing release rather than replacing it.
 


### PR DESCRIPTION
The first tagged build failed. Good news: it failed *safely* — Gradle refused to package rather than
producing something broken, and nothing was published.

```
KeytoolException: Failed to read key *** from store ".../release.jks":
No key with alias '***' found in keystore
```

The keystore decoded and opened, so `KEYSTORE_BASE64` and `KEYSTORE_PASSWORD` are both correct. Only
the alias was wrong — it had been set to the password. That was my fault in how I gave the commands:
three consecutive, identical-looking prompts, only one of which wanted something different.

## Fix

**An alias isn't a secret.** It's a label on a key inside the keystore and is useless without the
keystore and its password. It now lives in the workflow as `env.KEY_ALIAS: ftree`, where it's visible
and editable — and there's one fewer prompt to get out of step with.

Also added an up-front `keytool -list` check, so a mis-set secret fails in **seconds** with a message
that names the problem, instead of after a full R8 build with the offending value masked to `***`.

## After merging

The `KEY_ALIAS` secret is now unused and can be deleted:

```bash
gh secret delete KEY_ALIAS -R thisisankit27/f-tree
```

Then I'll re-tag v0.1.1 and we'll see it through.