### PR TITLE
Relation finder: name how any two people are related, and draw the line

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ replacing it**.
 - **Two charts.** *Around one person* draws their ancestors above and descendants below, with pan,
   zoom and tap-to-recentre. *Everyone* draws the entire tree at once — every generation, every
   household, and the people no relationship reaches, whom the focused chart has nowhere to put.
+- **A relation finder.** Pick any two people and f-tree names the relationship — "first cousin once
+  removed", "great-great-grandfather" — and lists every person the line runs through, which is the
+  form that can also answer the ones English has no word for. It walks marriages as well as blood,
+  and will draw the line across the whole-tree chart.
 - **Optional in-app updates.** Off until switched on. Checks GitHub for a newer release and installs
   it over the running copy, so a new version keeps your tree instead of costing an export and an
   import.
@@ -139,6 +143,25 @@ nothing else, and offscreen nodes cost a bounds check each.
 Notation: marriage is a doubled rule, a couple's children hang from one connector while a
 half-sibling hangs from their own, and a person with no name has a dashed brass edge — the gap is in
 what the family remembers, not a fault in the record.
+
+### Relating two people
+
+Two questions with different failure modes, so they are answered separately (`graph/Kinship.kt`,
+pure and JVM-tested):
+
+- **The word for it** comes from the nearest shared ancestor — generations *up* to them and back
+  *down* to the other person — and those two numbers produce every term English actually has.
+  Nearest, then most symmetric: measured through a grandparent instead, two siblings would come out
+  as first cousins. There is no word for most relationships, so this half is often absent.
+- **The line between them** is a breadth-first search over *every* edge kind. Marriage is walked as
+  well as blood, because "my wife's mother" is exactly what gets asked and no blood-only search can
+  answer it. Blood steps are enqueued before marriage ones, so where two routes are the same length
+  the one through the family wins — reaching a cousin via their husband is a true answer and a
+  useless one.
+
+The chain is always shown and the word only when there is one, because the chain is the half a
+reader can check against their own memory. `Kinship` returns the term as a *structure*, not a
+string; the English lives in `ui/common/KinshipLabels.kt` with the rest of the app's words.
 
 ## The `.ftree` format
 

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationFinderTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationFinderTest.kt
@@ -1,0 +1,194 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.ui.relation.RelationAnswerTag
+import com.vibethroughcode.ftree.ui.relation.RelationPickListTag
+import com.vibethroughcode.ftree.ui.relation.RelationPickSearchTag
+import com.vibethroughcode.ftree.ui.relation.RelationShowOnChartTag
+import com.vibethroughcode.ftree.ui.relation.RelationSlotFromTag
+import com.vibethroughcode.ftree.ui.relation.RelationSlotToTag
+import com.vibethroughcode.ftree.ui.relation.RelationSwapTag
+import com.vibethroughcode.ftree.ui.tree.FamilyChartTag
+import com.vibethroughcode.ftree.ui.tree.TreeClearTraceTag
+import com.vibethroughcode.ftree.ui.tree.TreeRelateTag
+import com.vibethroughcode.ftree.ui.tree.WholeFamilyChartTag
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Asking how two people are related, from the chart through to the answer and back onto the chart.
+ *
+ * The words themselves are settled on the JVM in `KinshipTest`; what is worth an emulator is that
+ * the two people can actually be picked, that the answer names the pair the right way round, and
+ * that "show me" lands on a chart with the line on it.
+ */
+@RunWith(AndroidJUnit4::class)
+class RelationFinderTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    @Before
+    fun emptyTheTree() {
+        app.container.database.clearAllTables()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Build your family tree").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /** Three generations down one line, and an aunt off to the side. */
+    private fun seedFourPeople() {
+        val repository = app.container.familyRepository
+        runBlocking {
+            // Recorded gender is what narrows "aunt or uncle" to "aunt", so it is part of the
+            // fixture rather than incidental to it.
+            val grandad = Person(name = "Raj Kumar", gender = Gender.MALE, birthDate = "1938")
+            val dad = Person(name = "Vinod Kumar", gender = Gender.MALE, birthDate = "1962")
+            val aunt = Person(name = "Meena Devi", gender = Gender.FEMALE, birthDate = "1968")
+            val me = Person(name = "Ankit Kumar", gender = Gender.MALE, birthDate = "1990")
+            listOf(grandad, dad, aunt, me).forEach { repository.addPerson(it) }
+            repository.addRelative(dad.id, grandad.id, RelativeKind.PARENT)
+            repository.addRelative(aunt.id, grandad.id, RelativeKind.PARENT)
+            repository.addRelative(me.id, dad.id, RelativeKind.PARENT)
+        }
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun openFinder() {
+        rule.onNodeWithTag(TreeRelateTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationSlotFromTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun pick(slotTag: String, name: String) {
+        rule.onNodeWithTag(slotTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationPickSearchTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(RelationPickSearchTag).performTextInput(name)
+        // Scoped to the list: the search field now holds the same words, and a bare text match
+        // would find it first.
+        val row = hasText(name) and hasAnyAncestor(hasTestTag(RelationPickListTag))
+        rule.waitUntil(5_000) { rule.onAllNodes(row).fetchSemanticsNodes().isNotEmpty() }
+        rule.onNode(row).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationSlotFromTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /**
+     * Relating two people walks the whole graph off the main thread, so the answer lands a beat
+     * after the pick. Waiting for the sentence is the honest way to say "eventually it reads this".
+     */
+    private fun awaitText(text: String) {
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText(text).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithText(text).assertIsDisplayed()
+    }
+
+    @Test
+    fun twoPeopleTwoGenerationsApartAreNamedAndTheirLineShown() {
+        seedFourPeople()
+        openFinder()
+
+        pick(RelationSlotFromTag, "Ankit Kumar")
+        pick(RelationSlotToTag, "Meena Devi")
+
+        rule.onNodeWithTag(RelationAnswerTag).assertIsDisplayed()
+        awaitText("Meena Devi is Ankit Kumar’s aunt.")
+        rule.onNodeWithText("2 steps apart").assertIsDisplayed()
+
+        // The working, not just the verdict: the father is the person the line runs through, and
+        // saying so is what lets a reader check the answer against what they already know.
+        rule.onNodeWithText("Father of Ankit Kumar").assertIsDisplayed()
+        rule.onNodeWithText("Sister of Vinod Kumar").assertIsDisplayed()
+    }
+
+    @Test
+    fun swappingTheTwoAsksTheOtherQuestionAndGetsTheOtherWord() {
+        seedFourPeople()
+        openFinder()
+
+        pick(RelationSlotFromTag, "Ankit Kumar")
+        pick(RelationSlotToTag, "Raj Kumar")
+        awaitText("Raj Kumar is Ankit Kumar’s grandfather.")
+
+        rule.onNodeWithTag(RelationSwapTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Ankit Kumar is Raj Kumar’s grandson.")
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun peopleTheRecordDoesNotJoinAreSaidToBeUnjoined() {
+        seedFourPeople()
+        runBlocking {
+            app.container.familyRepository.addPerson(Person(name = "Ishwar Dutt", birthDate = "1928"))
+        }
+        openFinder()
+
+        pick(RelationSlotFromTag, "Ankit Kumar")
+        pick(RelationSlotToTag, "Ishwar Dutt")
+
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Nothing in the record joins", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        // Absence of a connection is not a claim that there is none, and the wording says so.
+        rule.onNodeWithText("They may well be related", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun showingTheLineOnTheChartSwitchesToTheChartThatCanHoldIt() {
+        seedFourPeople()
+        openFinder()
+
+        pick(RelationSlotFromTag, "Ankit Kumar")
+        pick(RelationSlotToTag, "Meena Devi")
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationShowOnChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(RelationShowOnChartTag).performClick()
+
+        // The focused chart draws one person's neighbourhood, so a line across the family only
+        // means anything on the whole-tree one; asking to see it has to take you there.
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(WholeFamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithText("Tracing how two people connect").assertIsDisplayed()
+
+        rule.onNodeWithTag(TreeClearTraceTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Tracing how two people connect").fetchSemanticsNodes().isEmpty()
+        }
+    }
+}

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationshipFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationshipFlowTest.kt
@@ -179,7 +179,12 @@ class RelationshipFlowTest {
         rule.onNodeWithTag(DeleteKeepAsUnknownTag).performClick()
         rule.waitForIdle()
 
-        // He is now an unknown person, but the family still joins up through him.
+        // He is now an unknown person, but the family still joins up through him. Waiting for the
+        // row rather than for idleness: the delete is a database write and the page redraws from a
+        // flow, so there is a beat where the screen is idle and the name has not changed yet.
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Unknown").fetchSemanticsNodes().isNotEmpty()
+        }
         rule.onNodeWithText("Unknown").assertIsDisplayed()
         rule.onNodeWithText("Raj Kumar").assertIsDisplayed()
         rule.onNodeWithText("Aarav").assertIsDisplayed()

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
@@ -1,0 +1,210 @@
+package com.vibethroughcode.ftree.graph
+
+/**
+ * How any two people in a tree are related.
+ *
+ * Two questions, answered separately because they have different failure modes. *What is the word
+ * for it* — "first cousin once removed" — only exists when the two share a blood ancestor, and
+ * English simply has no term for most of the ways a family actually connects. *Which people join
+ * them* always exists whenever the record joins them at all, and is the answer that can be checked
+ * against the tree by eye.
+ *
+ * So a relation always carries the chain, and carries a term only when there is one. Nothing here
+ * knows any English: the term is a structure the UI names alongside the rest of its labels, so the
+ * words for a family live in one place rather than two.
+ */
+
+/** The kind of step taken from one person to the next along a chain. */
+enum class StepKind { PARENT, CHILD, SPOUSE, SIBLING }
+
+/** One link in the chain: the person arrived at, and what they are to the person before them. */
+data class RelationStep(val personId: String, val kind: StepKind)
+
+/**
+ * The English kinship term for a blood relationship, as a structure rather than a string.
+ *
+ * Everything a family says out loud falls out of two numbers: how many generations *up* from the
+ * subject to the ancestor they share, and how many back *down* to the other person.
+ */
+sealed interface KinshipTerm {
+    data object Self : KinshipTerm
+
+    /** 1 = parent, 2 = grandparent, 3 = great-grandparent. */
+    data class Ancestor(val generations: Int) : KinshipTerm
+
+    /** 1 = child, 2 = grandchild, 3 = great-grandchild. */
+    data class Descendant(val generations: Int) : KinshipTerm
+
+    data object Sibling : KinshipTerm
+
+    /** Aunt or uncle. [greats] 0 = aunt, 1 = great-aunt. */
+    data class ParentsSibling(val greats: Int) : KinshipTerm
+
+    /** Niece or nephew. [greats] 0 = niece, 1 = great-niece. */
+    data class SiblingsChild(val greats: Int) : KinshipTerm
+
+    /** [degree] 1 = first cousin. [removed] 0 = of the same generation. */
+    data class Cousin(val degree: Int, val removed: Int) : KinshipTerm
+}
+
+/** The answer to "how are these two related?". */
+sealed interface Relation {
+    /** The same person was picked twice. */
+    data object SamePerson : Relation
+
+    /** Nothing in the record joins them — which is not the same as knowing they are unrelated. */
+    data object Unrecorded : Relation
+
+    /**
+     * @param chain every step from the subject to the other person, the other person last.
+     * @param term the blood term, absent when no shared ancestor exists — in-laws and step-family.
+     * @param sharedAncestorId the ancestor [term] was measured through.
+     */
+    data class Found(
+        val chain: List<RelationStep>,
+        val term: KinshipTerm?,
+        val sharedAncestorId: String?,
+    ) : Relation {
+        /** The people the chain passes through, including both ends. */
+        fun peopleInvolved(fromId: String): Set<String> =
+            buildSet { add(fromId); chain.forEach { add(it.personId) } }
+
+        /** Joined only by a marriage somewhere along the way, with no blood between them. */
+        val byMarriage: Boolean
+            get() = term == null && chain.any { it.kind == StepKind.SPOUSE }
+
+        val steps: Int get() = chain.size
+    }
+}
+
+object Kinship {
+
+    /**
+     * Relates [toId] to [fromId] — the term reads "B is A's ...", in that order.
+     */
+    fun relate(snapshot: FamilySnapshot, fromId: String, toId: String): Relation {
+        if (fromId == toId) {
+            return if (fromId in snapshot.people) Relation.SamePerson else Relation.Unrecorded
+        }
+        if (fromId !in snapshot.people || toId !in snapshot.people) return Relation.Unrecorded
+
+        val chain = shortestChain(snapshot, fromId, toId) ?: return Relation.Unrecorded
+        val shared = nearestSharedAncestor(snapshot, fromId, toId)
+        return Relation.Found(
+            chain = chain,
+            term = shared?.let { termFor(it.up, it.down) },
+            sharedAncestorId = shared?.ancestorId,
+        )
+    }
+
+    /**
+     * The word for a blood relationship, from the two distances to a shared ancestor.
+     *
+     * @param up generations from the subject to the ancestor.
+     * @param down generations from that ancestor back to the other person.
+     */
+    fun termFor(up: Int, down: Int): KinshipTerm = when {
+        up == 0 && down == 0 -> KinshipTerm.Self
+        up == 0 -> KinshipTerm.Descendant(down)
+        down == 0 -> KinshipTerm.Ancestor(up)
+        up == 1 && down == 1 -> KinshipTerm.Sibling
+        down == 1 -> KinshipTerm.ParentsSibling(greats = up - 2)
+        up == 1 -> KinshipTerm.SiblingsChild(greats = down - 2)
+        else -> KinshipTerm.Cousin(
+            degree = minOf(up, down) - 1,
+            removed = kotlin.math.abs(up - down),
+        )
+    }
+
+    private data class Shared(val ancestorId: String, val up: Int, val down: Int)
+
+    /**
+     * The shared ancestor that names the relationship.
+     *
+     * Nearest first, and among equally near ones the most symmetric pair of distances — which is
+     * what picks the grandparent two cousins share over the great-grandparent they also share.
+     */
+    private fun nearestSharedAncestor(
+        snapshot: FamilySnapshot,
+        fromId: String,
+        toId: String,
+    ): Shared? {
+        val mine = ancestorDistances(snapshot, fromId)
+        val theirs = ancestorDistances(snapshot, toId)
+        var best: Shared? = null
+        mine.forEach { (ancestor, up) ->
+            val down = theirs[ancestor] ?: return@forEach
+            val current = best
+            if (current == null ||
+                up + down < current.up + current.down ||
+                (up + down == current.up + current.down &&
+                    kotlin.math.abs(up - down) < kotlin.math.abs(current.up - current.down))
+            ) {
+                best = Shared(ancestor, up, down)
+            }
+        }
+        return best
+    }
+
+    /** Everyone at or above [id], with the number of generations up to each. */
+    private fun ancestorDistances(snapshot: FamilySnapshot, id: String): Map<String, Int> {
+        val distance = linkedMapOf(id to 0)
+        val queue = ArrayDeque(listOf(id))
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            val step = distance.getValue(current) + 1
+            snapshot.parentsOf[current].orEmpty().forEach { parent ->
+                // The visited check also makes a cycle in bad data terminate rather than hang.
+                if (distance.putIfAbsent(parent, step) == null) queue.addLast(parent)
+            }
+        }
+        return distance
+    }
+
+    /**
+     * The shortest chain of relationships joining two people, over every kind of edge.
+     *
+     * Marriage is walked as well as blood, because "my wife's mother" is exactly the sort of
+     * question this feature is asked, and no blood-only search can answer it. Blood steps are
+     * enqueued before marriage ones so that where two routes are the same length the one through
+     * the family wins — arriving at a cousin through their spouse would be a true answer and a
+     * useless one.
+     */
+    private fun shortestChain(
+        snapshot: FamilySnapshot,
+        fromId: String,
+        toId: String,
+    ): List<RelationStep>? {
+        val cameFrom = HashMap<String, RelationStep>()
+        val previous = HashMap<String, String>()
+        val queue = ArrayDeque(listOf(fromId))
+        val seen = hashSetOf(fromId)
+
+        while (queue.isNotEmpty()) {
+            val current = queue.removeFirst()
+            if (current == toId) break
+
+            val neighbours = sequence {
+                snapshot.parentsOf[current].orEmpty().forEach { yield(it to StepKind.PARENT) }
+                snapshot.childrenOf[current].orEmpty().forEach { yield(it to StepKind.CHILD) }
+                snapshot.siblingsOf[current].orEmpty().forEach { yield(it to StepKind.SIBLING) }
+                snapshot.spousesOf[current].orEmpty().forEach { yield(it to StepKind.SPOUSE) }
+            }
+            neighbours.forEach { (next, kind) ->
+                if (next !in snapshot.people || !seen.add(next)) return@forEach
+                cameFrom[next] = RelationStep(next, kind)
+                previous[next] = current
+                queue.addLast(next)
+            }
+        }
+
+        if (toId !in cameFrom) return null
+        val chain = ArrayDeque<RelationStep>()
+        var cursor = toId
+        while (cursor != fromId) {
+            chain.addFirst(cameFrom.getValue(cursor))
+            cursor = previous.getValue(cursor)
+        }
+        return chain.toList()
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -39,6 +39,7 @@ import com.vibethroughcode.ftree.transfer.TreeDocument
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
 import com.vibethroughcode.ftree.ui.person.PersonDetailScreen
 import com.vibethroughcode.ftree.ui.person.PersonEditScreen
+import com.vibethroughcode.ftree.ui.relation.RelationScreen
 import com.vibethroughcode.ftree.ui.relative.AddRelativeScreen
 import com.vibethroughcode.ftree.ui.settings.SettingsScreen
 import com.vibethroughcode.ftree.ui.settings.SettingsViewModel
@@ -126,12 +127,33 @@ fun FTreeApp() {
             startDestination = TreeRoute(),
             modifier = Modifier.fillMaxSize().padding(padding),
         ) {
-            composable<TreeRoute> {
+            composable<TreeRoute> { entry ->
                 TreeScreen(
+                    trace = entry.toRoute<TreeRoute>().trace,
                     onOpenPerson = { navController.navigate(PersonRoute(it)) },
                     onAddPerson = { navController.navigate(EditPersonRoute()) },
                     onAddRelative = { anchorId, kind ->
                         navController.navigate(AddRelativeRoute(anchorId, kind))
+                    },
+                    onRelate = { navController.navigate(RelationRoute(fromId = it)) },
+                    // Dropping the trace means going back to the plain chart, which is where
+                    // clearing a highlight should leave you — not one screen further back.
+                    onClearTrace = {
+                        navController.navigate(TreeRoute()) {
+                            popUpTo<TreeRoute> { inclusive = true }
+                        }
+                    },
+                )
+            }
+
+            composable<RelationRoute> {
+                RelationScreen(
+                    onBack = { navController.popBackStack() },
+                    onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                    onShowOnChart = { trace ->
+                        navController.navigate(TreeRoute(trace = trace)) {
+                            popUpTo<TreeRoute> { inclusive = true }
+                        }
                     },
                 )
             }
@@ -165,6 +187,9 @@ fun FTreeApp() {
                         navController.navigate(TreeRoute(focusId = personId)) {
                             popUpTo<TreeRoute> { inclusive = true }
                         }
+                    },
+                    onRelate = { personId ->
+                        navController.navigate(RelationRoute(fromId = personId))
                     },
                 )
             }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
@@ -17,7 +17,17 @@ import kotlinx.serialization.Serializable
  * death are the same value in the same slot rather than two competing sources of truth.
  */
 @Serializable
-data class TreeRoute(val focusId: String? = null)
+data class TreeRoute(
+    val focusId: String? = null,
+    /**
+     * The people on a relation the reader asked to see drawn — both ends and everyone between.
+     *
+     * Carried in the route rather than held in a view model because it is part of *where you are*:
+     * pressing back must leave the trace behind, and coming back to the chart later must not
+     * silently relight a line from a question asked an hour ago.
+     */
+    val trace: List<String> = emptyList(),
+)
 
 @Serializable
 data object PeopleRoute
@@ -31,6 +41,10 @@ data class EditPersonRoute(val personId: String? = null)
 
 @Serializable
 data object SettingsRoute
+
+/** Finding how two people are related. Either end may arrive already chosen, or neither. */
+@Serializable
+data class RelationRoute(val fromId: String? = null, val toId: String? = null)
 
 /** Picking who to attach to [anchorPersonId] as a [kind]. */
 @Serializable

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -13,6 +13,7 @@ import com.vibethroughcode.ftree.data.PhotoStore
 import com.vibethroughcode.ftree.ui.people.PeopleViewModel
 import com.vibethroughcode.ftree.ui.person.PersonDetailViewModel
 import com.vibethroughcode.ftree.ui.person.PersonEditViewModel
+import com.vibethroughcode.ftree.ui.relation.RelationViewModel
 import com.vibethroughcode.ftree.ui.relative.AddRelativeViewModel
 import com.vibethroughcode.ftree.ui.transfer.TransferViewModel
 import com.vibethroughcode.ftree.ui.settings.SettingsViewModel
@@ -64,6 +65,11 @@ object FTreeViewModels {
                 personId = handle.toRoute<EditPersonRoute>().personId,
                 savedStateHandle = handle,
             )
+        }
+        initializer {
+            val handle: SavedStateHandle = createSavedStateHandle()
+            val route = handle.toRoute<RelationRoute>()
+            RelationViewModel(repository(), handle, route.fromId, route.toId)
         }
         initializer {
             val route = createSavedStateHandle().toRoute<AddRelativeRoute>()

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/KinshipLabels.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/KinshipLabels.kt
@@ -1,0 +1,97 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringArrayResource
+import androidx.compose.ui.res.stringResource
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.graph.KinshipTerm
+import com.vibethroughcode.ftree.graph.StepKind
+
+/**
+ * The word for a blood relationship.
+ *
+ * These are deliberately a separate set from the `role_*` labels beside a name on a person's page.
+ * Those are headings — "Father" — while these are read inside a sentence, and lower-casing a
+ * heading in code would be wrong the moment the app is read in a language that capitalises its
+ * nouns. Gender only ever narrows the word, and falls back to the neutral one when it is not
+ * recorded, so the term is never a guess.
+ */
+@Composable
+fun kinshipLabel(term: KinshipTerm, gender: Gender): String = when (term) {
+    KinshipTerm.Self -> stringResource(R.string.kin_self)
+
+    KinshipTerm.Sibling -> byGender(gender, R.string.kin_brother, R.string.kin_sister, R.string.kin_sibling)
+
+    is KinshipTerm.Ancestor ->
+        if (term.generations <= 1) {
+            byGender(gender, R.string.kin_father, R.string.kin_mother, R.string.kin_parent)
+        } else {
+            greats(term.generations - 2) +
+                byGender(gender, R.string.kin_grandfather, R.string.kin_grandmother, R.string.kin_grandparent)
+        }
+
+    is KinshipTerm.Descendant ->
+        if (term.generations <= 1) {
+            byGender(gender, R.string.kin_son, R.string.kin_daughter, R.string.kin_child)
+        } else {
+            greats(term.generations - 2) +
+                byGender(gender, R.string.kin_grandson, R.string.kin_granddaughter, R.string.kin_grandchild)
+        }
+
+    is KinshipTerm.ParentsSibling -> greats(term.greats) +
+        byGender(gender, R.string.kin_uncle, R.string.kin_aunt, R.string.kin_aunt_or_uncle)
+
+    is KinshipTerm.SiblingsChild -> greats(term.greats) +
+        byGender(gender, R.string.kin_nephew, R.string.kin_niece, R.string.kin_niece_or_nephew)
+
+    is KinshipTerm.Cousin -> {
+        val base = stringResource(R.string.kin_cousin, ordinal(term.degree))
+        when (term.removed) {
+            0 -> base
+            1 -> stringResource(R.string.kin_cousin_removed_once, base)
+            2 -> stringResource(R.string.kin_cousin_removed_twice, base)
+            else -> stringResource(R.string.kin_cousin_removed_many, base, term.removed)
+        }
+    }
+}
+
+@Composable
+private fun byGender(gender: Gender, male: Int, female: Int, neutral: Int): String =
+    stringResource(
+        when (gender) {
+            Gender.MALE -> male
+            Gender.FEMALE -> female
+            else -> neutral
+        }
+    )
+
+/** "great-great-" and so on. A generation is one repeat, which is exactly how it is said. */
+@Composable
+private fun greats(count: Int): String =
+    stringResource(R.string.kin_great_prefix).repeat(count.coerceAtLeast(0))
+
+/**
+ * "first", "second", … The words run out long before the cousins do, so past the list it falls
+ * back to a numeral rather than inventing a word nobody says.
+ */
+@Composable
+private fun ordinal(n: Int): String {
+    val words = stringArrayResource(R.array.kin_ordinals)
+    return if (n in 1..words.size) words[n - 1] else stringResource(R.string.kin_ordinal_nth, n)
+}
+
+/**
+ * A step along a chain, named the way the rest of the app names a relationship.
+ *
+ * The graph says "I walked a PARENT edge"; a reader reads "Father". The two enums stay separate
+ * for the same reason [com.vibethroughcode.ftree.data.RelativeKind] and `RelationshipType` do —
+ * one is how the tree is stored, the other how a family is spoken about.
+ */
+fun StepKind.asRelativeKind(): RelativeKind = when (this) {
+    StepKind.PARENT -> RelativeKind.PARENT
+    StepKind.CHILD -> RelativeKind.CHILD
+    StepKind.SPOUSE -> RelativeKind.SPOUSE
+    StepKind.SIBLING -> RelativeKind.SIBLING
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CompareArrows
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.AlertDialog
@@ -60,6 +61,7 @@ import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 const val PersonNameTag = "person-name"
 const val PersonDeleteTag = "person-delete"
 const val PersonMenuTag = "person-menu"
+const val PersonRelateTag = "person-relate"
 const val PersonEditTag = "person-edit"
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -70,6 +72,7 @@ fun PersonDetailScreen(
     onOpenPerson: (String) -> Unit,
     onAddRelative: (String, RelativeKind) -> Unit,
     onShowOnTree: (String) -> Unit,
+    onRelate: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PersonDetailViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
@@ -123,6 +126,16 @@ fun PersonDetailScreen(
                         )
                     }
                     DropdownMenu(expanded = menuOpen, onDismissRequest = { menuOpen = false }) {
+                        // Starting from the person whose page this is, because "how am I related
+                        // to them" is nearly always asked about somebody already in front of you.
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.relation_open_from_person)) },
+                            leadingIcon = {
+                                Icon(Icons.Default.CompareArrows, contentDescription = null)
+                            },
+                            onClick = { menuOpen = false; onRelate(viewModel.personId) },
+                            modifier = Modifier.testTag(PersonRelateTag),
+                        )
                         DropdownMenuItem(
                             text = { Text(stringResource(R.string.delete_person)) },
                             leadingIcon = {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
@@ -1,0 +1,471 @@
+package com.vibethroughcode.ftree.ui.relation
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.PersonSearch
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SwapVert
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.graph.Relation
+import com.vibethroughcode.ftree.ui.FTreeViewModels
+import com.vibethroughcode.ftree.ui.common.PersonAvatar
+import com.vibethroughcode.ftree.ui.common.PersonRow
+import com.vibethroughcode.ftree.ui.common.SectionRule
+import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.kinshipLabel
+import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
+import com.vibethroughcode.ftree.ui.common.asRelativeKind
+import com.vibethroughcode.ftree.ui.theme.FTreeText
+import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+
+const val RelationSlotFromTag = "relation-slot-from"
+const val RelationSlotToTag = "relation-slot-to"
+const val RelationSwapTag = "relation-swap"
+const val RelationAnswerTag = "relation-answer"
+const val RelationChainTag = "relation-chain"
+const val RelationPickListTag = "relation-pick-list"
+const val RelationPickSearchTag = "relation-pick-search"
+const val RelationShowOnChartTag = "relation-show-on-chart"
+
+/**
+ * How two people are related.
+ *
+ * Answered in two registers at once, because they are believed differently. The sentence — "Priya
+ * is Ankit's first cousin once removed" — is the answer somebody came for, and English has no
+ * phrase for most of the ways a family actually joins up. The chain underneath is the working:
+ * every person the line passes through, which is checkable against a reader's own memory and is
+ * the only form that can express in-laws and step-relations. So the chain is always shown, and the
+ * sentence only when there is one to give.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun RelationScreen(
+    onBack: () -> Unit,
+    onOpenPerson: (String) -> Unit,
+    onShowOnChart: (List<String>) -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: RelationViewModel = viewModel(factory = FTreeViewModels.Factory),
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val query by viewModel.currentQuery.collectAsStateWithLifecycle()
+    var picking by rememberSaveable { mutableStateOf<RelationSlot?>(null) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        stringResource(
+                            if (picking != null) R.string.relation_pick_title
+                            else R.string.relation_title
+                        )
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { if (picking != null) picking = null else onBack() }) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.edit_back),
+                        )
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        Box(Modifier.fillMaxSize().padding(padding)) {
+            when {
+                state.treeIsEmpty -> Text(
+                    text = stringResource(R.string.empty_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.align(Alignment.Center).padding(32.dp),
+                )
+
+                picking != null -> PersonPicker(
+                    people = state.candidates,
+                    query = query,
+                    onQueryChange = viewModel::onQueryChange,
+                    onPick = { id ->
+                        viewModel.choose(picking!!, id)
+                        picking = null
+                    },
+                )
+
+                else -> Answer(
+                    state = state,
+                    onPick = { picking = it },
+                    onSwap = viewModel::swap,
+                    onOpenPerson = onOpenPerson,
+                    onShowOnChart = { onShowOnChart(state.trace) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Answer(
+    state: RelationUiState,
+    onPick: (RelationSlot) -> Unit,
+    onSwap: () -> Unit,
+    onOpenPerson: (String) -> Unit,
+    onShowOnChart: () -> Unit,
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = 40.dp),
+    ) {
+        item {
+            /*
+             * The two slots read as one phrase down the page — "Between … and …" — which says
+             * plainly that this is a question about a pair, and leaves the direction to the answer
+             * sentence rather than making the reader decode two field labels first.
+             */
+            Column(Modifier.padding(horizontal = 20.dp, vertical = 8.dp)) {
+                Slot(
+                    label = stringResource(R.string.relation_between),
+                    person = state.from,
+                    tag = RelationSlotFromTag,
+                    onClick = { onPick(RelationSlot.FROM) },
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(R.string.relation_and),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    if (state.bothChosen) {
+                        IconButton(onClick = onSwap, modifier = Modifier.testTag(RelationSwapTag)) {
+                            Icon(
+                                Icons.Default.SwapVert,
+                                contentDescription = stringResource(R.string.relation_swap),
+                            )
+                        }
+                    }
+                }
+                Slot(
+                    label = null,
+                    person = state.to,
+                    tag = RelationSlotToTag,
+                    onClick = { onPick(RelationSlot.TO) },
+                )
+            }
+        }
+
+        item { Verdict(state) }
+
+        if (state.chain.isNotEmpty() && state.from != null) {
+            item {
+                Column(Modifier.padding(top = 8.dp)) {
+                    SectionRule(stringResource(R.string.relation_chain_title))
+                }
+            }
+            item {
+                PersonRow(
+                    person = state.from,
+                    onClick = { onOpenPerson(state.from.id) },
+                    supporting = stringResource(R.string.relation_chain_start),
+                    modifier = Modifier.testTag(RelationChainTag),
+                )
+            }
+            itemsIndexed(state.chain, key = { _, link -> link.person.id }) { index, link ->
+                ChainRow(
+                    link = link,
+                    previous = if (index == 0) state.from else state.chain[index - 1].person,
+                    onClick = { onOpenPerson(link.person.id) },
+                )
+            }
+            item {
+                Button(
+                    onClick = onShowOnChart,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 20.dp, vertical = 16.dp)
+                        .testTag(RelationShowOnChartTag),
+                ) {
+                    Icon(Icons.Default.AccountTree, contentDescription = null)
+                    Text(
+                        text = stringResource(R.string.relation_show_on_chart),
+                        modifier = Modifier.padding(start = 12.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Each person on the line, and what they are to the one before them.
+ *
+ * "Father of Vinod Kumar" rather than a bare "Father": the chain is only useful if each row can be
+ * checked against what the reader already knows, and that needs both ends of the step named.
+ */
+@Composable
+private fun ChainRow(link: ChainLink, previous: Person, onClick: () -> Unit) {
+    val role = stringResource(relativeRoleLabel(link.kind.asRelativeKind(), link.person.gender))
+    PersonRow(
+        person = link.person,
+        onClick = onClick,
+        supporting = stringResource(R.string.relation_chain_step, role, previous.displayName()),
+    )
+}
+
+/** The sentence, and how far apart the two of them are. */
+@Composable
+private fun Verdict(state: RelationUiState) {
+    val from = state.from
+    val to = state.to
+    val accents = FTreeTheme.accents
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .testTag(RelationAnswerTag),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+        ),
+    ) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            when (val relation = state.relation) {
+                null -> Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        Icons.Default.PersonSearch,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(24.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.relation_hint),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 16.dp),
+                    )
+                }
+
+                Relation.SamePerson -> Text(
+                    text = stringResource(R.string.relation_answer_same),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+
+                Relation.Unrecorded -> {
+                    Text(
+                        text = stringResource(
+                            R.string.relation_answer_none,
+                            from?.displayName().orEmpty(),
+                            to?.displayName().orEmpty(),
+                        ),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = stringResource(R.string.relation_answer_none_body),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+
+                is Relation.Found -> {
+                    val toName = to?.displayName().orEmpty()
+                    val fromName = from?.displayName().orEmpty()
+                    Text(
+                        text = when {
+                            relation.term != null && to != null -> stringResource(
+                                R.string.relation_answer_term,
+                                toName,
+                                fromName,
+                                kinshipLabel(relation.term, to.gender),
+                            )
+
+                            relation.byMarriage ->
+                                stringResource(R.string.relation_answer_marriage, toName, fromName)
+
+                            else -> stringResource(R.string.relation_answer_linked, toName, fromName)
+                        },
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = pluralStringResource(
+                            R.plurals.relation_steps,
+                            relation.steps,
+                            relation.steps,
+                        ),
+                        style = FTreeText.recordSmall,
+                        color = accents.unknown,
+                    )
+                    state.sharedAncestor?.let { ancestor ->
+                        Text(
+                            text = stringResource(
+                                R.string.relation_shared_ancestor,
+                                ancestor.displayName(),
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/** One of the two people, or an invitation to choose one. */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun Slot(
+    label: String?,
+    person: Person?,
+    tag: String,
+    onClick: () -> Unit,
+) {
+    Column {
+        label?.let {
+            Text(
+                text = it,
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
+        Card(
+            onClick = onClick,
+            modifier = Modifier.fillMaxWidth().testTag(tag),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface,
+            ),
+            border = CardDefaults.outlinedCardBorder(),
+        ) {
+            if (person == null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().height(64.dp).padding(horizontal = 20.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        Icons.Default.PersonSearch,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = stringResource(R.string.relation_choose),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(start = 16.dp),
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    PersonAvatar(person)
+                    Text(
+                        text = person.displayName(),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontStyle = if (person.isUnnamed) FontStyle.Italic else FontStyle.Normal,
+                        modifier = Modifier.weight(1f).padding(start = 16.dp),
+                    )
+                    Text(
+                        text = stringResource(R.string.relation_change),
+                        style = MaterialTheme.typography.labelLarge,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+            }
+        }
+    }
+}
+
+/** The whole tree, searchable — including the people no relationship reaches. */
+@Composable
+private fun PersonPicker(
+    people: List<Person>,
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onPick: (String) -> Unit,
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Column(Modifier.fillMaxSize()) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            placeholder = { Text(stringResource(R.string.relation_pick_hint)) },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .focusRequester(focusRequester)
+                .testTag(RelationPickSearchTag),
+        )
+        if (people.isEmpty()) {
+            Text(
+                text = stringResource(R.string.relation_pick_none),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth().padding(32.dp),
+            )
+        } else {
+            LazyColumn(Modifier.fillMaxSize().testTag(RelationPickListTag)) {
+                items(people, key = { it.id }) { person ->
+                    PersonRow(person = person, onClick = { onPick(person.id) })
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationViewModel.kt
@@ -1,0 +1,146 @@
+package com.vibethroughcode.ftree.ui.relation
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.graph.FamilySnapshot
+import com.vibethroughcode.ftree.graph.Kinship
+import com.vibethroughcode.ftree.graph.Relation
+import com.vibethroughcode.ftree.graph.StepKind
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.stateIn
+
+/** Which of the two slots a pick is filling. */
+enum class RelationSlot { FROM, TO }
+
+/** One person along the chain, with what they are to the person before them. */
+data class ChainLink(val person: Person, val kind: StepKind)
+
+data class RelationUiState(
+    val loading: Boolean = true,
+    val from: Person? = null,
+    val to: Person? = null,
+    val relation: Relation? = null,
+    val chain: List<ChainLink> = emptyList(),
+    val sharedAncestor: Person? = null,
+    /** Everyone on the chain including both ends — what the chart lights up. */
+    val trace: List<String> = emptyList(),
+    /** Everyone matching the picker's search, name-ordered. */
+    val candidates: List<Person> = emptyList(),
+    /** The whole tree, which is a different question from how many the search matched. */
+    val peopleCount: Int = 0,
+) {
+    val bothChosen: Boolean get() = from != null && to != null
+    val treeIsEmpty: Boolean get() = !loading && peopleCount == 0
+}
+
+/**
+ * Finding how two people are related.
+ *
+ * The whole graph is loaded once and both halves of the screen are served from it — the answer and
+ * the picker. A relation is a question about the connections *between* people, so there is no
+ * query that could return a useful subset: the search has to be able to reach anyone, and the
+ * answer has to be free to walk anywhere.
+ */
+class RelationViewModel(
+    repository: FamilyRepository,
+    private val savedStateHandle: SavedStateHandle,
+    initialFrom: String?,
+    initialTo: String?,
+) : ViewModel() {
+
+    private val fromId = MutableStateFlow(savedStateHandle[FROM_KEY] ?: initialFrom)
+    private val toId = MutableStateFlow(savedStateHandle[TO_KEY] ?: initialTo)
+
+    private val query = MutableStateFlow("")
+    val currentQuery: StateFlow<String> = query.asStateFlow()
+
+    private val snapshot: StateFlow<FamilySnapshot> = repository.observeWholeGraph()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FamilySnapshot.Empty)
+
+    /**
+     * The answer, recomputed only when the pair changes.
+     *
+     * Kept apart from the picker's list on purpose: relating two people walks the whole graph
+     * twice, and folding the search box into the same combine would redo that on every keystroke.
+     */
+    private val answer = combine(snapshot, fromId, toId) { graph, from, to ->
+        val relation = if (from != null && to != null) Kinship.relate(graph, from, to) else null
+        val found = relation as? Relation.Found
+        RelationUiState(
+            loading = false,
+            from = from?.let(graph.people::get),
+            to = to?.let(graph.people::get),
+            relation = relation,
+            chain = found?.chain.orEmpty().mapNotNull { step ->
+                graph.people[step.personId]?.let { ChainLink(it, step.kind) }
+            },
+            // Naming the ancestor is only worth a line when it is somebody else. "Through Ankit
+            // Kumar, the nearest ancestor they share" is a true thing to say about Ankit and his
+            // son, and a silly one.
+            sharedAncestor = found?.sharedAncestorId
+                ?.takeIf { it != from && it != to }
+                ?.let(graph.people::get),
+            trace = if (found != null && from != null) {
+                found.peopleInvolved(from).toList()
+            } else emptyList(),
+            peopleCount = graph.people.size,
+        )
+    }
+
+    private val candidates = combine(snapshot, query) { graph, text ->
+        // Unnamed people sort last rather than first: they are placeholders, and a picker that
+        // opens on a column of "Unknown" is no use to anybody.
+        val ordered = graph.people.values.sortedWith(
+            compareBy<Person> { it.name.isNullOrBlank() }
+                .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name.orEmpty() }
+        )
+        if (text.isBlank()) ordered
+        else ordered.filter { it.name?.contains(text.trim(), ignoreCase = true) == true }
+    }
+
+    val uiState: StateFlow<RelationUiState> =
+        combine(answer, candidates) { state, people -> state.copy(candidates = people) }
+            // Both halves walk the whole tree; neither is main-thread work.
+            .flowOn(Dispatchers.Default)
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), RelationUiState())
+
+    fun choose(slot: RelationSlot, personId: String) {
+        when (slot) {
+            RelationSlot.FROM -> { fromId.value = personId; savedStateHandle[FROM_KEY] = personId }
+            RelationSlot.TO -> { toId.value = personId; savedStateHandle[TO_KEY] = personId }
+        }
+        query.value = ""
+    }
+
+    /**
+     * Turns the question round.
+     *
+     * "Who is Priya to me" and "who am I to Priya" are different questions with different words
+     * for the answer — nephew one way, uncle the other — so swapping is worth a button.
+     */
+    fun swap() {
+        val a = fromId.value
+        fromId.value = toId.value
+        toId.value = a
+        savedStateHandle[FROM_KEY] = fromId.value
+        savedStateHandle[TO_KEY] = toId.value
+    }
+
+    fun onQueryChange(value: String) {
+        query.value = value
+    }
+
+    private companion object {
+        const val FROM_KEY = "relation-from"
+        const val TO_KEY = "relation-to"
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CenterFocusStrong
+import androidx.compose.material.icons.filled.CompareArrows
 import androidx.compose.material.icons.filled.PersonAddAlt
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AssistChip
@@ -66,6 +67,9 @@ const val TreeFocusHereTag = "tree-focus-here"
 const val TreeOpenPersonTag = "tree-open-person"
 const val TreeModeFocusedTag = "tree-mode-focused"
 const val TreeModeWholeTag = "tree-mode-whole"
+const val TreeRelateTag = "tree-relate"
+const val TreeRelateFromTag = "tree-relate-from"
+const val TreeClearTraceTag = "tree-clear-trace"
 
 /**
  * Which chart is on screen.
@@ -83,7 +87,11 @@ fun TreeScreen(
     onOpenPerson: (String) -> Unit,
     onAddPerson: () -> Unit,
     onAddRelative: (String, RelativeKind) -> Unit,
+    onRelate: (String?) -> Unit,
+    onClearTrace: () -> Unit,
     modifier: Modifier = Modifier,
+    /** The people on a relation to draw: both ends and everyone between. Empty is the usual case. */
+    trace: List<String> = emptyList(),
     viewModel: TreeViewModel = viewModel(factory = FTreeViewModels.Factory),
     wholeTreeViewModel: WholeTreeViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
@@ -95,6 +103,19 @@ fun TreeScreen(
     var mode by rememberSaveable { mutableStateOf(ChartMode.FOCUSED) }
     var selected by remember { mutableStateOf<Person?>(null) }
     val sheetState = rememberModalBottomSheetState()
+
+    /*
+     * A traced relation is only meaningful on the whole-tree chart — the focused one draws three
+     * generations around one person, and the far end of a line is usually not among them. So
+     * arriving with a trace switches charts rather than showing an empty highlight.
+     */
+    val tracing = remember(trace) { trace.toSet() }
+    LaunchedEffect(tracing) {
+        if (tracing.isNotEmpty()) {
+            mode = ChartMode.WHOLE
+            wholeTreeViewModel.select(null)
+        }
+    }
 
     // The chart is drawn, not composed, so it has to be told about the reader's text size itself.
     val textScale = LocalDensity.current.fontScale
@@ -109,6 +130,17 @@ fun TreeScreen(
                 CenterAlignedTopAppBar(
                     title = { Text(stringResource(R.string.tree_title)) },
                     actions = {
+                        if (!treeIsEmpty) {
+                            IconButton(
+                                onClick = { onRelate(null) },
+                                modifier = Modifier.testTag(TreeRelateTag),
+                            ) {
+                                Icon(
+                                    Icons.Default.CompareArrows,
+                                    contentDescription = stringResource(R.string.relation_find),
+                                )
+                            }
+                        }
                         if (mode == ChartMode.FOCUSED && state.layout.truncated) {
                             IconButton(onClick = viewModel::showMoreGenerations) {
                                 Icon(
@@ -129,6 +161,8 @@ fun TreeScreen(
                             if (it == ChartMode.FOCUSED) wholeTreeViewModel.select(null)
                         },
                         summary = wholeSummary(wholeState).takeIf { mode == ChartMode.WHOLE },
+                        tracing = tracing.isNotEmpty() && mode == ChartMode.WHOLE,
+                        onClearTrace = onClearTrace,
                     )
                 }
             }
@@ -161,10 +195,14 @@ fun TreeScreen(
 
                 else -> when {
                     wholeState.loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
+                    // While a line is traced it is what the chart lights up. Letting a tap
+                    // replace it with that person's neighbours would throw away the answer the
+                    // reader came here to look at.
                     else -> WholeFamilyChart(
                         layout = wholeState.layout,
                         selectedId = wholeSelection?.id,
-                        highlighted = highlighted,
+                        highlighted = if (tracing.isNotEmpty()) tracing else highlighted,
+                        frameOn = tracing,
                         onSelect = {
                             wholeTreeViewModel.select(it)
                             selected = it
@@ -194,6 +232,10 @@ fun TreeScreen(
                     wholeTreeViewModel.select(null)
                     viewModel.focusOn(person.id)
                 },
+                onRelate = {
+                    selected = null
+                    onRelate(person.id)
+                },
                 onAddRelative = { kind ->
                     selected = null
                     onAddRelative(person.id, kind)
@@ -215,6 +257,8 @@ private fun ChartModeBar(
     mode: ChartMode,
     onModeChange: (ChartMode) -> Unit,
     summary: String?,
+    tracing: Boolean,
+    onClearTrace: () -> Unit,
 ) {
     Column(Modifier.fillMaxWidth()) {
         SingleChoiceSegmentedButtonRow(
@@ -237,7 +281,24 @@ private fun ChartModeBar(
             ) { Text(stringResource(R.string.tree_mode_whole)) }
         }
 
-        summary?.let {
+        // While a line is traced, saying so — and offering the way out — matters more than the
+        // record's counts, which are unchanged and still a chip away.
+        if (tracing) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(start = 24.dp, end = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.relation_tracing),
+                    style = FTreeText.recordSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.weight(1f),
+                )
+                TextButton(onClick = onClearTrace, modifier = Modifier.testTag(TreeClearTraceTag)) {
+                    Text(stringResource(R.string.relation_clear))
+                }
+            }
+        } else summary?.let {
             Text(
                 text = it,
                 style = FTreeText.recordSmall,
@@ -280,6 +341,7 @@ private fun PersonActions(
     isFocus: Boolean,
     onOpen: () -> Unit,
     onFocus: () -> Unit,
+    onRelate: () -> Unit,
     onAddRelative: (RelativeKind) -> Unit,
 ) {
     Column(
@@ -301,6 +363,12 @@ private fun PersonActions(
             label = stringResource(R.string.tree_open_person, person.displayName()),
             tag = TreeOpenPersonTag,
             onClick = onOpen,
+        )
+        SheetAction(
+            icon = { Icon(Icons.Default.CompareArrows, contentDescription = null) },
+            label = stringResource(R.string.relation_open_from_person),
+            tag = TreeRelateFromTag,
+            onClick = onRelate,
         )
         // Naming the four kinds outright is one tap either way, and avoids the sheet quietly
         // choosing "parent" on the user's behalf.

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -62,6 +62,7 @@ fun WholeFamilyChart(
     modifier: Modifier = Modifier,
     selectedId: String? = null,
     highlighted: Set<String> = emptySet(),
+    frameOn: Set<String> = emptySet(),
 ) {
     val description = stringResource(R.string.a11y_whole_chart, layout.nodes.size, layout.unconnectedCount)
     val density = LocalDensity.current
@@ -90,8 +91,8 @@ fun WholeFamilyChart(
      * a card would be too small to carry a name it stops being a chart and becomes a texture, so
      * beyond that the view opens at a readable scale on the largest family instead.
      */
-    LaunchedEffect(layout, viewport) {
-        if (viewport == IntSize.Zero || layout.isEmpty) return@LaunchedEffect
+    LaunchedEffect(layout, viewport, frameOn) {
+        if (viewport == IntSize.Zero || layout.isEmpty || frameOn.isNotEmpty()) return@LaunchedEffect
         with(density) {
             val chartWidth = layout.width.dp.toPx()
             val chartHeight = layout.height.dp.toPx()
@@ -125,6 +126,38 @@ fun WholeFamilyChart(
                     },
                 )
             }
+        }
+    }
+
+    /*
+     * Framing on a named few — the people on a traced relation.
+     *
+     * A highlight is no use if it lands off screen, and the general framing above has no reason to
+     * put a line between two distant cousins in view. This fits their bounding box instead, capped
+     * so that two people who happen to sit side by side do not open at absurd magnification.
+     */
+    LaunchedEffect(layout, viewport, frameOn) {
+        if (viewport == IntSize.Zero || layout.isEmpty || frameOn.isEmpty()) return@LaunchedEffect
+        val nodes = frameOn.mapNotNull { layout.node(it) }
+        if (nodes.isEmpty()) return@LaunchedEffect
+
+        val left = nodes.minOf { it.x }
+        val top = nodes.minOf { it.y }
+        val right = nodes.maxOf { it.x } + TreeMetrics.NODE_WIDTH
+        val bottom = nodes.maxOf { it.y } + TreeMetrics.NODE_HEIGHT
+        with(density) {
+            val margin = 32.dp.toPx()
+            val boxWidth = (right - left).dp.toPx()
+            val boxHeight = (bottom - top).dp.toPx()
+            val fit = minOf(
+                (viewport.width - margin * 2) / boxWidth,
+                (viewport.height - margin * 2) / boxHeight,
+            ).coerceIn(MIN_ZOOM, MAX_FIT)
+            zoom = fit
+            pan = Offset(
+                (viewport.width - boxWidth * fit) / 2f - left.dp.toPx() * fit,
+                (viewport.height - boxHeight * fit) / 2f - top.dp.toPx() * fit,
+            )
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,4 +297,79 @@
     <!-- Person detail -->
     <string name="person_show_on_tree">Show on the tree</string>
     <string name="person_more">More</string>
+
+    <!-- Relation finder -->
+    <string name="relation_title">How are we related?</string>
+    <string name="relation_between">Between</string>
+    <string name="relation_and">and</string>
+    <string name="relation_choose">Choose someone</string>
+    <string name="relation_change">Change</string>
+    <string name="relation_swap">Swap them round</string>
+    <string name="relation_pick_title">Who?</string>
+    <string name="relation_pick_hint">Search by name</string>
+    <string name="relation_pick_none">Nobody by that name.</string>
+    <string name="relation_hint">Pick two people and f-tree traces the line between them, however far apart they sit in the tree.</string>
+    <string name="relation_open_from_person">How are we related?</string>
+    <string name="relation_find">Find a relation</string>
+
+    <string name="relation_answer_term">%1$s is %2$s’s %3$s.</string>
+    <string name="relation_answer_marriage">%1$s is related to %2$s by marriage.</string>
+    <string name="relation_answer_linked">%1$s is related to %2$s.</string>
+    <string name="relation_answer_same">That is the same person on both sides.</string>
+    <string name="relation_answer_none">Nothing in the record joins %1$s and %2$s.</string>
+    <string name="relation_answer_none_body">They may well be related — the tree just does not connect them yet. Adding the missing parent or marriage is usually all it takes.</string>
+    <plurals name="relation_steps">
+        <item quantity="one">%1$d step apart</item>
+        <item quantity="other">%1$d steps apart</item>
+    </plurals>
+    <string name="relation_chain_title">The line between them</string>
+    <string name="relation_chain_step">%1$s of %2$s</string>
+    <string name="relation_chain_start">Where the line starts</string>
+    <string name="relation_shared_ancestor">Through %1$s, the nearest ancestor they share.</string>
+    <string name="relation_show_on_chart">Show on the chart</string>
+    <string name="relation_tracing">Tracing how two people connect</string>
+    <string name="relation_clear">Clear</string>
+
+    <!-- Kinship terms, lower case because they are read inside a sentence rather than as headings -->
+    <string name="kin_father">father</string>
+    <string name="kin_mother">mother</string>
+    <string name="kin_parent">parent</string>
+    <string name="kin_son">son</string>
+    <string name="kin_daughter">daughter</string>
+    <string name="kin_child">child</string>
+    <string name="kin_brother">brother</string>
+    <string name="kin_sister">sister</string>
+    <string name="kin_sibling">sibling</string>
+    <string name="kin_grandfather">grandfather</string>
+    <string name="kin_grandmother">grandmother</string>
+    <string name="kin_grandparent">grandparent</string>
+    <string name="kin_grandson">grandson</string>
+    <string name="kin_granddaughter">granddaughter</string>
+    <string name="kin_grandchild">grandchild</string>
+    <string name="kin_uncle">uncle</string>
+    <string name="kin_aunt">aunt</string>
+    <string name="kin_aunt_or_uncle">aunt or uncle</string>
+    <string name="kin_nephew">nephew</string>
+    <string name="kin_niece">niece</string>
+    <string name="kin_niece_or_nephew">niece or nephew</string>
+    <string name="kin_self">the same person</string>
+    <string name="kin_great_prefix">great-</string>
+    <string name="kin_cousin">%1$s cousin</string>
+    <string name="kin_cousin_removed_once">%1$s once removed</string>
+    <string name="kin_cousin_removed_twice">%1$s twice removed</string>
+    <string name="kin_cousin_removed_many">%1$s %2$d times removed</string>
+    <string name="kin_ordinal_nth">%1$dth</string>
+    <string-array name="kin_ordinals">
+        <item>first</item>
+        <item>second</item>
+        <item>third</item>
+        <item>fourth</item>
+        <item>fifth</item>
+        <item>sixth</item>
+        <item>seventh</item>
+        <item>eighth</item>
+        <item>ninth</item>
+        <item>tenth</item>
+    </string-array>
+
 </resources>

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/KinshipTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/KinshipTest.kt
@@ -1,0 +1,247 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.Person
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The relation finder answers a question people can check against their own memory, so a wrong
+ * answer is worse than no answer. Every shape of family that has its own word in English is
+ * pinned here, along with the ones that have no word and must fall back to the chain.
+ */
+class KinshipTest {
+
+    private class Builder {
+        private val people = mutableMapOf<String, Person>()
+        private val parents = mutableListOf<Pair<String, String>>()
+        private val spouses = mutableListOf<Pair<String, String>>()
+        private val siblings = mutableListOf<Pair<String, String>>()
+
+        fun person(vararg ids: String) = apply {
+            ids.forEach { people[it] = Person(id = it, name = it) }
+        }
+
+        fun parentOf(parent: String, vararg children: String) = apply {
+            children.forEach { parents += parent to it }
+        }
+
+        fun married(a: String, b: String) = apply { spouses += a to b }
+        fun siblingOf(a: String, b: String) = apply { siblings += a to b }
+        fun build() = FamilySnapshot(people, parents, spouses, siblings)
+    }
+
+    /**
+     * Four generations with two branches, which between them contain every term worth having:
+     *
+     *              great ── great-wife
+     *                    │
+     *          ┌─────────┴──────────┐
+     *        grandad ── granny    granduncle
+     *          │                    │
+     *      ┌───┴────┐            cousin-parent
+     *     dad ── mum  aunt          │
+     *      │                     second-line
+     *     me ── wife
+     *      │
+     *     kid
+     */
+    private fun family() = Builder()
+        .person("great", "great-wife", "grandad", "granny", "granduncle")
+        .person("dad", "mum", "aunt", "me", "wife", "kid")
+        .person("cousin-parent", "second-line")
+        .person("wifes-mother")
+        .married("great", "great-wife")
+        .married("grandad", "granny")
+        .married("dad", "mum")
+        .married("me", "wife")
+        .parentOf("great", "grandad", "granduncle")
+        .parentOf("great-wife", "grandad", "granduncle")
+        .parentOf("grandad", "dad", "aunt")
+        .parentOf("granny", "dad", "aunt")
+        .parentOf("dad", "me")
+        .parentOf("mum", "me")
+        .parentOf("me", "kid")
+        .parentOf("wife", "kid")
+        .parentOf("granduncle", "cousin-parent")
+        .parentOf("cousin-parent", "second-line")
+        .parentOf("wifes-mother", "wife")
+        .build()
+
+    private fun term(from: String, to: String): KinshipTerm? =
+        (Kinship.relate(family(), from, to) as Relation.Found).term
+
+    private fun chain(from: String, to: String): List<RelationStep> =
+        (Kinship.relate(family(), from, to) as Relation.Found).chain
+
+    /* --------------------------------------------------------------- the words */
+
+    @Test
+    fun `the straight line up and down is named by its generations`() {
+        assertEquals(KinshipTerm.Ancestor(1), term("me", "dad"))
+        assertEquals(KinshipTerm.Ancestor(2), term("me", "grandad"))
+        assertEquals(KinshipTerm.Ancestor(3), term("me", "great"))
+        assertEquals(KinshipTerm.Descendant(1), term("me", "kid"))
+        assertEquals(KinshipTerm.Descendant(3), term("grandad", "kid"))
+        assertEquals(KinshipTerm.Descendant(4), term("great", "kid"))
+    }
+
+    @Test
+    fun `siblings, aunts and nieces come out of the same two numbers`() {
+        assertEquals(KinshipTerm.Sibling, term("dad", "aunt"))
+        assertEquals(KinshipTerm.ParentsSibling(greats = 0), term("me", "aunt"))
+        assertEquals(KinshipTerm.ParentsSibling(greats = 1), term("me", "granduncle"))
+        assertEquals(KinshipTerm.SiblingsChild(greats = 0), term("aunt", "me"))
+        assertEquals(KinshipTerm.SiblingsChild(greats = 1), term("granduncle", "me"))
+    }
+
+    @Test
+    fun `cousins carry both a degree and a remove`() {
+        // me and cousin-parent share "great": two up, two down.
+        assertEquals(KinshipTerm.Cousin(degree = 1, removed = 0), term("dad", "cousin-parent"))
+        assertEquals(KinshipTerm.Cousin(degree = 1, removed = 1), term("me", "cousin-parent"))
+        assertEquals(KinshipTerm.Cousin(degree = 2, removed = 0), term("me", "second-line"))
+        assertEquals(KinshipTerm.Cousin(degree = 1, removed = 2), term("kid", "cousin-parent"))
+    }
+
+    @Test
+    fun `the nearest shared ancestor names it, not the most distant one`() {
+        // dad and aunt share both their parents and both their grandparents; measured through a
+        // grandparent they would come out as first cousins rather than as brother and sister.
+        assertEquals(KinshipTerm.Sibling, term("dad", "aunt"))
+    }
+
+    @Test
+    fun `a term is a claim about blood, so marriage does not get one`() {
+        assertNull(term("me", "wife"))
+        assertNull(term("me", "wifes-mother"))
+        // Two people married into the same family have no blood between them at all.
+        assertNull(term("wife", "mum"))
+    }
+
+    /* --------------------------------------------------------------- the chain */
+
+    @Test
+    fun `the chain names each person and how they arrive`() {
+        // Not up to the grandfather and back down: siblings are derived from the parents they
+        // share, so the aunt is one step from the father and the chain says so.
+        assertEquals(
+            listOf(
+                RelationStep("dad", StepKind.PARENT),
+                RelationStep("aunt", StepKind.SIBLING),
+            ),
+            chain("me", "aunt"),
+        )
+        assertEquals(
+            listOf(
+                RelationStep("dad", StepKind.PARENT),
+                RelationStep("grandad", StepKind.PARENT),
+            ),
+            chain("me", "grandad"),
+        )
+    }
+
+    @Test
+    fun `a marriage is walked, because in-laws are most of what gets asked`() {
+        val relation = Kinship.relate(family(), "me", "wifes-mother") as Relation.Found
+
+        assertEquals(
+            listOf(
+                RelationStep("wife", StepKind.SPOUSE),
+                RelationStep("wifes-mother", StepKind.PARENT),
+            ),
+            relation.chain,
+        )
+        assertTrue("no blood between them, so this is a marriage", relation.byMarriage)
+        assertNull(relation.term)
+    }
+
+    @Test
+    fun `a blood route wins over a marriage route of the same length`() {
+        // Reaching the aunt through her own husband would be true and useless.
+        val snapshot = Builder()
+            .person("me", "parent", "aunt", "aunts-husband")
+            .parentOf("parent", "me")
+            .siblingOf("parent", "aunt")
+            .married("aunt", "aunts-husband")
+            .married("parent", "aunts-husband")   // an absurd edge, there to bait the search
+            .build()
+
+        val relation = Kinship.relate(snapshot, "me", "aunt") as Relation.Found
+        assertEquals(listOf(StepKind.PARENT, StepKind.SIBLING), relation.chain.map { it.kind })
+    }
+
+    @Test
+    fun `siblings are one step, not up to a parent and back down`() {
+        assertEquals(listOf(RelationStep("aunt", StepKind.SIBLING)), chain("dad", "aunt"))
+    }
+
+    @Test
+    fun `the chain and the term agree about who is involved`() {
+        val relation = Kinship.relate(family(), "me", "second-line") as Relation.Found
+
+        // The ancestor that names the relationship need not be on the shortest route to it: the
+        // two branches join at their siblings, a generation below the ancestor they share.
+        assertEquals("great", relation.sharedAncestorId)
+        assertEquals(
+            listOf("me", "dad", "grandad", "granduncle", "cousin-parent", "second-line"),
+            listOf("me") + relation.chain.map { it.personId },
+        )
+        assertFalse("nobody outside the route is lit up", "kid" in relation.peopleInvolved("me"))
+    }
+
+    /* --------------------------------------------------------------- the edges */
+
+    @Test
+    fun `the same person twice is said plainly rather than answered with an empty chain`() {
+        assertEquals(Relation.SamePerson, Kinship.relate(family(), "me", "me"))
+    }
+
+    @Test
+    fun `two families in one file are not related to each other`() {
+        val snapshot = Builder()
+            .person("a", "b", "x", "y")
+            .parentOf("a", "b")
+            .parentOf("x", "y")
+            .build()
+
+        assertEquals(Relation.Unrecorded, Kinship.relate(snapshot, "b", "y"))
+    }
+
+    @Test
+    fun `somebody who is not in the tree is unrecorded, not a crash`() {
+        assertEquals(Relation.Unrecorded, Kinship.relate(family(), "me", "ghost"))
+        assertEquals(Relation.Unrecorded, Kinship.relate(family(), "ghost", "me"))
+        assertEquals(Relation.Unrecorded, Kinship.relate(FamilySnapshot.Empty, "a", "b"))
+    }
+
+    @Test
+    fun `a cycle in bad data terminates rather than hanging`() {
+        // Rejected when created, but a corrupt import must not be able to spin the search forever.
+        val snapshot = Builder()
+            .person("a", "b", "c")
+            .parentOf("a", "b").parentOf("b", "c").parentOf("c", "a")
+            .build()
+
+        assertTrue(Kinship.relate(snapshot, "a", "c") is Relation.Found)
+    }
+
+    @Test
+    fun `a long line is answered in reasonable time`() {
+        val builder = Builder()
+        builder.person("p0")
+        repeat(2000) {
+            builder.person("p${it + 1}").parentOf("p$it", "p${it + 1}")
+        }
+        val snapshot = builder.build()
+
+        val started = System.currentTimeMillis()
+        val relation = Kinship.relate(snapshot, "p0", "p2000") as Relation.Found
+        val elapsed = System.currentTimeMillis() - started
+
+        assertEquals(KinshipTerm.Descendant(2000), relation.term)
+        assertTrue("took ${elapsed}ms", elapsed < 2000)
+    }
+}

--- a/site/index.html
+++ b/site/index.html
@@ -173,6 +173,15 @@
         </p>
       </div>
       <div class="entry">
+        <h3>How am I related to them?</h3>
+        <p>
+          Pick two people — any two, however far apart — and f-tree names the relationship
+          and shows every person the line passes through. It walks marriages as well as
+          blood, so it can answer the ones English has no single word for, and it will
+          draw the line across the whole tree for you.
+        </p>
+      </div>
+      <div class="entry">
         <h3>Made to outlast you</h3>
         <p>
           Thousands of people stay quick, because the chart only ever loads the family


### PR DESCRIPTION
Pick any two people; f-tree answers in two registers.

**The word**, when English has one — *"Shyam Lal is Aarav Kumar's great-great-grandfather."* It comes from the nearest shared ancestor: generations up, generations back down. Those two numbers produce every term a family actually says.

**The line**, always — every person it runs through, each labelled against the one before:

```
Ankit Kumar     Where the line starts
Vinod Kumar     Father of Ankit Kumar
Meena Devi      Sister of Vinod Kumar
```

Both, because they are believed differently. The sentence is the answer somebody came for; the chain is the working, and the only form that can express an in-law or the long way round. So the chain is always shown and the sentence only when there is one to give.

## Decisions worth reviewing

- **Marriage is walked, not just blood.** "My wife's mother" is exactly what this gets asked, and no blood-only search answers it. Blood steps are enqueued before marriage ones, so where two routes are the same length the one through the family wins — reaching a cousin by way of their husband is a true answer and a useless one.
- **Nearest shared ancestor, then most symmetric.** Measured through a grandparent instead, two siblings come out as first cousins.
- **The term is a structure, not a string.** `graph/Kinship.kt` returns `Cousin(degree, removed)`; the English lives in `ui/common/KinshipLabels.kt` with the rest of the app's words, in its own lower-case set — `father` read inside a sentence is not the `Father` that heads a section, and lower-casing a heading in code breaks the first time this is read in a language that capitalises its nouns.
- **While a line is traced it owns the chart's highlight.** Letting a tap replace it with that person's neighbours would throw away the answer the reader came to look at.
- **The trace lives in the route**, not a view model, so going back leaves it behind rather than relighting an hour-old question.

## Where it is

Three ways in, all from somebody already in front of you: the chart's app bar, a person's overflow menu, and the chart's tap sheet. A swap button turns the question round — *grandfather* one way, *grandson* the other. **Show on the chart** switches to the whole-tree view, frames on the people involved, and lights them against the faded rest.

## Testing

- 15 unit tests pinning every shape of family that has its own word in English, plus the ones that have none, cycles in bad data, and a 2,000-deep line.
- 4 instrumented tests: pick → answer → chart → clear.
- Full suite green: **122 unit, 104 instrumented, 0 failures**, lint clean.
- Exercised by hand on the emulator.

Also hardens a pre-existing `RelationshipFlowTest` flake that surfaced during a full run — it asserted a renamed row immediately after a database write.

The browser viewer already had this feature; the two now agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)