### PR TITLE
Show a traced relation on its own, and call the departed Late

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ local.properties
 
 # Scratch imports and exports kept for debugging; never part of the repo.
 temp/
+
+# Kotlin build-tool scratch directory.
+.kotlin/

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ The chain is always shown and the word only when there is one, because the chain
 reader can check against their own memory. `Kinship` returns the term as a *structure*, not a
 string; the English lives in `ui/common/KinshipLabels.kt` with the rest of the app's words.
 
+**Shown on the chart, the line is drawn on its own** rather than lit up inside the whole tree.
+Fading the other hundred and forty people still leaves them on the page, and at the scale a whole
+family needs, a faded hundred and forty is what the eye actually sees. So the chart lays out just
+the people on the line — plus whoever holds it together, which is why `peopleToDraw` adds the parent
+two siblings are derived through: a sibling step carries no edge of its own, and without him the
+answer arrives as two loose cards. He is on the chart without being in the sentence. *Clear* puts
+the rest of the family back.
+
 ## The `.ftree` format
 
 A ZIP. Version 1:

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PersonFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PersonFlowTest.kt
@@ -178,8 +178,13 @@ class PersonFlowTest {
         )
 
         rule.onNodeWithTag(DeleteCompletelyTag).performClick()
-        rule.waitForIdle()
 
+        // Waiting for the empty state itself, not for idleness: the delete pops a screen, and the
+        // chart only calls itself empty once both the focused and the whole-tree view models have
+        // reported the tree gone. Idle can arrive a frame before the second of them does.
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Build your family tree").fetchSemanticsNodes().isNotEmpty()
+        }
         rule.onNodeWithText("Build your family tree").assertIsDisplayed()
     }
 

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationFinderTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationFinderTest.kt
@@ -1,5 +1,7 @@
 package com.vibethroughcode.ftree.ui
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasTestTag
@@ -189,6 +191,48 @@ class RelationFinderTest {
         rule.onNodeWithTag(TreeClearTraceTag).performClick()
         rule.waitUntil(5_000) {
             rule.onAllNodesWithText("Tracing how two people connect").fetchSemanticsNodes().isEmpty()
+        }
+    }
+
+    @Test
+    fun theTracedChartDrawsTheLineAndNobodyElse() {
+        seedFourPeople()
+        // Somebody with no part in the answer, who must not be on the chart while it is given.
+        runBlocking {
+            app.container.familyRepository.addPerson(
+                Person(name = "Sunita Rao", gender = Gender.FEMALE, birthDate = "1995")
+            )
+        }
+        openFinder()
+
+        pick(RelationSlotFromTag, "Ankit Kumar")
+        pick(RelationSlotToTag, "Meena Devi")
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationShowOnChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(RelationShowOnChartTag).performClick()
+
+        /*
+         * Four: Ankit, his father, his aunt, and the grandfather the two of them are siblings
+         * through. He is on the chart without being in the sentence — the sibling step has no edge
+         * of its own, so without him the answer would be two loose cards.
+         *
+         * Not Sunita. Fading her would still leave her on the page, and in a real tree that is a
+         * hundred and forty faded cards over the answer.
+         */
+        awaitChartOf(4)
+
+        rule.onNodeWithTag(TreeClearTraceTag).performClick()
+        awaitChartOf(5)
+    }
+
+    /** Waits for the whole-tree canvas to say, in its own words, how many people it is drawing. */
+    private fun awaitChartOf(people: Int) {
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(WholeFamilyChartTag).fetchSemanticsNodes().any { node ->
+                node.config.getOrNull(SemanticsProperties.ContentDescription)
+                    ?.any { it.contains("showing $people people") } == true
+            }
         }
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/FamilySnapshot.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/FamilySnapshot.kt
@@ -43,6 +43,23 @@ data class FamilySnapshot(
         }
     }.mapValues { (_, v) -> v.toList() }
 
+    /**
+     * The same graph cut down to [ids], keeping only the edges with both ends still in it.
+     *
+     * Used to draw one relation on its own. Everything derived — siblings especially — is derived
+     * again from what is left, so the cut-down graph states only what it can still show rather
+     * than remembering connections whose other end is no longer on the page.
+     */
+    fun restrictedTo(ids: Set<String>): FamilySnapshot {
+        fun List<Pair<String, String>>.kept() = filter { it.first in ids && it.second in ids }
+        return FamilySnapshot(
+            people = people.filterKeys { it in ids },
+            parentEdges = parentEdges.kept(),
+            spouseEdges = spouseEdges.kept(),
+            siblingEdges = siblingEdges.kept(),
+        )
+    }
+
     companion object {
         val Empty = FamilySnapshot(emptyMap(), emptyList(), emptyList(), emptyList())
     }

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
@@ -69,6 +69,33 @@ sealed interface Relation {
         fun peopleInvolved(fromId: String): Set<String> =
             buildSet { add(fromId); chain.forEach { add(it.personId) } }
 
+        /**
+         * The people a *chart* needs before it can draw this relation.
+         *
+         * The chain alone is not always drawable. Siblings are derived from the parent they share,
+         * so a sibling step carries no edge of its own: draw only the chain and two siblings arrive
+         * as two loose cards with nothing between them, which is precisely the question the reader
+         * asked. Their shared parent is the missing element, so it is drawn even though nobody
+         * would say it aloud when naming the relationship — "my father's sister" needs my
+         * grandfather on the page, and does not need him in the sentence.
+         *
+         * Nothing else is added. Everybody here is on the line or holds it together.
+         */
+        fun peopleToDraw(snapshot: FamilySnapshot, fromId: String): Set<String> = buildSet {
+            addAll(peopleInvolved(fromId))
+            var previous = fromId
+            chain.forEach { step ->
+                if (step.kind == StepKind.SIBLING) {
+                    val mine = snapshot.parentsOf[previous].orEmpty()
+                    val theirs = snapshot.parentsOf[step.personId].orEmpty().toSet()
+                    // An explicit sibling edge has no parents to add, and needs none: it carries
+                    // its own bracket, drawn exactly because the parents are not known.
+                    addAll(mine.filter { it in theirs })
+                }
+                previous = step.personId
+            }
+        }
+
         /** Joined only by a marriage somewhere along the way, with no blood between them. */
         val byMarriage: Boolean
             get() = term == null && chain.any { it.kind == StepKind.SPOUSE }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -130,6 +130,7 @@ fun FTreeApp() {
             composable<TreeRoute> { entry ->
                 TreeScreen(
                     trace = entry.toRoute<TreeRoute>().trace,
+                    startWhole = entry.toRoute<TreeRoute>().whole,
                     onOpenPerson = { navController.navigate(PersonRoute(it)) },
                     onAddPerson = { navController.navigate(EditPersonRoute()) },
                     onAddRelative = { anchorId, kind ->
@@ -139,7 +140,7 @@ fun FTreeApp() {
                     // Dropping the trace means going back to the plain chart, which is where
                     // clearing a highlight should leave you — not one screen further back.
                     onClearTrace = {
-                        navController.navigate(TreeRoute()) {
+                        navController.navigate(TreeRoute(whole = true)) {
                             popUpTo<TreeRoute> { inclusive = true }
                         }
                     },

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/Navigation.kt
@@ -27,6 +27,14 @@ data class TreeRoute(
      * silently relight a line from a question asked an hour ago.
      */
     val trace: List<String> = emptyList(),
+    /**
+     * Open on the whole-tree chart rather than the focused one.
+     *
+     * Set when a traced line is cleared. Clearing means "put the rest of the family back", so it
+     * has to land on the chart that holds them; dropping onto the focused chart instead reads as
+     * the chart having vanished along with the answer.
+     */
+    val whole: Boolean = false,
 )
 
 @Serializable

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonRow.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonRow.kt
@@ -13,9 +13,11 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
@@ -68,7 +70,7 @@ fun PersonRow(
             }
         }
 
-        person.lifespanLabel()?.let { years ->
+        person.lifespanLabel(stringResource(R.string.person_late))?.let { years ->
             Text(
                 text = years,
                 style = FTreeText.record,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonUi.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonUi.kt
@@ -15,12 +15,16 @@ fun Person.displayName(): String =
 fun Person.initial(): String = name?.trim()?.firstOrNull()?.uppercase().orEmpty()
 
 /**
- * The compact life span shown beside a name: `1938–2010`, `1938–`, `b. 1990`, or nothing.
+ * The compact life span shown beside a name: `1938–2010`, `1938–`, `1990`, `Late`, or nothing.
  *
  * Only years, because that is the precision a list can show without becoming a table, and an
  * en dash because this is a span rather than a subtraction.
+ *
+ * [late] is the word for somebody known to have died with no date recorded. It is passed in rather
+ * than read here so this stays usable off the main thread and out of a composable, and so the one
+ * piece of user-facing English in it lives in the string resources with the rest.
  */
-fun Person.lifespanLabel(): String? {
+fun Person.lifespanLabel(late: String = "Late"): String? {
     val born = PartialDate.parse(birthDate)?.year
     val died = PartialDate.parse(deathDate)?.year
     return when {
@@ -28,7 +32,7 @@ fun Person.lifespanLabel(): String? {
         born != null && deceased -> "$born–"
         born != null -> born.toString()
         died != null -> "–$died"
-        deceased -> "died"
+        deceased -> late
         else -> null
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationViewModel.kt
@@ -89,8 +89,10 @@ class RelationViewModel(
             sharedAncestor = found?.sharedAncestorId
                 ?.takeIf { it != from && it != to }
                 ?.let(graph.people::get),
+            // What the chart is asked to draw, which is the chain plus whatever holds it
+            // together — not the same set as the chain listed on this screen.
             trace = if (found != null && from != null) {
-                found.peopleInvolved(from).toList()
+                found.peopleToDraw(graph, from).toList()
             } else emptyList(),
             peopleCount = graph.people.size,
         )

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -92,6 +92,8 @@ fun TreeScreen(
     modifier: Modifier = Modifier,
     /** The people on a relation to draw: both ends and everyone between. Empty is the usual case. */
     trace: List<String> = emptyList(),
+    /** Open on the whole-tree chart — set when a traced line has just been cleared. */
+    startWhole: Boolean = false,
     viewModel: TreeViewModel = viewModel(factory = FTreeViewModels.Factory),
     wholeTreeViewModel: WholeTreeViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
@@ -100,7 +102,9 @@ fun TreeScreen(
     val highlighted by wholeTreeViewModel.highlighted.collectAsStateWithLifecycle()
     val wholeSelection by wholeTreeViewModel.selected.collectAsStateWithLifecycle()
 
-    var mode by rememberSaveable { mutableStateOf(ChartMode.FOCUSED) }
+    var mode by rememberSaveable {
+        mutableStateOf(if (startWhole) ChartMode.WHOLE else ChartMode.FOCUSED)
+    }
     var selected by remember { mutableStateOf<Person?>(null) }
     val sheetState = rememberModalBottomSheetState()
 
@@ -110,6 +114,10 @@ fun TreeScreen(
      * arriving with a trace switches charts rather than showing an empty highlight.
      */
     val tracing = remember(trace) { trace.toSet() }
+
+    // The chart draws the traced line on its own rather than lighting it inside the whole record,
+    // so the view model has to know before it lays anything out.
+    LaunchedEffect(trace) { wholeTreeViewModel.onTraceChanged(trace) }
     LaunchedEffect(tracing) {
         if (tracing.isNotEmpty()) {
             mode = ChartMode.WHOLE
@@ -201,8 +209,9 @@ fun TreeScreen(
                     else -> WholeFamilyChart(
                         layout = wholeState.layout,
                         selectedId = wholeSelection?.id,
-                        highlighted = if (tracing.isNotEmpty()) tracing else highlighted,
-                        frameOn = tracing,
+                        // Nothing to fade while tracing: everybody drawn is on the line.
+                        highlighted = if (tracing.isNotEmpty()) emptySet() else highlighted,
+                        tracing = tracing.isNotEmpty(),
                         onSelect = {
                             wholeTreeViewModel.select(it)
                             selected = it

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -62,9 +62,14 @@ fun WholeFamilyChart(
     modifier: Modifier = Modifier,
     selectedId: String? = null,
     highlighted: Set<String> = emptySet(),
-    frameOn: Set<String> = emptySet(),
+    /** True when [layout] holds one traced relation rather than the whole record. */
+    tracing: Boolean = false,
 ) {
-    val description = stringResource(R.string.a11y_whole_chart, layout.nodes.size, layout.unconnectedCount)
+    val description = if (tracing) {
+        stringResource(R.string.a11y_traced_chart, layout.nodes.size)
+    } else {
+        stringResource(R.string.a11y_whole_chart, layout.nodes.size, layout.unconnectedCount)
+    }
     val density = LocalDensity.current
     val measurer = rememberTextMeasurer()
     val colors = MaterialTheme.colorScheme
@@ -91,8 +96,8 @@ fun WholeFamilyChart(
      * a card would be too small to carry a name it stops being a chart and becomes a texture, so
      * beyond that the view opens at a readable scale on the largest family instead.
      */
-    LaunchedEffect(layout, viewport, frameOn) {
-        if (viewport == IntSize.Zero || layout.isEmpty || frameOn.isNotEmpty()) return@LaunchedEffect
+    LaunchedEffect(layout, viewport) {
+        if (viewport == IntSize.Zero || layout.isEmpty) return@LaunchedEffect
         with(density) {
             val chartWidth = layout.width.dp.toPx()
             val chartHeight = layout.height.dp.toPx()
@@ -126,38 +131,6 @@ fun WholeFamilyChart(
                     },
                 )
             }
-        }
-    }
-
-    /*
-     * Framing on a named few — the people on a traced relation.
-     *
-     * A highlight is no use if it lands off screen, and the general framing above has no reason to
-     * put a line between two distant cousins in view. This fits their bounding box instead, capped
-     * so that two people who happen to sit side by side do not open at absurd magnification.
-     */
-    LaunchedEffect(layout, viewport, frameOn) {
-        if (viewport == IntSize.Zero || layout.isEmpty || frameOn.isEmpty()) return@LaunchedEffect
-        val nodes = frameOn.mapNotNull { layout.node(it) }
-        if (nodes.isEmpty()) return@LaunchedEffect
-
-        val left = nodes.minOf { it.x }
-        val top = nodes.minOf { it.y }
-        val right = nodes.maxOf { it.x } + TreeMetrics.NODE_WIDTH
-        val bottom = nodes.maxOf { it.y } + TreeMetrics.NODE_HEIGHT
-        with(density) {
-            val margin = 32.dp.toPx()
-            val boxWidth = (right - left).dp.toPx()
-            val boxHeight = (bottom - top).dp.toPx()
-            val fit = minOf(
-                (viewport.width - margin * 2) / boxWidth,
-                (viewport.height - margin * 2) / boxHeight,
-            ).coerceIn(MIN_ZOOM, MAX_FIT)
-            zoom = fit
-            pan = Offset(
-                (viewport.width - boxWidth * fit) / 2f - left.dp.toPx() * fit,
-                (viewport.height - boxHeight * fit) / 2f - top.dp.toPx() * fit,
-            )
         }
     }
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeTreeViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeTreeViewModel.kt
@@ -32,6 +32,8 @@ data class WholeTreeUiState(
     val unconnectedCount: Int = 0,
     val unnamedCount: Int = 0,
     val generations: Int = 0,
+    /** True while [layout] holds one traced relation rather than the whole record. */
+    val tracing: Boolean = false,
 ) {
     val isEmpty: Boolean get() = !loading && peopleCount == 0
 }
@@ -44,20 +46,36 @@ class WholeTreeViewModel(private val repository: FamilyRepository) : ViewModel()
     private val snapshot: StateFlow<FamilySnapshot> = repository.observeWholeGraph()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), FamilySnapshot.Empty)
 
-    val uiState: StateFlow<WholeTreeUiState> = snapshot
-        .map { snapshot ->
-            // Laying out a few thousand people is not main-thread work.
-            val layout = WholeTreeLayoutEngine.layout(snapshot)
-            WholeTreeUiState(
-                loading = false,
-                layout = layout,
-                peopleCount = snapshot.people.size,
-                familyCount = layout.groups.count { !it.unconnected },
-                unconnectedCount = layout.unconnectedCount,
-                unnamedCount = snapshot.people.values.count { it.isUnnamed },
-                generations = layout.generations,
-            )
-        }
+    private val trace = MutableStateFlow<Set<String>>(emptySet())
+
+    /**
+     * The people on a relation being traced, or nothing.
+     *
+     * A traced line is drawn *on its own* rather than lit up inside the whole chart. Fading the
+     * other hundred and forty people still leaves them on the page, and at the scale a whole
+     * family needs, a faded hundred and forty is what the eye actually sees. The question was how
+     * two people connect; the answer is those people and the ones holding the line together.
+     */
+    fun onTraceChanged(ids: List<String>) {
+        trace.value = ids.toSet()
+    }
+
+    val uiState: StateFlow<WholeTreeUiState> = combine(snapshot, trace) { whole, traced ->
+        val shown = if (traced.isEmpty()) whole else whole.restrictedTo(traced)
+        // Laying out a few thousand people is not main-thread work.
+        val layout = WholeTreeLayoutEngine.layout(shown)
+        WholeTreeUiState(
+            loading = false,
+            layout = layout,
+            // The counts describe the record, not the cutting of it currently on screen.
+            peopleCount = whole.people.size,
+            familyCount = layout.groups.count { !it.unconnected },
+            unconnectedCount = layout.unconnectedCount,
+            unnamedCount = whole.people.values.count { it.isUnnamed },
+            generations = layout.generations,
+            tracing = traced.isNotEmpty(),
+        )
+    }
         .flowOn(Dispatchers.Default)
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), WholeTreeUiState())
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,10 @@
     <string name="person_unknown_of">Unknown %1$s</string>
     <string name="person_edit">Edit</string>
     <string name="person_born">Born %1$s</string>
-    <string name="person_died">Died %1$s</string>
+    <!-- Shown where a lifespan would go for somebody with no dates recorded. The
+         honorific, not a verb: it is read directly after the name. -->
+    <string name="person_late">Late</string>
+    <string name="person_died">Passed away %1$s</string>
     <string name="person_age">%1$d years old</string>
     <string name="person_age_at_death">%1$d years old</string>
     <string name="person_no_dates">No dates recorded</string>
@@ -40,7 +43,7 @@
     <string name="edit_name_hint">Leave blank if you don\'t know it</string>
     <string name="edit_gender">Gender</string>
     <string name="edit_born">Born</string>
-    <string name="edit_died">Died</string>
+    <string name="edit_died">Passed away</string>
     <string name="edit_date_hint">Year, or a fuller date</string>
     <string name="edit_date_support">1938, 1938-04, or 1938-04-17</string>
     <string name="edit_date_invalid">Use a year like 1938, or 1938-04-17</string>
@@ -243,6 +246,7 @@
     <string name="whole_unconnected_note">%1$d of these has no recorded relatives. The other chart cannot show them at all.</string>
     <string name="whole_unconnected_note_plural">%1$d of these have no recorded relatives. The other chart cannot show them at all.</string>
     <string name="a11y_whole_chart">Chart of the whole tree, showing %1$d people, %2$d of whom have no recorded relatives. Use the people list for a readable list of everyone and their relationships.</string>
+    <string name="a11y_traced_chart">Chart of one relation, showing %1$d people on the line between two of them.</string>
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/KinshipTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/KinshipTest.kt
@@ -306,4 +306,88 @@ class KinshipTest {
         assertEquals(KinshipTerm.Sibling, relation.term)
         assertEquals("measured through the mother who is actually recorded", "mum", relation.sharedAncestorId)
     }
+
+    /* -------------------------------------------------- what a chart needs to draw the answer */
+
+    @Test
+    fun `drawing two siblings needs the parent they are derived from`() {
+        // Siblings are derived from a shared parent, so the sibling step carries no edge of its
+        // own. Drawn without him, an aunt and a father are two loose cards with nothing between.
+        val snapshot = Builder()
+            .person("me", "dad", "aunt", "grandad")
+            .parentOf("grandad", "dad").parentOf("grandad", "aunt")
+            .parentOf("dad", "me")
+            .build()
+
+        val relation = Kinship.relate(snapshot, "me", "aunt") as Relation.Found
+
+        assertEquals(
+            "the chain itself says nothing about the grandfather",
+            setOf("me", "dad", "aunt"),
+            relation.peopleInvolved("me"),
+        )
+        assertEquals(
+            "but the chart cannot join the two of them without him",
+            setOf("me", "dad", "aunt", "grandad"),
+            relation.peopleToDraw(snapshot, "me"),
+        )
+    }
+
+    @Test
+    fun `an explicit sibling edge needs nobody added, because it draws its own bracket`() {
+        val snapshot = Builder()
+            .person("me", "dad", "aunt")
+            .parentOf("dad", "me")
+            .siblingOf("dad", "aunt")
+            .build()
+
+        val relation = Kinship.relate(snapshot, "me", "aunt") as Relation.Found
+
+        assertEquals(setOf("me", "dad", "aunt"), relation.peopleToDraw(snapshot, "me"))
+    }
+
+    @Test
+    fun `nobody off the line is dragged in`() {
+        val snapshot = Builder()
+            .person("me", "dad", "mum", "grandad", "granny", "stranger")
+            .parentOf("dad", "me").parentOf("mum", "me")
+            .parentOf("grandad", "dad").parentOf("granny", "dad")
+            .married("dad", "mum").married("grandad", "granny")
+            .person("cousin").parentOf("grandad", "uncle").person("uncle")
+            .parentOf("uncle", "cousin")
+            .build()
+
+        val drawn = (Kinship.relate(snapshot, "me", "grandad") as Relation.Found)
+            .peopleToDraw(snapshot, "me")
+
+        assertEquals(setOf("me", "dad", "grandad"), drawn)
+        listOf("mum", "granny", "stranger", "uncle", "cousin").forEach {
+            assertFalse("$it is not on the line and must not be drawn", it in drawn)
+        }
+    }
+
+    @Test
+    fun `the drawn people still form one connected chart`() {
+        val snapshot = Builder()
+            .person("me", "dad", "aunt", "grandad", "noise-a", "noise-b")
+            .parentOf("grandad", "dad").parentOf("grandad", "aunt")
+            .parentOf("dad", "me")
+            .parentOf("noise-a", "noise-b")
+            .build()
+
+        val drawn = (Kinship.relate(snapshot, "me", "aunt") as Relation.Found)
+            .peopleToDraw(snapshot, "me")
+        val cut = snapshot.restrictedTo(drawn)
+
+        assertEquals(drawn.size, cut.people.size)
+        assertEquals("only edges with both ends still present", 3, cut.parentEdges.size)
+        // One family, not four loose cards: the whole point of keeping the shared parent.
+        val layout = WholeTreeLayoutEngine.layout(cut)
+        assertEquals(0, layout.unconnectedCount)
+        assertEquals(
+            "and it reads top-down: grandfather, then his children, then me",
+            3,
+            layout.generations,
+        )
+    }
 }

--- a/site/playground/main.js
+++ b/site/playground/main.js
@@ -10,6 +10,7 @@
 import { readTreeFile, ArchiveError, canDecompress } from './archive.js';
 import {
   buildGraph, relationsOf, relate, displayName, displayDate, lifespan, initials, ageOf,
+  peopleToDraw, restrictedGraph,
 } from './model.js';
 import { layoutArchive } from './layout.js';
 import { Chart } from './chart.js';
@@ -26,6 +27,8 @@ const state = {
   view: 'chart',
   relateA: null,
   relateB: null,
+  /** The people on a traced relation while the chart is showing that alone. */
+  trace: null,
   photoUrls: new Map(),
 };
 
@@ -101,6 +104,7 @@ async function openFile(file) {
     state.selected = null;
     state.relateA = null;
     state.relateB = null;
+    state.trace = null;
 
     chart.load(graph, layout, archive);
     viewer.dataset.state = 'loaded';
@@ -158,6 +162,7 @@ function closeFile() {
   releasePhotos();
   state.graph = null;
   state.layout = null;
+  state.trace = null;
   state.archive = null;
   state.selected = null;
   chart.layout = null;
@@ -182,21 +187,26 @@ function select(id, { centre = true, quiet = false } = {}) {
   }
   state.selected = id;
   chart.selected = id;
-  chart.pathIds = null;
 
-  // Everyone one step away stays at full strength; the rest fade, which is what makes a person
-  // findable in a chart with two thousand cards on it.
-  const near = new Set([id]);
-  for (const p of state.graph.parents(id)) near.add(p.id);
-  for (const c of state.graph.children(id)) near.add(c.id);
-  for (const s of state.graph.spouses(id)) near.add(s.id);
-  for (const s of state.graph.siblings(id)) near.add(s.id);
-  chart.related = near;
+  // While a line is traced, everybody drawn is already on it, and fading part of the answer the
+  // reader came to look at would be throwing it away.
+  if (!state.trace) {
+    // Everyone one step away stays at full strength; the rest fade, which is what makes a person
+    // findable in a chart with two thousand cards on it.
+    const near = new Set([id]);
+    for (const p of state.graph.parents(id)) near.add(p.id);
+    for (const c of state.graph.children(id)) near.add(c.id);
+    for (const s of state.graph.spouses(id)) near.add(s.id);
+    for (const s of state.graph.siblings(id)) near.add(s.id);
+    chart.related = near;
+  }
 
   if (centre && state.view === 'chart') chart.centreOn(id, Math.max(chart.scale, 0.7));
   chart.invalidate();
   renderPanel(id);
-  if (!quiet) $('relate').hidden = true;
+  // Tapping somebody while a line is traced keeps both the line and the panel that explains it;
+  // closing the answer the reader just asked for would be the wrong way to read a tap.
+  if (!quiet && !state.trace) $('relate').hidden = true;
 }
 
 /* ------------------------------------------------------------------ the person panel */
@@ -237,7 +247,7 @@ function renderPanel(id) {
 
   const facts = [];
   if (person.birthDate) facts.push(['Born', escape(displayDate(person.birthDate) ?? person.birthDate)]);
-  if (person.deathDate) facts.push(['Died', escape(displayDate(person.deathDate) ?? person.deathDate)]);
+  if (person.deathDate) facts.push(['Passed away', escape(displayDate(person.deathDate) ?? person.deathDate)]);
   if (age !== null) facts.push([person.deceased ? 'Lived' : 'Age', `${age} years`]);
   if (person.gender && person.gender !== 'UNSPECIFIED') {
     facts.push(['Gender', escape(person.gender[0] + person.gender.slice(1).toLowerCase())]);
@@ -357,6 +367,32 @@ function wireSearch() {
 
 /* ------------------------------------------------------------------ relate */
 
+/**
+ * Shows one relation on its own.
+ *
+ * Not a highlight inside the whole chart. Fading the other hundred and forty people still leaves
+ * them on the page, and at the scale a whole family needs, a faded hundred and forty is what the
+ * eye actually sees. The question was how two people connect, so the answer is those people and
+ * the ones holding the line together, laid out by themselves.
+ *
+ * `state.layout` deliberately keeps pointing at the whole archive: the index and the counts are
+ * describing the file, not the cutting of it currently on screen.
+ */
+function drawTrace(ids) {
+  state.trace = ids;
+  const cut = restrictedGraph(state.graph, ids);
+  chart.load(cut, layoutArchive(cut), state.archive);
+  chart.fit();
+}
+
+function clearTrace() {
+  if (!state.trace) return;
+  state.trace = null;
+  chart.load(state.graph, state.layout, state.archive);
+  chart.fit();
+}
+
+
 function wireRelate() {
   for (const slot of ['a', 'b']) {
     const input = $(`relate-${slot}`);
@@ -377,7 +413,7 @@ function wireRelate() {
 function renderRelation() {
   const box = $('relate-answer');
   const { relateA: a, relateB: b } = state;
-  if (!a || !b) { box.innerHTML = ''; chart.pathIds = null; chart.invalidate(); return; }
+  if (!a || !b) { box.innerHTML = ''; clearTrace(); chart.invalidate(); return; }
 
   const from = state.graph.people.get(a);
   const to = state.graph.people.get(b);
@@ -391,7 +427,7 @@ function renderRelation() {
     box.innerHTML = `<p class="r-term r-none">Nothing in this file connects
       <b>${nameHtml(from)}</b> to <b>${nameHtml(to)}</b>. They may still be related — the record
       simply does not say how.</p>`;
-    chart.pathIds = null;
+    clearTrace();
     chart.invalidate();
     return;
   }
@@ -426,12 +462,8 @@ function renderRelation() {
         </li>`).join('')}
     </ol>`;
 
-  // Light the chain up on the chart, and frame both ends of it.
-  chart.pathIds = new Set([a, ...result.path.map((s) => s.id)]);
-  chart.related = chart.pathIds;
-  chart.selected = null;
-  chart.invalidate();
-  if (state.view === 'chart') chart.centreOn(a, Math.max(chart.scale, 0.5));
+  // The chart shows this line and nothing else.
+  drawTrace(peopleToDraw(state.graph, a, result.path));
 }
 
 function openRelate(seed) {
@@ -638,13 +670,11 @@ function wireChrome() {
 
   $('relate-btn').addEventListener('click', () => {
     if ($('relate').hidden) openRelate(state.selected);
-    else $('relate').hidden = true;
+    else { $('relate').hidden = true; clearTrace(); }
   });
   $('relate-close').addEventListener('click', () => {
     $('relate').hidden = true;
-    chart.pathIds = null;
-    chart.related = null;
-    chart.invalidate();
+    clearTrace();
   });
   $('panel-close').addEventListener('click', () => select(null));
   $('shortcuts-close').addEventListener('click', () => { $('shortcuts').hidden = true; });
@@ -697,7 +727,7 @@ function wireKeys() {
 
     if (e.key === 'Escape') {
       if (!$('shortcuts').hidden) { $('shortcuts').hidden = true; return; }
-      if (!$('relate').hidden) { $('relate').hidden = true; chart.pathIds = null; chart.related = null; chart.invalidate(); return; }
+      if (!$('relate').hidden) { $('relate').hidden = true; clearTrace(); return; }
       if (!$('panel').hidden) { select(null); return; }
       if (typing) e.target.blur();
       return;

--- a/site/playground/model.js
+++ b/site/playground/model.js
@@ -215,14 +215,19 @@ export function birthYear(person) {
   return m ? Number(m[1]) : null;
 }
 
-/** The short line under a name on the chart. */
+/**
+ * The short line under a name on the chart.
+ *
+ * "Late" rather than "died" where nothing but the fact is known: it sits directly beneath the name
+ * and is read as part of it, so the honorific is both the respectful word and the grammatical one.
+ */
 export function lifespan(person) {
   const b = /^(\d{4})/.exec(person.birthDate ?? '')?.[1];
   const d = /^(\d{4})/.exec(person.deathDate ?? '')?.[1];
   if (b && d) return `${b}–${d}`;
   if (b) return person.deceased ? `${b}–` : b;
   if (d) return `–${d}`;
-  return person.deceased ? 'died' : '';
+  return person.deceased ? 'Late' : '';
 }
 
 /** Whole years lived, or reached so far. Derived, never stored, exactly as the app does it. */
@@ -469,6 +474,48 @@ function shortestPath(graph, fromId, toId) {
     else if (step.via === 'child') label = childLabel(person, step.subtype).toLowerCase();
     else if (step.via === 'spouse') label = spouseLabel(person, step.subtype).toLowerCase();
     else label = siblingLabel(person, step.half).toLowerCase();
-    return { id: step.id, label };
+    // `via` is carried through: a chart needs to know which steps are sibling ones, because those
+    // are the steps with no edge of their own to draw.
+    return { id: step.id, label, via: step.via };
+  });
+}
+
+/**
+ * The people a chart needs before it can draw a relation.
+ *
+ * The chain alone is not always drawable. Siblings are derived from the parent they share, so a
+ * sibling step carries no edge of its own: draw only the chain and two siblings arrive as two loose
+ * cards with nothing between them, which is precisely the question the reader asked. Their shared
+ * parent is the missing element, so it is drawn - "my father's sister" needs my grandfather on the
+ * page and does not need him in the sentence. An explicit sibling edge needs nobody added; it
+ * carries its own bracket, drawn exactly because the parents are not known.
+ */
+export function peopleToDraw(graph, fromId, path) {
+  const drawn = new Set([fromId]);
+  let previous = fromId;
+  for (const step of path) {
+    drawn.add(step.id);
+    if (step.via === 'sibling') {
+      const theirs = new Set(graph.parents(step.id).map((p) => p.id));
+      for (const p of graph.parents(previous)) if (theirs.has(p.id)) drawn.add(p.id);
+    }
+    previous = step.id;
+  }
+  return drawn;
+}
+
+/**
+ * The same archive cut down to a set of people, keeping only the edges with both ends still in it.
+ *
+ * Rebuilt from a filtered document rather than by trimming the graph in place, so everything
+ * derived - siblings especially - is derived again from what is left, and the cut-down graph states
+ * only what it can still show.
+ */
+export function restrictedGraph(graph, ids) {
+  const keep = ids instanceof Set ? ids : new Set(ids);
+  return buildGraph({
+    ...graph.doc,
+    people: graph.doc.people.filter((p) => keep.has(p.id)),
+    relationships: graph.doc.relationships.filter((r) => keep.has(r.from) && keep.has(r.to)),
   });
 }


### PR DESCRIPTION
Two requested changes to the same screenful.

## "Late" rather than "died"

The blunt word showed up where a lifespan would go for somebody known to have died with no dates recorded — under their name on a card, and down the chain of a relation.

**"Late"** is the respectful word and, sitting directly beneath a name and read as part of it, the grammatical one: it is the honorific, not a verb.

**One deviation, flagged:** where the word labels a *date* it cannot be the honorific — "Late 12 March 1978" is not English — so the person page and the edit field say **"Passed away"**. Same register, correct grammar. Say the word if you'd rather have "Late" literally everywhere and I'll change those two.

The word was also *hardcoded in Kotlin*, which is its own small bug. It now lives in the string resources with the rest of the app's English.

## A traced line is drawn on its own

Lighting the line inside the whole chart and fading the rest sounds like focus and isn't. Fading a hundred and forty people still leaves them on the page, and at the scale a whole family needs, a faded hundred and forty is what the eye actually sees.

So the chart now lays out **just the people on the line**.

Not quite *only* them, and this is the interesting part. A sibling step carries no edge of its own — siblings are derived from the parent they share — so drawing the chain alone puts an aunt and a father on screen as two loose cards with nothing between them, which is precisely the question that was asked. `peopleToDraw` adds the parent they are derived through: **on the chart without being in the sentence**, because "my father's sister" needs my grandfather on the page and not in the words. An explicit sibling edge adds nobody — it has its own bracket already, drawn exactly because the parents are unknown.

On the reported 148-person tree, a first-cousin trace draws **6 people across 3 generations on a 644×522 canvas**, in place of six lit cards adrift in 14523×978 of fade.

**Clearing now returns to the whole-tree chart** rather than the focused one. It always dropped to the focused chart, which was survivable while tracing was a highlight; now that tracing replaces what the chart holds, *Clear* means "put the rest of the family back" and has to land somewhere that has them.

## Testing

- 4 new unit tests on `peopleToDraw`: the derived-sibling case, the explicit-sibling case, nobody off the line being dragged in, and the drawn set still forming one connected chart rather than loose cards.
- 1 new instrumented test asserting the canvas's own description — 4 people while tracing, 5 after clearing — so "only the line" is checked against what is actually drawn.
- Fixes a **pre-existing flake** in `PersonFlowTest`, same family as the ones fixed before: it asserted the empty state right after idleness, and the chart only calls itself empty once both view models report the tree gone.
- Full suite green: **134 unit, 105 instrumented, 0 failures**, lint clean.
- Verified by hand in the browser viewer against the reported file, both directions.

Mirrored in the viewer, so the app and the browser keep giving one answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)