### PR TITLE
chore: version 0.2.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 3
-        versionName = "0.2.0"
+        versionCode = 4
+        versionName = "0.2.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to 0.2.1 and `versionCode` to 4.

**Why this can't wait.** 0.2.0 was tagged at `220cbc1`, and both of the chart fixes merged after it — so the APK people can download right now still puts a grandfather whose own parents are unknown on the top row beside a great-great-grandfather, and scatters his children across separate rows.

Since 0.2.0 this adds:

- [#33](https://github.com/thisisankit27/f-tree/pull/33) — generations are relative offsets, not ancestral depth
- [#34](https://github.com/thisisankit27/f-tree/pull/34) — a traced relation draws only the line; "Late" rather than "died"

A patch rather than a minor: nothing here is a new capability. It corrects a chart that drew real families wrongly, and refines what 0.2.0 shipped hours earlier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)