### PR TITLE
An aunt known only as somebody's sister is still an aunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ pure and JVM-tested):
   *down* to the other person — and those two numbers produce every term English actually has.
   Nearest, then most symmetric: measured through a grandparent instead, two siblings would come out
   as first cousins. There is no word for most relationships, so this half is often absent.
+  An explicit `SIBLING` edge is recorded precisely when the parents are *not* known, so each such
+  group is given one unnamed stand-in ancestor to measure through — otherwise an aunt reachable only
+  through her brother comes back as merely "related", the gap in the record swallowing a word the
+  family uses every day. The stand-in is never shown; it has no name to show.
 - **The line between them** is a breadth-first search over *every* edge kind. Marriage is walked as
   well as blood, because "my wife's mother" is exactly what gets asked and no blood-only search can
   answer it. Blood steps are enqueued before marriage ones, so where two routes are the same length

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
@@ -89,7 +89,7 @@ object Kinship {
         if (fromId !in snapshot.people || toId !in snapshot.people) return Relation.Unrecorded
 
         val chain = shortestChain(snapshot, fromId, toId) ?: return Relation.Unrecorded
-        val shared = nearestSharedAncestor(snapshot, fromId, toId)
+        val shared = nearestSharedAncestor(snapshot, fromId, toId, standInAncestors(snapshot))
         return Relation.Found(
             chain = chain,
             term = shared?.let { termFor(it.up, it.down) },
@@ -128,9 +128,10 @@ object Kinship {
         snapshot: FamilySnapshot,
         fromId: String,
         toId: String,
+        standIns: Map<String, String>,
     ): Shared? {
-        val mine = ancestorDistances(snapshot, fromId)
-        val theirs = ancestorDistances(snapshot, toId)
+        val mine = ancestorDistances(snapshot, fromId, standIns)
+        val theirs = ancestorDistances(snapshot, toId, standIns)
         var best: Shared? = null
         mine.forEach { (ancestor, up) ->
             val down = theirs[ancestor] ?: return@forEach
@@ -147,18 +148,64 @@ object Kinship {
     }
 
     /** Everyone at or above [id], with the number of generations up to each. */
-    private fun ancestorDistances(snapshot: FamilySnapshot, id: String): Map<String, Int> {
+    private fun ancestorDistances(
+        snapshot: FamilySnapshot,
+        id: String,
+        standIns: Map<String, String>,
+    ): Map<String, Int> {
         val distance = linkedMapOf(id to 0)
         val queue = ArrayDeque(listOf(id))
         while (queue.isNotEmpty()) {
             val current = queue.removeFirst()
             val step = distance.getValue(current) + 1
-            snapshot.parentsOf[current].orEmpty().forEach { parent ->
+            val above = snapshot.parentsOf[current].orEmpty() + listOfNotNull(standIns[current])
+            above.forEach { parent ->
                 // The visited check also makes a cycle in bad data terminate rather than hang.
                 if (distance.putIfAbsent(parent, step) == null) queue.addLast(parent)
             }
         }
         return distance
+    }
+
+    /**
+     * A stand-in parent for each group of people joined by explicit sibling edges.
+     *
+     * A SIBLING edge is only ever recorded when the parents are *not* known — shared parents derive
+     * siblings on their own. So an explicit edge is a statement that these people share an ancestor
+     * whom nobody wrote down, and without somebody to measure through, the term calculation has
+     * nothing to work with: an aunt comes back as merely "related", the gap in the record
+     * swallowing a word the family uses every day.
+     *
+     * The stand-in is never shown. It has no name to show, which is the whole point of it, and the
+     * screen already declines to name an ancestor it cannot look up.
+     */
+    private fun standInAncestors(snapshot: FamilySnapshot): Map<String, String> {
+        if (snapshot.siblingEdges.isEmpty()) return emptyMap()
+
+        // Whole groups, not pairs: three siblings recorded as two edges share one unknown parent,
+        // and minting two stand-ins would make one of them their own cousin.
+        val groupOf = HashMap<String, String>()
+        val members = HashMap<String, MutableList<String>>()
+        snapshot.siblingEdges.forEach { (a, b) ->
+            if (a !in snapshot.people || b !in snapshot.people) return@forEach
+            val left = groupOf[a]
+            val right = groupOf[b]
+            when {
+                left == null && right == null -> {
+                    val id = "unrecorded-parent:" + groupOf.size
+                    groupOf[a] = id
+                    groupOf[b] = id
+                    members[id] = mutableListOf(a, b)
+                }
+                left == null -> { groupOf[a] = right!!; members.getValue(right)+= a }
+                right == null -> { groupOf[b] = left; members.getValue(left) += b }
+                left != right -> {
+                    members.getValue(right).forEach { groupOf[it] = left }
+                    members.getValue(left).addAll(members.remove(right).orEmpty())
+                }
+            }
+        }
+        return groupOf
     }
 
     /**

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/KinshipTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/KinshipTest.kt
@@ -244,4 +244,66 @@ class KinshipTest {
         assertEquals(KinshipTerm.Descendant(2000), relation.term)
         assertTrue("took ${elapsed}ms", elapsed < 2000)
     }
+
+    /*
+     * A SIBLING edge is recorded exactly when the parents are unknown, so these cases have no
+     * ancestor to measure through until one is stood in for them. Caught on a device: an aunt
+     * reachable only through her brother came back as merely "related".
+     */
+
+    @Test
+    fun `an aunt known only as somebody's sister is still an aunt`() {
+        val snapshot = Builder()
+            .person("me", "dad", "aunt")
+            .parentOf("dad", "me")
+            .siblingOf("dad", "aunt")
+            .build()
+
+        val relation = Kinship.relate(snapshot, "me", "aunt") as Relation.Found
+
+        assertEquals(KinshipTerm.ParentsSibling(greats = 0), relation.term)
+        assertFalse("blood, not marriage", relation.byMarriage)
+    }
+
+    @Test
+    fun `the stand-in ancestor is not a person, so nothing can try to name it`() {
+        val snapshot = Builder()
+            .person("elder", "younger")
+            .siblingOf("elder", "younger")
+            .build()
+
+        val relation = Kinship.relate(snapshot, "elder", "younger") as Relation.Found
+
+        assertEquals(KinshipTerm.Sibling, relation.term)
+        assertFalse(relation.sharedAncestorId in snapshot.people)
+        assertEquals("the chain still crosses one edge, not two", 1, relation.steps)
+    }
+
+    @Test
+    fun `three siblings on two edges share one unrecorded parent, not two`() {
+        // Minting a stand-in per edge rather than per group would make the outer two cousins.
+        val snapshot = Builder()
+            .person("a", "b", "c")
+            .siblingOf("a", "b").siblingOf("b", "c")
+            .build()
+
+        assertEquals(
+            KinshipTerm.Sibling,
+            (Kinship.relate(snapshot, "a", "c") as Relation.Found).term,
+        )
+    }
+
+    @Test
+    fun `an explicit edge does not overrule the parents when both are recorded`() {
+        val snapshot = Builder()
+            .person("mum", "one", "two")
+            .parentOf("mum", "one").parentOf("mum", "two")
+            .siblingOf("one", "two")
+            .build()
+
+        val relation = Kinship.relate(snapshot, "one", "two") as Relation.Found
+
+        assertEquals(KinshipTerm.Sibling, relation.term)
+        assertEquals("measured through the mother who is actually recorded", "mum", relation.sharedAncestorId)
+    }
 }

--- a/site/playground/model.js
+++ b/site/playground/model.js
@@ -342,15 +342,57 @@ export function kinshipTerm(u, d, other) {
   return `${base} ${removed} times removed`;
 }
 
+/**
+ * A stand-in parent for each group of people joined by explicit sibling edges.
+ *
+ * An explicit SIBLING edge is only recorded when the parents are *not* known - shared parents
+ * derive siblings on their own. So the edge is a statement that these people share an ancestor
+ * nobody wrote down, and without somebody to measure through, an aunt reachable only through her
+ * brother comes back as merely "related": the gap in the record swallowing a word the family uses
+ * every day. Whole groups, not pairs - three siblings recorded as two edges share one unknown
+ * parent, and a stand-in per edge would make the outer two cousins.
+ *
+ * The stand-in is never shown. It has no name to show, which is the point of it.
+ */
+function standInAncestors(graph) {
+  const groupOf = new Map();
+  const members = new Map();
+  for (const [id, siblings] of graph.explicitSiblings) {
+    for (const s of siblings.values()) {
+      const a = id;
+      const b = s.id;
+      const left = groupOf.get(a);
+      const right = groupOf.get(b);
+      if (left === undefined && right === undefined) {
+        const key = `unrecorded-parent:${members.size}`;
+        groupOf.set(a, key); groupOf.set(b, key);
+        members.set(key, [a, b]);
+      } else if (left === undefined) {
+        groupOf.set(a, right); members.get(right).push(a);
+      } else if (right === undefined) {
+        groupOf.set(b, left); members.get(left).push(b);
+      } else if (left !== right) {
+        for (const m of members.get(right)) groupOf.set(m, left);
+        members.get(left).push(...members.get(right));
+        members.delete(right);
+      }
+    }
+  }
+  return groupOf;
+}
+
 /** Ancestors of a person, with the number of generations up to each. */
-function ancestorDistances(graph, id) {
+function ancestorDistances(graph, id, standIns) {
   const dist = new Map([[id, 0]]);
   const queue = [id];
   while (queue.length) {
     const current = queue.shift();
     const step = dist.get(current) + 1;
-    for (const p of graph.parents(current)) {
-      if (!dist.has(p.id)) { dist.set(p.id, step); queue.push(p.id); }
+    const above = graph.parents(current).map((p) => p.id);
+    const standIn = standIns.get(current);
+    if (standIn !== undefined) above.push(standIn);
+    for (const parent of above) {
+      if (!dist.has(parent)) { dist.set(parent, step); queue.push(parent); }
     }
   }
   return dist;
@@ -370,8 +412,9 @@ export function relate(graph, fromId, toId) {
   if (!graph.people.get(fromId) || !to) return { kind: 'none' };
 
   let term = null;
-  const mine = ancestorDistances(graph, fromId);
-  const theirs = ancestorDistances(graph, toId);
+  const standIns = standInAncestors(graph);
+  const mine = ancestorDistances(graph, fromId, standIns);
+  const theirs = ancestorDistances(graph, toId, standIns);
   let best = null;
   for (const [ancestor, u] of mine) {
     const d = theirs.get(ancestor);


### PR DESCRIPTION
Caught while exercising the release build before tagging 0.2.0 — the check the README insists on, earning its keep.

Built a three-person family on the device: Ankit, his father, and his father's sister. The app said **"Meena is related to Ankit Kumar."** The word it exists to supply is *aunt*.

## Why it happened

The term is measured through the nearest ancestor two people share, and these two share nobody. A `SIBLING` edge is recorded *precisely* when the parents are not known — shared parents derive siblings on their own, so an explicit edge only ever appears where derivation cannot reach.

So the pair have a mother, she is real, and nobody wrote her down. With no one to measure through, the gap in the record was swallowing the answer.

## The fix

Each group of explicitly-recorded siblings gets one stand-in for that unnamed parent, and the ancestor walk goes through it.

- **Groups, not pairs.** Three siblings written down as two edges share one mother; a stand-in per edge would make the outer two cousins. There's a test.
- **Real parents still win.** Where the parents *are* recorded they give an equal-or-nearer ancestor, so nothing about an ordinary family changes. There's a test for that too.
- **The stand-in is never shown.** It has no name to show, which is the point of it — and `RelationViewModel` already declines to name an ancestor it cannot look up, so this needed no UI change.

## Also

The browser viewer had the identical gap and gets the identical fix, so the two keep giving one answer. `tools/check_layout.mjs` passes.

## Testing

- 4 new unit tests: the aunt case that failed on the device, three siblings across two edges, real parents outranking the stand-in, and the stand-in not being a person.
- Full suite green: **126 unit, 104 instrumented, 0 failures**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)