### PR TITLE
chore: version 0.2.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 4
-        versionName = "0.2.1"
+        versionCode = 5
+        versionName = "0.2.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to 0.2.2 and `versionCode` to 5, which is what lets the tag be cut — [`release.yml`](.github/workflows/release.yml) refuses a tag that disagrees with the app's own version.

Since 0.2.1: [#37](https://github.com/thisisankit27/f-tree/pull/37) — relationships through a marriage are named where English names them, said plainly where it does not, and left to the chain where nothing can be said.

Tagging happens after this merges, not before; 0.2.0 shipped with a bug still in review because that order got reversed once already.

🤖 Generated with [Claude Code](https://claude.com/claude-code)