### PR TITLE
No frame label over the header while a line is traced

### DIFF
--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -168,7 +168,12 @@ fun WholeFamilyChart(
             currentZoom < SHOW_YEARS -> CardDetail.NAME
             else -> CardDetail.NAME_AND_YEARS
         }
-        val showLabels = currentZoom >= SHOW_LABELS
+        /*
+         * No frame labels while a line is traced. There is exactly one group and it is the answer,
+         * so "3 people · 3 generations" restates the header directly above it — and, drawn above a
+         * group that now sits at the very top of a small chart, collides with it.
+         */
+        val showLabels = currentZoom >= SHOW_LABELS && !tracing
         val dimming = highlighted.isNotEmpty()
 
         val visible = Rect(


### PR DESCRIPTION
Caught while exercising the release build before tagging 0.2.1 — the check earning its keep again.

The whole-tree chart labels each family frame with *"N people · M generations"*, drawn just above the frame's top edge. That was written for a chart of many families, where the frames sit well down the canvas.

A traced line is a single small group that opens centred near the top, so the label lands on the header row and prints itself straight through *"Tracing how two people connect"*:

```
Tracing how₃twᴏ ᴘeᴏple connecᴛ generations
       3 people · 3
```

It shouldn't be drawn there at all. Tracing puts exactly one group on screen and it **is** the answer, so labelling it restates the line directly above it. One condition fixes the collision and the redundancy together.

## Testing

- Verified on the emulator: header now reads *"Tracing how two people connect · Clear"* alone.
- Full suite green: **134 unit, 105 instrumented, 0 failures**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)