### PR TITLE
A generation is a relative fact, not how deep the record goes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ local.properties
 
 # Playwright MCP scratch output
 .playwright-mcp/
+
+# Scratch imports and exports kept for debugging; never part of the repo.
+temp/

--- a/README.md
+++ b/README.md
@@ -367,9 +367,16 @@ distance the cards are plain shapes and what you read is the shape of the family
 generations, how wide each got, and where the record has holes, because an unknown person keeps
 their brass dashed edge at every scale.
 
-**Generation ranking is compacted after it is assigned.** Longest-path ranking alone strands a
-person whose only child married into a deeper part of the family several rows above them, trailing
-a connector the height of the chart.
+**A generation is a relative fact, not a depth.** A child sits exactly one row below each parent,
+and spouses — and siblings whose parents nobody recorded — sit on the same row; those offsets are
+propagated out from one seed per connected family, which fixes every row exactly, because the offset
+between two people is the same along every route between them.
+
+The textbook alternative, ranking people by their longest path down from the oldest ancestor on
+record, is wrong in a way that takes a real family to notice: it makes a person's row depend on how
+far back *their* ancestry happens to be written down. A maternal grandfather whose own parents are
+unknown lands on the top row beside a great-great-grandfather from the other side of the family, and
+his children scatter across rows, each dragged down by however deep their own spouse's ancestry ran.
 
 Everything happens in the tab. The file is never uploaded, there is no analytics on the page, and
 the only thing stored is four display preferences in `localStorage`.

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
@@ -198,106 +198,77 @@ object WholeTreeLayoutEngine {
     /**
      * Puts every person on a generation.
      *
-     * Spouses are unioned first so a married pair cannot land a row apart; generations are then the
-     * longest path over parent edges between those unions — longest rather than shortest, or a
-     * person with both a parent and a great-grandparent recorded would sit above one of them.
+     * A generation is a *relative* fact and nothing else: a child stands exactly one row below each
+     * parent, and spouses — and siblings whose parents nobody recorded — stand on the same row as
+     * each other. Those constraints are propagated outward from one seed per connected family,
+     * which fixes every generation exactly, because the offset between two people is the same along
+     * every route between them. [layoutComponent] then normalises each family against its own
+     * topmost member.
      *
-     * Longest-path ranking alone leaves slack, though: somebody whose only child married into a
-     * deeper part of the family gets stranded rows above them trailing a connector the height of
-     * the chart. So a second pass pulls every group down until it sits directly above its earliest
-     * child, which is as far as it can go without overtaking its own parents.
+     * It is worth saying what this deliberately is *not*, because the obvious alternative is wrong
+     * in a way that takes a real family to notice. Ranking people by their longest path down from
+     * the oldest ancestor on record — the textbook layering — makes a person's row depend on how far
+     * back their ancestry happens to be written down. A maternal grandfather whose own parents are
+     * unknown lands on the top row beside a great-great-grandfather from the other side of the
+     * family; worse, his three children come out on different rows from each other, because each
+     * was dragged down by however deep their own spouse's ancestry ran. Generations are not depths.
+     * Two people are one generation apart or they are not, and how much of the record survives
+     * above them cannot change that.
      */
     private fun assignLevels(snapshot: FamilySnapshot): Map<String, Int> {
-        val parent = mutableMapOf<String, String>()
-        snapshot.people.keys.forEach { parent[it] = it }
+        val level = HashMap<String, Int>(snapshot.people.size)
 
-        fun find(x: String): String {
-            var root = x
-            while (parent[root] != root) root = parent[root]!!
-            var cursor = x
-            while (parent[cursor] != root) {
-                val next = parent[cursor]!!
-                parent[cursor] = root
-                cursor = next
-            }
-            return root
-        }
-
-        fun union(a: String, b: String) {
-            val ra = find(a)
-            val rb = find(b)
-            if (ra != rb) parent[ra] = rb
-        }
-
-        snapshot.spouseEdges.forEach { (a, b) ->
-            if (a in snapshot.people && b in snapshot.people) union(a, b)
-        }
-
-        val outs = mutableMapOf<String, MutableSet<String>>()
-        val indegree = mutableMapOf<String, Int>()
-        snapshot.people.keys.forEach {
-            val g = find(it)
-            outs.getOrPut(g) { mutableSetOf() }
-            indegree.putIfAbsent(g, 0)
-        }
-        snapshot.parentEdges.forEach { (from, to) ->
-            if (from !in snapshot.people || to !in snapshot.people) return@forEach
-            val a = find(from)
-            val b = find(to)
-            // A couple who are also parent and child cannot be placed; the app's own rules forbid
-            // it, but a hand-edited import could carry it.
-            if (a == b) return@forEach
-            if (outs.getValue(a).add(b)) indegree[b] = indegree.getValue(b) + 1
-        }
-
-        val level = outs.keys.associateWith { 0 }.toMutableMap()
-        val queue = ArrayDeque(indegree.filterValues { it == 0 }.keys)
-        var placed = 0
-        while (queue.isNotEmpty()) {
-            val g = queue.removeFirst()
-            placed++
-            outs.getValue(g).forEach { next ->
-                level[next] = max(level.getValue(next), level.getValue(g) + 1)
-                indegree[next] = indegree.getValue(next) - 1
-                if (indegree.getValue(next) == 0) queue.addLast(next)
+        /*
+         * Every constraint, as an offset. Derived siblings need no edge of their own — sharing a
+         * parent already puts them on one row — but an explicit sibling edge exists precisely where
+         * the parents are unknown, and without it those two would float apart.
+         */
+        fun stepsFrom(id: String): List<Pair<String, Int>> = buildList {
+            snapshot.parentsOf[id].orEmpty().forEach { add(it to -1) }
+            snapshot.childrenOf[id].orEmpty().forEach { add(it to 1) }
+            snapshot.spousesOf[id].orEmpty().forEach { add(it to 0) }
+            snapshot.siblingEdges.forEach { (a, b) ->
+                if (a == id) add(b to 0) else if (b == id) add(a to 0)
             }
         }
 
-        // Anything left sits in a cycle. Relax it a bounded number of times so a broken file still
-        // draws rather than hanging.
-        if (placed < outs.size) {
-            repeat(40) {
-                var changed = false
-                outs.forEach { (g, children) ->
-                    children.forEach { next ->
-                        if (level.getValue(next) <= level.getValue(g)) {
-                            level[next] = level.getValue(g) + 1
-                            changed = true
-                        }
-                    }
+        snapshot.people.keys.forEach { seed ->
+            if (seed in level) return@forEach
+            level[seed] = 0
+            val queue = ArrayDeque(listOf(seed))
+            while (queue.isNotEmpty()) {
+                val current = queue.removeFirst()
+                val base = level.getValue(current)
+                stepsFrom(current).forEach { (next, delta) ->
+                    if (next !in snapshot.people || next in level) return@forEach
+                    level[next] = base + delta
+                    queue.addLast(next)
                 }
-                if (!changed) return@repeat
             }
         }
 
-        val parents = mutableMapOf<String, MutableSet<String>>()
-        outs.forEach { (g, children) -> children.forEach { parents.getOrPut(it) { mutableSetOf() } += g } }
-        repeat(8) {
+        /*
+         * The constraints can only disagree when the record itself does — somebody married to their
+         * own aunt gives one route saying "same row" and another saying "one row apart", and no
+         * assignment satisfies both. Where that happens the parent edge wins, because a connector
+         * running upward out of a child into their parent is unreadable in a way that a couple
+         * sitting a row apart is not. Bounded, so a cycle in an imported file still draws rather
+         * than hanging.
+         */
+        repeat(40) {
             var changed = false
-            outs.forEach { (g, children) ->
-                if (children.isEmpty()) return@forEach
-                val earliestChild = children.minOf { level.getValue(it) }
-                val floor = parents[g]?.maxOfOrNull { level.getValue(it) + 1 } ?: 0
-                val want = earliestChild - 1
-                if (want > level.getValue(g) && want >= floor) {
-                    level[g] = want
+            snapshot.parentEdges.forEach { (from, to) ->
+                val above = level[from] ?: return@forEach
+                val below = level[to] ?: return@forEach
+                if (below <= above) {
+                    level[to] = above + 1
                     changed = true
                 }
             }
             if (!changed) return@repeat
         }
 
-        return snapshot.people.keys.associateWith { level[find(it)] ?: 0 }
+        return level
     }
 
     /** Connected families, over every edge kind, so nobody is dropped for being unconnected. */

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngineTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngineTest.kt
@@ -285,4 +285,93 @@ class WholeTreeLayoutEngineTest {
         assertEquals(snapshot.people.size, layout.nodes.size)
         assertTrue("layout of ${snapshot.people.size} people took ${elapsed}ms", elapsed < 5000)
     }
+
+    /*
+     * The shape that exposed longest-path ranking, taken from a real 148-person tree.
+     *
+     * One side of the family is written down four generations back; the other stops at a
+     * grandfather whose own parents nobody recorded. Ranked by depth from the oldest ancestor, that
+     * grandfather is a root and lands on the top row beside the great-great-grandfather — and his
+     * children scatter across three rows, each dragged down by however deep their spouse's ancestry
+     * ran. Generations are not depths.
+     */
+    private fun lopsided() = Builder()
+        .person("great-great", "1890").person("great", "1915")
+        .person("grandfather", "1940").person("grandmother", "1944")
+        .person("father", "1968").person("mother", "1972")
+        .person("me", "2002")
+        // The mother's father, with no ancestry recorded above him at all.
+        .person("maternal-grandfather", "1942").person("maternal-grandmother", "1946")
+        // ...and the mother's siblings, who married people with no recorded ancestry either.
+        .person("uncle", "1970").person("uncles-wife", "1974")
+        .person("aunt", "1976").person("aunts-husband", "1973")
+        .parentOf("great-great", "great")
+        .parentOf("great", "grandfather")
+        .parentOf("grandfather", "father").parentOf("grandmother", "father")
+        .parentOf("father", "me").parentOf("mother", "me")
+        .parentOf("maternal-grandfather", "mother").parentOf("maternal-grandmother", "mother")
+        .parentOf("maternal-grandfather", "uncle").parentOf("maternal-grandmother", "uncle")
+        .parentOf("maternal-grandfather", "aunt").parentOf("maternal-grandmother", "aunt")
+        .married("grandfather", "grandmother").married("maternal-grandfather", "maternal-grandmother")
+        .married("father", "mother").married("uncle", "uncles-wife").married("aunt", "aunts-husband")
+        .build()
+
+    @Test
+    fun `both grandfathers stand on one row, however far back either line is recorded`() {
+        val layout = WholeTreeLayoutEngine.layout(lopsided())
+
+        assertEquals(
+            "a grandfather is a grandfather; how much survives above him cannot move his row",
+            layout.node("grandfather")!!.level,
+            layout.node("maternal-grandfather")!!.level,
+        )
+        assertEquals(
+            "and he belongs one row above his own daughter, not four",
+            layout.node("mother")!!.level - 1,
+            layout.node("maternal-grandfather")!!.level,
+        )
+    }
+
+    @Test
+    fun `siblings share a row whoever each of them married`() {
+        val layout = WholeTreeLayoutEngine.layout(lopsided())
+
+        val rows = listOf("mother", "uncle", "aunt").map { layout.node(it)!!.level }
+        assertEquals("three siblings, one generation, one row", 1, rows.distinct().size)
+    }
+
+    @Test
+    fun `every parent is exactly one row above every child`() {
+        val snapshot = lopsided()
+        val layout = WholeTreeLayoutEngine.layout(snapshot)
+
+        snapshot.parentEdges.forEach { (parent, child) ->
+            assertEquals(
+                "$child should sit exactly one row below $parent",
+                layout.node(parent)!!.level + 1,
+                layout.node(child)!!.level,
+            )
+        }
+    }
+
+    @Test
+    fun `a marriage that contradicts the generations still draws downward`() {
+        // Somebody married to their own aunt: one route says "same row", another "one row apart",
+        // and nothing satisfies both. The parent edges are what must not invert.
+        val snapshot = Builder()
+            .person("grandparent").person("parent").person("aunt").person("child")
+            .parentOf("grandparent", "parent").parentOf("grandparent", "aunt")
+            .parentOf("parent", "child")
+            .married("child", "aunt")
+            .build()
+
+        val layout = WholeTreeLayoutEngine.layout(snapshot)
+
+        snapshot.parentEdges.forEach { (parent, child) ->
+            assertTrue(
+                "$child is not below $parent",
+                layout.node(child)!!.level > layout.node(parent)!!.level,
+            )
+        }
+    }
 }

--- a/site/playground/layout.js
+++ b/site/playground/layout.js
@@ -43,99 +43,71 @@ const ROW_PITCH = METRICS.NODE_H + METRICS.LEVEL_GAP;
 /**
  * Puts every person on a generation.
  *
- * Spouses are unioned first so a married pair cannot land a row apart, then generations are the
- * longest path over parent edges between those unions. Longest rather than shortest: a person with
- * both a parent and a great-grandparent recorded belongs below the deeper of the two, or the
- * connector would run upward.
+ * A generation is a *relative* fact and nothing else: a child stands exactly one row below each
+ * parent, and spouses - and siblings whose parents nobody recorded - stand on the same row as each
+ * other. Those constraints are propagated outward from one seed per connected family, which fixes
+ * every generation exactly, because the offset between two people is the same along every route
+ * between them. Normalising each family against its own topmost member then gives the rows.
+ *
+ * It is worth saying what this deliberately is *not*, because the obvious alternative is wrong in a
+ * way that takes a real family to notice. Ranking people by their longest path down from the
+ * oldest ancestor on record - the textbook layering - makes a person's row depend on how far back
+ * their ancestry happens to be written down. A maternal grandfather whose own parents are unknown
+ * lands on the top row beside a great-great-grandfather on the other side of the family; worse, his
+ * three children come out on different rows from each other, because each was dragged down by
+ * however deep their spouse's ancestry ran. Generations are not depths. Two people are one
+ * generation apart or they are not, and how much of the record survives above them cannot change
+ * that.
  */
 function assignLevels(graph) {
-  const parentOf = new Map();
-  const find = (x) => {
-    let root = x;
-    while (parentOf.get(root) !== root) root = parentOf.get(root);
-    while (parentOf.get(x) !== root) { const next = parentOf.get(x); parentOf.set(x, root); x = next; }
-    return root;
-  };
-  const union = (a, b) => { const ra = find(a); const rb = find(b); if (ra !== rb) parentOf.set(ra, rb); };
-
-  for (const id of graph.order) parentOf.set(id, id);
-  for (const id of graph.order) for (const s of graph.spouses(id)) union(id, s.id);
-
-  // One vertex per spouse-union; parent edges become edges between unions.
-  const groupEdges = new Map();
-  const indegree = new Map();
-  for (const id of graph.order) { groupEdges.set(find(id), groupEdges.get(find(id)) ?? new Set()); indegree.set(find(id), 0); }
-  for (const id of graph.order) {
-    for (const c of graph.children(id)) {
-      const a = find(id);
-      const b = find(c.id);
-      if (a === b) continue;               // a couple who are also parent and child: ignore, unplaceable
-      const outs = groupEdges.get(a);
-      if (!outs.has(b)) { outs.add(b); indegree.set(b, indegree.get(b) + 1); }
-    }
-  }
-
   const level = new Map();
-  for (const g of groupEdges.keys()) level.set(g, 0);
 
-  // Kahn's order gives the longest path exactly in one pass.
-  const queue = [...indegree.keys()].filter((g) => indegree.get(g) === 0);
-  let head = 0;
-  let placed = 0;
-  while (head < queue.length) {
-    const g = queue[head++];
-    placed++;
-    for (const next of groupEdges.get(g)) {
-      level.set(next, Math.max(level.get(next), level.get(g) + 1));
-      indegree.set(next, indegree.get(next) - 1);
-      if (indegree.get(next) === 0) queue.push(next);
-    }
-  }
+  /*
+   * Every constraint, as an offset. Derived siblings need no edge of their own - sharing a parent
+   * already puts them on one row - but an explicit SIBLING edge exists precisely where the parents
+   * are unknown, and without it those two would float into separate families.
+   */
+  const steps = function* (id) {
+    for (const p of graph.parents(id)) yield [p.id, -1];
+    for (const c of graph.children(id)) yield [c.id, 1];
+    for (const s of graph.spouses(id)) yield [s.id, 0];
+    for (const s of graph.explicitSiblings.get(id)?.values() ?? []) yield [s.id, 0];
+  };
 
-  // Anything left sits in a cycle, which the app's rules forbid but a hand-edited file could hold.
-  // Relax it a bounded number of times so a broken file still draws instead of hanging.
-  if (placed < groupEdges.size) {
-    for (let pass = 0; pass < 40; pass++) {
-      let changed = false;
-      for (const [g, outs] of groupEdges) {
-        for (const next of outs) {
-          if (level.get(next) <= level.get(g)) { level.set(next, level.get(g) + 1); changed = true; }
-        }
+  for (const seed of graph.order) {
+    if (level.has(seed)) continue;
+    level.set(seed, 0);
+    const queue = [seed];
+    let head = 0;
+    while (head < queue.length) {
+      const current = queue[head++];
+      const base = level.get(current);
+      for (const [next, delta] of steps(current)) {
+        if (level.has(next)) continue;
+        level.set(next, base + delta);
+        queue.push(next);
       }
-      if (!changed) break;
     }
   }
 
   /*
-   * Longest-path ranking leaves slack: a person whose only child married into a much deeper part
-   * of the family gets stranded at the top of the chart with a connector three rows long. Pull
-   * every group down until it sits directly above its earliest child, which is as far as it can go
-   * without overtaking its own parents.
+   * The constraints can only disagree when the record itself does - somebody married to their own
+   * aunt gives one route saying "same row" and another saying "one row apart", and no assignment
+   * satisfies both. Where that happens the parent edge wins, because a connector running upward
+   * out of a child into their parent is unreadable in a way that a couple sitting a row apart is
+   * not. Bounded, so a cycle in a hand-edited file still draws instead of hanging.
    */
-  const groupParents = new Map();
-  for (const [g, outs] of groupEdges) {
-    for (const next of outs) {
-      if (!groupParents.has(next)) groupParents.set(next, new Set());
-      groupParents.get(next).add(g);
-    }
-  }
-  for (let pass = 0; pass < 8; pass++) {
+  for (let pass = 0; pass < 40; pass++) {
     let changed = false;
-    for (const [g, outs] of groupEdges) {
-      if (outs.size === 0) continue;
-      let earliestChild = Infinity;
-      for (const next of outs) earliestChild = Math.min(earliestChild, level.get(next));
-      let floor = 0;
-      for (const p of groupParents.get(g) ?? []) floor = Math.max(floor, level.get(p) + 1);
-      const want = earliestChild - 1;
-      if (want > level.get(g) && want >= floor) { level.set(g, want); changed = true; }
+    for (const id of graph.order) {
+      for (const c of graph.children(id)) {
+        if (level.get(c.id) <= level.get(id)) { level.set(c.id, level.get(id) + 1); changed = true; }
+      }
     }
     if (!changed) break;
   }
 
-  const levels = new Map();
-  for (const id of graph.order) levels.set(id, level.get(find(id)) ?? 0);
-  return levels;
+  return level;
 }
 
 /* ------------------------------------------------------------------ ordering within rows */

--- a/tools/check_layout.mjs
+++ b/tools/check_layout.mjs
@@ -93,6 +93,46 @@ async function run(name, { expectPhotos = false } = {}) {
   }
   check('children are drawn below their parents', inverted === 0, `${inverted} inverted`);
 
+  /*
+   * Stronger than "below": a child belongs exactly one row below each parent, and siblings belong
+   * on one row as each other. Ranking people by how far back their ancestry happens to be recorded
+   * satisfies the weaker check and still draws a wrong chart - a grandfather whose own parents are
+   * unknown lands on the top row beside a great-great-grandfather, and his children scatter across
+   * rows according to whom each of them married.
+   */
+  let notOneApart = 0;
+  for (const id of graph.order) {
+    const child = layout.byId.get(id);
+    for (const p of graph.parents(id)) {
+      const parent = layout.byId.get(p.id);
+      if (parent && child && child.level - parent.level !== 1) notOneApart++;
+    }
+  }
+  check('every parent is exactly one row above every child', notOneApart === 0,
+    `${notOneApart} edges spanning the wrong number of rows`);
+
+  let splitSiblings = 0;
+  for (const [parent, kids] of graph.childrenOf) {
+    const rows = new Set();
+    for (const c of kids.values()) {
+      const node = layout.byId.get(c.id);
+      if (node) rows.add(node.level);
+    }
+    if (rows.size > 1) splitSiblings++;
+  }
+  check('siblings share a row whoever each of them married', splitSiblings === 0,
+    `${splitSiblings} sets of siblings spread over more than one row`);
+
+  let splitCouples = 0;
+  for (const [a, set] of graph.spousesOf) {
+    for (const s of set.values()) {
+      const left = layout.byId.get(a);
+      const right = layout.byId.get(s.id);
+      if (a < s.id && left && right && left.level !== right.level) splitCouples++;
+    }
+  }
+  check('partners share a row', splitCouples === 0, `${splitCouples} couples split`);
+
   // Isolated people are the reason this page exists; they must be on the canvas.
   const isolatedPlaced = graph.isolated.every((id) => layout.byId.has(id));
   check('unconnected people are on the canvas', isolatedPlaced,


### PR DESCRIPTION
Reported against a real 148-person tree: a maternal grandfather sat on the **top row beside a great-great-grandfather** from the other side of the family, and his three children came out on three different rows.

## What was wrong

The whole-tree chart ranked people by their longest path down from the oldest ancestor on record — the textbook layering, and wrong for a family. It makes a person's row depend on how far back *their own* ancestry happens to be written down.

A grandfather whose parents nobody recorded is a root, so he goes to the top. His daughter is dragged down by however deep her husband's line runs; her brother, who married into a family with no recorded ancestry, stays near the top. Siblings on three rows, and every generation label a lie.

The compaction pass meant to absorb this **could not**: it pulls a group down to just above its *earliest* child, and the earliest of three children was already near the top, so it had nothing to do.

## The fix

Generations are not depths. Two people are one generation apart or they are not, and how much of the record survives above them cannot change that.

So the constraints are stated directly — a child exactly one row below each parent, spouses and explicitly-recorded siblings on the same row — and propagated outward from one seed per connected family. That fixes every row exactly, because the offset between two people is the same along every route between them.

Where the record contradicts itself — somebody married to their own aunt gives one route saying "same row" and another saying "one row apart" — the parent edge wins. A connector running upward out of a child is unreadable in a way that a couple sitting a row apart is not. There's a test.

The union-find over spouse groups, Kahn ranking and compaction pass all go; the replacement is shorter than what it replaces.

## On the reported tree

| | before | after |
|---|---|---|
| parent edges not exactly one row apart | 5 | **0** of 176 |
| sets of siblings split across rows | 5 | **0** |
| couples split across rows | 0 | 0 |

It now reads as a pyramid — 2 · 6 · 27 · 64 · 47 · 2 across six generations — and the maternal grandfather sits beside the paternal one, one row above his own daughter.

## Scope

The **focused** chart was already correct: it counts generations outward from the person in the middle, which is the same idea arrived at directly. Only the whole-tree engine and its browser twin needed changing.

## Testing

- 4 new unit tests, built on the shape that exposed this: both grandfathers on one row, siblings sharing a row whoever they married, every parent exactly one row up, and the contradictory-marriage case still drawing downward.
- `check_layout.mjs` gains the three invariants that would have caught this — all of which the old algorithm passed the *weaker* version of ("children below parents" was true the whole time).
- Full suite green: **130 unit, 104 instrumented, 0 failures**, lint clean.
- Verified by eye in the viewer against the reported file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)