### PR TITLE
chore: version 0.2.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 2
-        versionName = "0.1.1"
+        versionCode = 3
+        versionName = "0.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to 0.2.0 and `versionCode` to 3, which is the trigger for cutting the release: [`release.yml`](.github/workflows/release.yml) refuses a tag that disagrees with the app's own version.

A minor bump rather than a patch. Since 0.1.1 the app gained two things it could not do before — the whole-tree chart, and the relation finder — plus the opt-in updater, which makes this the last version that has to be installed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)