### PR TITLE
Faces on the chart, and a landscape that is mostly chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ replacing it**.
   it over the running copy, so a new version keeps your tree instead of costing an export and an
   import.
 - **Export and import as a single `.ftree` file**, with merge semantics that never overwrite.
+- **Faces on the chart.** Every card carries a portrait, framed in a circle when the photograph was
+  added and a coloured initial when it was not. Photographs can be switched off for a very large
+  tree without a single card moving.
 - **Photos**, stored inside the app and carried in the export.
 
 ## Build
@@ -143,6 +146,32 @@ nothing else, and offscreen nodes cost a bounds check each.
 Notation: marriage is a doubled rule, a couple's children hang from one connector while a
 half-sibling hangs from their own, and a person with no name has a dashed brass edge — the gap is in
 what the family remembers, not a fault in the record.
+
+Every card opens with a circular portrait. With a photograph it is the square the reader framed;
+without one it is the person's initial on a ground coloured by gender, so a chart of a hundred
+faceless cards still reads as people rather than as a wall of identical discs. A person whose name
+was never recorded keeps the dashed brass ring they have everywhere else. The disc is part of the
+card at every zoom and whether or not photographs are switched on, which is what lets
+**Settings → Photos on the chart** be turned off on a very large tree without anybody moving.
+
+Photographs on a drawn surface have no `AsyncImage` to hang from, so `ui/tree/ChartPhotos.kt` is the
+equivalent for a canvas: it asks only for the faces the viewport can see, decodes them off the main
+thread at 160px in `RGB_565` — about fifty kilobytes each — and holds them in snapshot state, so a
+face arriving re-runs the draw phase and nothing else. What is held is capped, so panning across a
+thousand people trades faces in and out rather than accumulating them.
+
+### Photographs
+
+A picked photograph is always framed before it is kept. The window is a fixed circle and the picture
+moves behind it, which makes the awkward case impossible: the picture can never be smaller than the
+circle, so there is no way to frame a crescent of empty space and no error to explain. The sums are
+in `ui/person/CircleCrop.kt`, kept free of any Android type so the part that can be wrong — which
+pixels end up saved — is tested on the JVM rather than checked by eye.
+
+What is stored is the square, not a circle: roundness is drawn by every place that shows a face, so
+a round image would only mean carrying an alpha channel to save a shape we redraw anyway. It is kept
+at 512px, which is sharper than any circle in the app can show even on a 4x screen, and costs about
+twenty kilobytes a person rather than several hundred.
 
 ### Relating two people
 
@@ -268,6 +297,26 @@ Re-importing the same file, or the app's own export, is a no-op.
 | No dynamic colour | Brass means "not known" throughout, including in the chart's notation; a wallpaper-derived palette would reassign that meaning |
 | One `Canvas` for the chart | At a few hundred people, a composable per node costs far more than the drawing |
 | Backup file instead of transactional undo | A file the user can re-import is a far simpler promise, and it cannot itself go wrong |
+| A mandatory circular crop, stored square | The face is shown in a circle everywhere; framing it as a rectangle and hoping would mean choosing one thing and seeing another |
+| Photographs off changes drawing, never layout | A setting that rearranged a hundred and fifty people would cost more than the memory it saves |
+| A rail on a short window, not a bottom bar | A bottom bar takes eighty of a landscape phone's three hundred and sixty dp from the axis a tree is read along |
+
+## Turned sideways
+
+A phone on its side has about three hundred and sixty density-independent pixels of height, and the
+app was spending a third of them on its own furniture: a title bar, a mode switch, a line of counts
+and a navigation bar, all stacked along the axis a family tree is read down.
+
+On a short window — which is a question about the window, not the orientation, so a tablet on its
+side keeps the bottom bar and a phone in a split screen does not — the three destinations move to a
+`NavigationRail` on the leading edge, and the chart's title bar, mode switch and actions fold into
+one row. That is roughly a hundred and forty dp given back to the drawing, which on a real family is
+the difference between two generations on screen and four.
+
+Reading matter goes the other way. A list of names stretched across a landscape phone puts the name
+at one edge and the date at the other with a hand's width of nothing between them, so the lists,
+forms and the settings are held to a readable measure and centred (`ui/common/Windowing.kt`). The
+charts are exempt: they are pictures, not prose, and they want every pixel.
 
 ## Accessibility
 
@@ -440,8 +489,6 @@ framework, no networking, no analytics.
 - **Transactional undo of an import.** The backup file covers the same need far more simply.
 - **GEDCOM import/export.** A large format for a lightweight app; the documented `.ftree` schema
   covers sharing between users of this app.
-- **Photos on chart nodes.** Needs pre-decoded bitmaps in the canvas; the chart's value does not
-  depend on it.
 - **A whole-graph chart.** Unreadable at any real family size; re-focusing is the answer.
 
 ## Licence

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/data/PhotoStoreTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/data/PhotoStoreTest.kt
@@ -63,8 +63,82 @@ class PhotoStoreTest {
         // A family of a thousand should not be carrying a thousand camera-resolution originals.
         assertTrue(
             "stored at ${bounds.outWidth}x${bounds.outHeight}",
-            maxOf(bounds.outWidth, bounds.outHeight) <= 1024,
+            maxOf(bounds.outWidth, bounds.outHeight) <= PhotoStore.STORED_EDGE,
         )
+    }
+
+    /**
+     * A framed photograph is kept as the square the reader chose, at the size every circle in the
+     * app can actually show. Both halves matter: the wrong square is the wrong face, and the wrong
+     * size is a tree that costs gigabytes to hold a few hundred portraits.
+     */
+    @Test
+    fun aFramedPhotoIsKeptAsASquareAtTheStoredSize() = runTest {
+        val source = Bitmap.createBitmap(2000, 1200, Bitmap.Config.ARGB_8888)
+
+        val id = store.saveCrop(source, SquareCrop(x = 400, y = 0, size = 1200))!!
+
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(store.file(id).absolutePath, bounds)
+        assertEquals(PhotoStore.STORED_EDGE, bounds.outWidth)
+        assertEquals(PhotoStore.STORED_EDGE, bounds.outHeight)
+    }
+
+    /** A square smaller than the kept size is left alone rather than blown up into blur. */
+    @Test
+    fun aSmallFramedPhotoIsNotEnlarged() = runTest {
+        val source = Bitmap.createBitmap(300, 300, Bitmap.Config.ARGB_8888)
+
+        val id = store.saveCrop(source, SquareCrop(x = 0, y = 0, size = 300))!!
+
+        val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(store.file(id).absolutePath, bounds)
+        assertEquals(300, bounds.outWidth)
+    }
+
+    /**
+     * A square that runs off the edge of the picture is pulled back inside it.
+     *
+     * Not defensiveness for its own sake: Bitmap.createBitmap throws on an out-of-bounds rectangle,
+     * so a pixel of drift after a rotation would be a crash at the moment somebody saves a face.
+     */
+    @Test
+    fun aCropOutsideThePictureIsBroughtBackInsideIt() = runTest {
+        val source = Bitmap.createBitmap(400, 400, Bitmap.Config.ARGB_8888)
+
+        val id = store.saveCrop(source, SquareCrop(x = 380, y = 380, size = 400))
+
+        assertNotNull(id)
+        assertTrue(store.exists(id))
+    }
+
+    /**
+     * The chart holds hundreds of faces at once, so it is given small ones.
+     *
+     * The comparison that matters is against decoding the stored file whole, which is what a naive
+     * chart would do: at 512px in ARGB_8888 that is a megabyte per person, and a hundred people on
+     * screen would be a hundred megabytes of faces.
+     */
+    @Test
+    fun aThumbnailIsFarCheaperThanTheStoredPhotograph() = runTest {
+        val id = store.saveBytes(jpegBytes(1000, 1000))!!
+
+        val thumb = store.thumbnail(id, edgePx = 96)!!
+
+        // Decoding samples by powers of two, so the result lands within a factor of two of the ask.
+        assertTrue(
+            "thumbnail was ${thumb.width}x${thumb.height}",
+            maxOf(thumb.width, thumb.height) <= 96 * 2,
+        )
+        assertEquals(Bitmap.Config.RGB_565, thumb.config)
+
+        val whole = PhotoStore.STORED_EDGE * PhotoStore.STORED_EDGE * 4
+        assertTrue("thumbnail cost ${thumb.byteCount} bytes", thumb.byteCount * 8 < whole)
+    }
+
+    @Test
+    fun aThumbnailOfSomethingThatIsNotThereIsNothingRatherThanACrash() = runTest {
+        assertNull(store.thumbnail("gone.jpg", edgePx = 96))
     }
 
     @Test

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/AvatarsAndPhotosTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/AvatarsAndPhotosTest.kt
@@ -1,0 +1,163 @@
+package com.vibethroughcode.ftree.ui
+
+import android.graphics.Bitmap
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onFirst
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.data.SquareCrop
+import com.vibethroughcode.ftree.ui.person.CropRequest
+import com.vibethroughcode.ftree.ui.person.PhotoCropConfirmTag
+import com.vibethroughcode.ftree.ui.person.PhotoCropDialog
+import com.vibethroughcode.ftree.ui.settings.SettingsPhotosToggleTag
+import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import com.vibethroughcode.ftree.ui.tree.FamilyChartTag
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Faces on the chart, and the framing that puts them there.
+ */
+@RunWith(AndroidJUnit4::class)
+class AvatarsAndPhotosTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    private fun seed() {
+        app.container.database.clearAllTables()
+        runBlocking {
+            val parent = Person(name = "Vinod Kumar", birthDate = "1962")
+            val child = Person(name = "Ankit Kumar", birthDate = "1990")
+            listOf(parent, child).forEach { app.container.familyRepository.addPerson(it) }
+            app.container.familyRepository.addRelative(child.id, parent.id, RelativeKind.PARENT)
+        }
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /**
+     * Photographs are on unless the reader says otherwise, and turning them off is a drawing
+     * decision rather than a change to the record or to the shape of the chart.
+     */
+    @Test
+    fun photosOnTheChartAreOnByDefaultAndCanBeTurnedOff() {
+        app.container.chartPreferences.setPhotosInChart(true)
+        seed()
+
+        rule.onNodeWithTag(NavSettingsTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(SettingsPhotosToggleTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(SettingsPhotosToggleTag).assertIsOn()
+
+        // The whole row is the target, not the 32dp switch at the far edge of the screen.
+        rule.onNodeWithTag(SettingsPhotosToggleTag).performClick()
+        rule.onNodeWithTag(SettingsPhotosToggleTag).assertIsOff()
+        assert(!app.container.chartPreferences.photosInChart.value) {
+            "the setting did not reach the preference the charts read"
+        }
+
+        // And the chart is still a chart with it off — the discs simply carry initials instead.
+        rule.onNodeWithTag(NavTreeTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(FamilyChartTag).assertIsDisplayed()
+
+        app.container.chartPreferences.setPhotosInChart(true)
+    }
+
+    /** The setting outlives the screen it is set on, which is the whole point of a setting. */
+    @Test
+    fun theChoiceIsRemembered() {
+        app.container.chartPreferences.setPhotosInChart(false)
+        seed()
+
+        rule.onNodeWithTag(NavSettingsTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(SettingsPhotosToggleTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(SettingsPhotosToggleTag).assertIsOff()
+
+        app.container.chartPreferences.setPhotosInChart(true)
+    }
+}
+
+/**
+ * The crop screen, wired to the arithmetic behind it.
+ *
+ * [com.vibethroughcode.ftree.ui.person.CircleCropTest] proves the sums; this proves the screen asks
+ * for the square it is showing, which is the join the reader actually depends on.
+ */
+@RunWith(AndroidJUnit4::class)
+class PhotoCropDialogTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    @Test
+    fun framingNothingStillReturnsTheMiddleOfThePicture() {
+        val bitmap = Bitmap.createBitmap(400, 200, Bitmap.Config.ARGB_8888)
+        var result: SquareCrop? = null
+
+        rule.setContent {
+            FTreeTheme {
+                PhotoCropDialog(
+                    request = CropRequest.Ready(bitmap),
+                    onCancel = {},
+                    onConfirm = { result = it },
+                )
+            }
+        }
+
+        rule.onNodeWithTag(PhotoCropConfirmTag).performClick()
+        rule.waitForIdle()
+
+        assertNotNull("no crop came back from the screen", result)
+        // The short side fills the circle, so the square is the picture's height, centred.
+        assertEquals(200, result!!.size)
+        assertEquals(100, result!!.x)
+        assertEquals(0, result!!.y)
+    }
+
+    @Test
+    fun anUnreadableImageOffersAWayOutRatherThanAnEmptyScreen() {
+        var cancelled = false
+        rule.setContent {
+            FTreeTheme {
+                PhotoCropDialog(
+                    request = CropRequest.Unreadable,
+                    onCancel = { cancelled = true },
+                    onConfirm = {},
+                )
+            }
+        }
+
+        rule.onAllNodesWithText("Cancel").onFirst().performClick()
+        rule.waitForIdle()
+
+        assert(cancelled) { "the reader was left on a dead screen" }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
@@ -1,6 +1,7 @@
 package com.vibethroughcode.ftree
 
 import android.content.Context
+import com.vibethroughcode.ftree.data.ChartPreferences
 import com.vibethroughcode.ftree.data.FTreeDatabase
 import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.PhotoStore
@@ -39,6 +40,7 @@ class AppContainer(context: Context) {
     }
 
     val updatePreferences: UpdatePreferences by lazy { UpdatePreferences(context) }
+    val chartPreferences: ChartPreferences by lazy { ChartPreferences(context) }
 
     /**
      * Built lazily like everything else, which also means the updater's objects do not exist at

--- a/app/src/main/java/com/vibethroughcode/ftree/data/ChartPreferences.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/ChartPreferences.kt
@@ -1,0 +1,34 @@
+package com.vibethroughcode.ftree.data
+
+import android.content.Context
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * How the chart is drawn, as the reader has asked for it.
+ *
+ * On by default, unlike the updater's switch. Nothing here leaves the device or costs anything the
+ * reader has not already paid for — the photographs are theirs and already on the phone — so the
+ * useful default is the one that shows them, and the switch is there for the tree large enough that
+ * decoding faces while panning becomes noticeable.
+ */
+class ChartPreferences(context: Context) {
+
+    private val prefs = context.applicationContext
+        .getSharedPreferences("chart-preferences", Context.MODE_PRIVATE)
+
+    private val _photosInChart = MutableStateFlow(prefs.getBoolean(KEY_PHOTOS, true))
+
+    /** Whether the chart draws photographs, or only the coloured discs behind them. */
+    val photosInChart: StateFlow<Boolean> = _photosInChart.asStateFlow()
+
+    fun setPhotosInChart(value: Boolean) {
+        prefs.edit().putBoolean(KEY_PHOTOS, value).apply()
+        _photosInChart.value = value
+    }
+
+    private companion object {
+        const val KEY_PHOTOS = "photos-in-chart"
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/data/PhotoStore.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/PhotoStore.kt
@@ -10,8 +10,12 @@ import java.io.File
 import java.io.InputStream
 import java.util.UUID
 import kotlin.math.max
+import kotlin.math.min
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+/** The square a picked photograph is cut down to, in pixels of the source image. */
+data class SquareCrop(val x: Int, val y: Int, val size: Int)
 
 /**
  * Photos, kept inside the app's own storage.
@@ -22,8 +26,10 @@ import kotlinx.coroutines.withContext
  * database records only the file name, never a path, so the reference survives a reinstall or a
  * restore onto a different device.
  *
- * Images are downscaled on the way in: a family of a thousand should not carry a thousand
- * camera-resolution originals, and nothing here is ever shown larger than a phone screen.
+ * Everything stored here is small on purpose. A photograph is only ever shown inside a circle — in
+ * a list row, on a person's page, on a chart card — so it is squared and cut to [STORED_EDGE] on
+ * the way in. A face at 512px is sharper than any of those circles can show even on a 4x screen,
+ * and a family of a thousand then costs tens of megabytes rather than gigabytes.
  */
 class PhotoStore(private val context: Context) {
 
@@ -35,31 +41,85 @@ class PhotoStore(private val context: Context) {
     fun exists(photoId: String?): Boolean =
         photoId != null && file(photoId).exists()
 
-    /** Copies and downscales a picked image. Returns the new photo id, or null if unreadable. */
-    suspend fun save(source: Uri): String? = withContext(Dispatchers.IO) {
+    /**
+     * Reads a picked image at a size fit for choosing a crop from.
+     *
+     * Larger than what is finally kept, because the reader can zoom in before cutting and cutting a
+     * quarter of a 512px picture would keep 256. Still bounded, so an enormous original never has
+     * to fit in memory whole.
+     */
+    suspend fun decodeForCrop(source: Uri): Bitmap? = withContext(Dispatchers.IO) {
         runCatching {
             val bytes = context.contentResolver.openInputStream(source)?.use { it.readBytes() }
                 ?: return@runCatching null
-            val bitmap = decodeScaled(bytes) ?: return@runCatching null
-            val oriented = context.contentResolver.openInputStream(source)?.use { orient(bitmap, it) }
-                ?: bitmap
-            write(oriented)
+            val bitmap = decodeScaled(bytes, CROP_EDGE) ?: return@runCatching null
+            orient(bitmap, bytes)
+        }.getOrNull()
+    }
+
+    /**
+     * Writes the square the reader framed, scaled to [STORED_EDGE].
+     *
+     * The circle is a matter of display, not of storage: a round image would have to be a PNG with
+     * an alpha channel, several times the size of the JPEG, to save a shape that every place that
+     * shows it already draws for itself.
+     */
+    suspend fun saveCrop(bitmap: Bitmap, crop: SquareCrop): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val x = crop.x.coerceIn(0, max(0, bitmap.width - 1))
+            val y = crop.y.coerceIn(0, max(0, bitmap.height - 1))
+            val size = crop.size.coerceAtMost(min(bitmap.width - x, bitmap.height - y))
+            if (size <= 0) return@runCatching null
+
+            val square = Bitmap.createBitmap(bitmap, x, y, size, size)
+            val scaled = if (size <= STORED_EDGE) square else {
+                Bitmap.createScaledBitmap(square, STORED_EDGE, STORED_EDGE, true)
+            }
+            write(scaled)
         }.getOrNull()
     }
 
     /**
      * Stores bytes that already are an image — used when importing a tree that carries photos.
      *
-     * Downscaled by the same rule as a picked image: an export made by someone whose phone takes
-     * enormous photos should not be able to bloat this device's storage.
+     * Not cropped: nobody is at the phone to frame somebody else's photograph, and squaring it
+     * blindly would be as likely to cut off a head as to centre one. It is squared where it is
+     * drawn instead, which is reversible.
      */
     suspend fun saveBytes(bytes: ByteArray, preferredId: String? = null): String? =
         withContext(Dispatchers.IO) {
             runCatching {
-                val bitmap = decodeScaled(bytes) ?: return@runCatching null
+                val bitmap = decodeScaled(bytes, STORED_EDGE) ?: return@runCatching null
                 write(bitmap, preferredId)
             }.getOrNull()
         }
+
+    /**
+     * A small square copy for the chart, which may be drawing hundreds of faces at once.
+     *
+     * Decoded at the size it will be drawn and in [Bitmap.Config.RGB_565], so one face costs about
+     * eighteen kilobytes rather than the megabyte its stored file would. At the size a chart card
+     * is, the missing alpha channel and the shallower colour are invisible.
+     */
+    suspend fun thumbnail(photoId: String, edgePx: Int): Bitmap? = withContext(Dispatchers.IO) {
+        runCatching {
+            val path = file(photoId).takeIf { it.exists() }?.absolutePath ?: return@runCatching null
+
+            val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+            BitmapFactory.decodeFile(path, bounds)
+            if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return@runCatching null
+
+            val shortest = min(bounds.outWidth, bounds.outHeight)
+            var sample = 1
+            while (shortest / (sample * 2) >= edgePx) sample *= 2
+
+            val options = BitmapFactory.Options().apply {
+                inSampleSize = sample
+                inPreferredConfig = Bitmap.Config.RGB_565
+            }
+            BitmapFactory.decodeFile(path, options)
+        }.getOrNull()
+    }
 
     suspend fun delete(photoId: String?) = withContext(Dispatchers.IO) {
         if (photoId != null) file(photoId).delete()
@@ -79,20 +139,20 @@ class PhotoStore(private val context: Context) {
      * Decodes at roughly the size we intend to keep rather than decoding full size and shrinking,
      * so a 50-megapixel photo never has to fit in memory at all.
      */
-    private fun decodeScaled(bytes: ByteArray): Bitmap? {
+    private fun decodeScaled(bytes: ByteArray, maxEdge: Int): Bitmap? {
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         BitmapFactory.decodeByteArray(bytes, 0, bytes.size, bounds)
 
         val longest = max(bounds.outWidth, bounds.outHeight)
         var sample = 1
-        while (longest / sample > MAX_EDGE * 2) sample *= 2
+        while (longest / sample > maxEdge * 2) sample *= 2
 
         val options = BitmapFactory.Options().apply { inSampleSize = sample }
         val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size, options) ?: return null
 
         val edge = max(decoded.width, decoded.height)
-        if (edge <= MAX_EDGE) return decoded
-        val ratio = MAX_EDGE.toFloat() / edge
+        if (edge <= maxEdge) return decoded
+        val ratio = maxEdge.toFloat() / edge
         return Bitmap.createScaledBitmap(
             decoded,
             (decoded.width * ratio).toInt().coerceAtLeast(1),
@@ -102,6 +162,9 @@ class PhotoStore(private val context: Context) {
     }
 
     /** Phones record rotation in EXIF rather than in the pixels; without this, faces come in sideways. */
+    private fun orient(bitmap: Bitmap, bytes: ByteArray): Bitmap =
+        bytes.inputStream().use { orient(bitmap, it) }
+
     private fun orient(bitmap: Bitmap, stream: InputStream): Bitmap {
         val degrees = when (ExifInterface(stream).getAttributeInt(
             ExifInterface.TAG_ORIENTATION,
@@ -118,7 +181,13 @@ class PhotoStore(private val context: Context) {
 
     companion object {
         const val DIRECTORY = "photos"
-        private const val MAX_EDGE = 1024
+
+        /** What a photograph is kept at, which is all any circle in this app can show. */
+        const val STORED_EDGE = 512
+
+        /** What a photograph is *offered* at while the reader frames it. */
+        const val CROP_EDGE = 1440
+
         private const val QUALITY = 85
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
@@ -61,8 +61,20 @@ data class TreeLayout(
 
 /** Chart geometry, in dp-equivalent layout units. */
 object TreeMetrics {
-    const val NODE_WIDTH = 132f
-    const val NODE_HEIGHT = 56f
+    /**
+     * A card holds a face and a name side by side, so it is wider than a card holding only words.
+     *
+     * The avatar is part of the card at every zoom and whether or not there is a photograph behind
+     * it, which is what lets the "photos in the chart" setting be turned on and off without a
+     * single person moving: the setting changes what is drawn inside the circle, never the shape of
+     * the chart around it.
+     */
+    const val NODE_WIDTH = 160f
+    const val NODE_HEIGHT = 60f
+
+    /** The avatar's diameter and the space around it, as fractions of a card's height. */
+    const val AVATAR_DIAMETER = 0.6f
+    const val AVATAR_INSET = 0.13f
 
     /**
      * Between unrelated nodes on the same row. Deliberately much wider than [COUPLE_GAP]: the

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -2,8 +2,11 @@ package com.vibethroughcode.ftree.ui
 
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.AccountTree
@@ -11,6 +14,8 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -22,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -36,6 +42,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.transfer.TreeDocument
+import com.vibethroughcode.ftree.ui.common.isShortWindow
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
 import com.vibethroughcode.ftree.ui.person.PersonDetailScreen
 import com.vibethroughcode.ftree.ui.person.PersonEditScreen
@@ -103,10 +110,20 @@ fun FTreeApp() {
     val destination = backStackEntry?.destination
     val onTopLevel = destinations.any { destination?.hasRoute(it.type) == true }
 
+    /*
+     * The three places move to the side when the window is short.
+     *
+     * A bottom bar costs eighty of the roughly three hundred and sixty density-independent pixels a
+     * phone has on its side, and it takes them from the axis a family tree is read along. A rail
+     * costs width instead, which is the axis that has just doubled. Same three destinations, same
+     * order, same labels — only the edge they sit on changes.
+     */
+    val useRail = onTopLevel && isShortWindow()
+
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
         bottomBar = {
-            if (onTopLevel) {
+            if (onTopLevel && !useRail) {
                 NavigationBar {
                     destinations.forEach { item ->
                         val selected = destination?.hasRoute(item.type) == true
@@ -122,101 +139,119 @@ fun FTreeApp() {
             }
         },
     ) { padding ->
-        NavHost(
-            navController = navController,
-            startDestination = TreeRoute(),
-            modifier = Modifier.fillMaxSize().padding(padding),
-        ) {
-            composable<TreeRoute> { entry ->
-                TreeScreen(
-                    trace = entry.toRoute<TreeRoute>().trace,
-                    startWhole = entry.toRoute<TreeRoute>().whole,
-                    onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                    onAddPerson = { navController.navigate(EditPersonRoute()) },
-                    onAddRelative = { anchorId, kind ->
-                        navController.navigate(AddRelativeRoute(anchorId, kind))
-                    },
-                    onRelate = { navController.navigate(RelationRoute(fromId = it)) },
-                    // Dropping the trace means going back to the plain chart, which is where
-                    // clearing a highlight should leave you — not one screen further back.
-                    onClearTrace = {
-                        navController.navigate(TreeRoute(whole = true)) {
-                            popUpTo<TreeRoute> { inclusive = true }
-                        }
-                    },
-                )
+        Row(Modifier.fillMaxSize().padding(padding)) {
+            if (useRail) {
+                // Held to the standard rail width. Left to size itself it takes a quarter of a
+            // landscape phone, which is the opposite of the point of moving off the bottom edge.
+            NavigationRail(modifier = Modifier.fillMaxHeight().width(112.dp)) {
+                    destinations.forEach { item ->
+                        val selected = destination?.hasRoute(item.type) == true
+                        NavigationRailItem(
+                            selected = selected,
+                            onClick = { navController.switchTo(item.route) },
+                            icon = { Icon(item.icon, contentDescription = null) },
+                            label = { Text(stringResource(item.label)) },
+                            modifier = Modifier.testTag(item.tag),
+                        )
+                    }
+                }
             }
-
-            composable<RelationRoute> {
-                RelationScreen(
-                    onBack = { navController.popBackStack() },
-                    onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                    onShowOnChart = { trace ->
-                        navController.navigate(TreeRoute(trace = trace)) {
-                            popUpTo<TreeRoute> { inclusive = true }
-                        }
-                    },
-                )
-            }
-
-            composable<PeopleRoute> {
-                PeopleScreen(
-                    onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                    onAddPerson = { navController.navigate(EditPersonRoute()) },
-                )
-            }
-
-            composable<SettingsRoute> {
-                val settingsViewModel: SettingsViewModel =
-                    viewModel(factory = FTreeViewModels.Factory)
-                SettingsScreen(
-                    onExport = { exportPicker.launch(defaultExportName()) },
-                    onImport = { importPicker.launch(arrayOf("*/*")) },
-                    viewModel = settingsViewModel,
-                )
-            }
-
-            composable<PersonRoute> {
-                PersonDetailScreen(
-                    onBack = { navController.popBackStack() },
-                    onEdit = { navController.navigate(EditPersonRoute(it)) },
-                    onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                    onAddRelative = { anchorId, kind ->
-                        navController.navigate(AddRelativeRoute(anchorId, kind))
-                    },
-                    onShowOnTree = { personId ->
-                        navController.navigate(TreeRoute(focusId = personId)) {
-                            popUpTo<TreeRoute> { inclusive = true }
-                        }
-                    },
-                    onRelate = { personId ->
-                        navController.navigate(RelationRoute(fromId = personId))
-                    },
-                )
-            }
-
-            composable<AddRelativeRoute> {
-                AddRelativeScreen(onBack = { navController.popBackStack() })
-            }
-
-            composable<EditPersonRoute> { entry ->
-                val route = entry.toRoute<EditPersonRoute>()
-                PersonEditScreen(
-                    onBack = { navController.popBackStack() },
-                    onSaved = { personId ->
-                        if (route.personId == null) {
-                            // A newly added person opens straight onto their own page, which is
-                            // where the next thing you want to do — add a relative — lives. Only
-                            // the form is dropped from the back stack, so going back returns to
-                            // wherever the add started rather than always to the chart.
-                            navController.navigate(PersonRoute(personId)) {
-                                popUpTo<EditPersonRoute> { inclusive = true }
+            NavHost(
+                navController = navController,
+                startDestination = TreeRoute(),
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+            ) {
+                composable<TreeRoute> { entry ->
+                    TreeScreen(
+                        trace = entry.toRoute<TreeRoute>().trace,
+                        startWhole = entry.toRoute<TreeRoute>().whole,
+                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                        onAddPerson = { navController.navigate(EditPersonRoute()) },
+                        onAddRelative = { anchorId, kind ->
+                            navController.navigate(AddRelativeRoute(anchorId, kind))
+                        },
+                        onRelate = { navController.navigate(RelationRoute(fromId = it)) },
+                        // Dropping the trace means going back to the plain chart, which is where
+                        // clearing a highlight should leave you — not one screen further back.
+                        onClearTrace = {
+                            navController.navigate(TreeRoute(whole = true)) {
+                                popUpTo<TreeRoute> { inclusive = true }
                             }
-                        } else {
-                            navController.popBackStack()
-                        }
-                    },
-                )
+                        },
+                    )
+                }
+
+                composable<RelationRoute> {
+                    RelationScreen(
+                        onBack = { navController.popBackStack() },
+                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                        onShowOnChart = { trace ->
+                            navController.navigate(TreeRoute(trace = trace)) {
+                                popUpTo<TreeRoute> { inclusive = true }
+                            }
+                        },
+                    )
+                }
+
+                composable<PeopleRoute> {
+                    PeopleScreen(
+                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                        onAddPerson = { navController.navigate(EditPersonRoute()) },
+                    )
+                }
+
+                composable<SettingsRoute> {
+                    val settingsViewModel: SettingsViewModel =
+                        viewModel(factory = FTreeViewModels.Factory)
+                    SettingsScreen(
+                        onExport = { exportPicker.launch(defaultExportName()) },
+                        onImport = { importPicker.launch(arrayOf("*/*")) },
+                        viewModel = settingsViewModel,
+                    )
+                }
+
+                composable<PersonRoute> {
+                    PersonDetailScreen(
+                        onBack = { navController.popBackStack() },
+                        onEdit = { navController.navigate(EditPersonRoute(it)) },
+                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                        onAddRelative = { anchorId, kind ->
+                            navController.navigate(AddRelativeRoute(anchorId, kind))
+                        },
+                        onShowOnTree = { personId ->
+                            navController.navigate(TreeRoute(focusId = personId)) {
+                                popUpTo<TreeRoute> { inclusive = true }
+                            }
+                        },
+                        onRelate = { personId ->
+                            navController.navigate(RelationRoute(fromId = personId))
+                        },
+                    )
+                }
+
+                composable<AddRelativeRoute> {
+                    AddRelativeScreen(onBack = { navController.popBackStack() })
+                }
+
+                composable<EditPersonRoute> { entry ->
+                    val route = entry.toRoute<EditPersonRoute>()
+                    PersonEditScreen(
+                        onBack = { navController.popBackStack() },
+                        onSaved = { personId ->
+                            if (route.personId == null) {
+                                // A newly added person opens straight onto their own page, which is
+                                // where the next thing you want to do — add a relative — lives. Only
+                                // the form is dropped from the back stack, so going back returns to
+                                // wherever the add started rather than always to the chart.
+                                navController.navigate(PersonRoute(personId)) {
+                                    popUpTo<EditPersonRoute> { inclusive = true }
+                                }
+                            } else {
+                                navController.popBackStack()
+                            }
+                        },
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -35,12 +35,16 @@ private fun CreationExtras.photos(): PhotoStore =
 object FTreeViewModels {
     val Factory = viewModelFactory {
         initializer { PeopleViewModel(repository()) }
-        initializer { TreeViewModel(repository(), createSavedStateHandle()) }
+        initializer {
+            val app = this[APPLICATION_KEY] as FTreeApplication
+            TreeViewModel(repository(), app.container.chartPreferences, createSavedStateHandle())
+        }
         initializer { WholeTreeViewModel(repository()) }
         initializer {
             val app = this[APPLICATION_KEY] as FTreeApplication
             SettingsViewModel(
                 preferences = app.container.updatePreferences,
+                chart = app.container.chartPreferences,
                 updates = app.container.updateRepository,
             )
         }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonAvatar.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/PersonAvatar.kt
@@ -26,7 +26,10 @@ import coil3.compose.AsyncImage
 import com.vibethroughcode.ftree.data.PhotoStore
 import java.io.File
 import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Gender
 import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.ui.theme.AvatarInk
+import com.vibethroughcode.ftree.ui.theme.FTreeAccents
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 
 /**
@@ -94,17 +97,18 @@ fun PersonAvatar(
             )
         }
     } else {
+        val ink = accents.avatarFor(person.gender)
         Box(
             modifier = modifier
                 .size(diameter)
                 .clip(CircleShape)
-                .background(MaterialTheme.colorScheme.primaryContainer)
+                .background(ink.fill)
                 .clearAndSetSemantics { contentDescription = description },
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = person.initial(),
-                color = MaterialTheme.colorScheme.onPrimaryContainer,
+                color = ink.ink,
                 textAlign = TextAlign.Center,
                 style = MaterialTheme.typography.titleMedium.copy(
                     fontSize = (diameter.value * 0.4f).sp,
@@ -114,6 +118,19 @@ fun PersonAvatar(
     }
 }
 
+
+/**
+ * The ground an initial is written on when there is no photograph.
+ *
+ * The same two hues the chart uses, so a person looks like themselves whether you meet them in a
+ * list or on a card. An unspecified gender gets the quiet third colour rather than a blank, because
+ * not recording it is a legitimate answer and should not look like a fault.
+ */
+fun FTreeAccents.avatarFor(gender: Gender): AvatarInk = when (gender) {
+    Gender.MALE -> avatarMale
+    Gender.FEMALE -> avatarFemale
+    else -> avatarOther
+}
 
 /**
  * Resolves a stored photo id to a file.

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/Windowing.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/Windowing.kt
@@ -1,0 +1,43 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Whether the window is short enough that horizontal chrome has to give way.
+ *
+ * Phrased as a question about the window rather than about the *orientation*, because that is what
+ * actually matters: a tablet on its side has room for a bottom bar and a chart both, and a phone
+ * held upright in a split screen has none. Rotating a phone is simply the common way to arrive here.
+ *
+ * The threshold is where a top bar, a mode switch, a bottom bar and their insets leave a chart less
+ * than half the screen — the point at which the app is mostly showing the reader its own furniture.
+ */
+@Composable
+fun isShortWindow(): Boolean {
+    val height = LocalWindowInfo.current.containerSize.height
+    return with(LocalDensity.current) { height.toDp() } < SHORT_WINDOW
+}
+
+private val SHORT_WINDOW = 500.dp
+
+/**
+ * Holds a column of reading matter to a sensible measure, centred in whatever is left.
+ *
+ * A list of names stretched across a landscape phone puts the name at one edge of the screen and
+ * the date at the other, with a hand's width of nothing between them — the eye loses the row on the
+ * way across. Typographers have known the answer for five hundred years and it is not "wider": a
+ * line has a comfortable length, and past it you add margins rather than words.
+ *
+ * The charts are exempt, deliberately. They are pictures, not prose, and they want every pixel.
+ */
+fun Modifier.readableMeasure(max: Dp = 560.dp): Modifier =
+    fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally).widthIn(max = max)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
@@ -1,6 +1,7 @@
 package com.vibethroughcode.ftree.ui.people
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material3.FilterChip
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -48,6 +49,7 @@ import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.ui.FTreeViewModels
 import com.vibethroughcode.ftree.ui.common.EmptyState
 import com.vibethroughcode.ftree.ui.common.PersonRow
+import com.vibethroughcode.ftree.ui.common.readableMeasure
 import com.vibethroughcode.ftree.ui.common.peopleCount
 import com.vibethroughcode.ftree.ui.common.TreeGlyph
 import com.vibethroughcode.ftree.ui.theme.FTreeText
@@ -133,7 +135,7 @@ fun PeopleScreen(
             }
         },
     ) { padding ->
-        Column(Modifier.fillMaxSize().padding(padding)) {
+        Column(Modifier.fillMaxHeight().padding(padding).readableMeasure()) {
             if (!state.isEmptyTree) {
                 PeopleFilterRow(
                     filter = state.filter,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/CircleCrop.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/CircleCrop.kt
@@ -1,0 +1,68 @@
+package com.vibethroughcode.ftree.ui.person
+
+import com.vibethroughcode.ftree.data.SquareCrop
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * The arithmetic behind framing a photograph in a circle.
+ *
+ * Kept apart from the composable that draws it, and free of any Android or Compose type, so the
+ * part that can be wrong — which pixels of the original end up saved — is testable on the JVM
+ * rather than only visible by eye on a device.
+ *
+ * The model is the one the reader sees: a fixed circular window in the middle of the screen, with
+ * the photograph moved and scaled behind it. [baseScale] is the scale at which the picture exactly
+ * covers that window, so the window can never contain a corner of empty space, and [offsetLimit]
+ * is what keeps it that way while the picture is dragged.
+ */
+object CircleCrop {
+
+    /** How far in the reader may zoom, beyond the scale that just covers the window. */
+    const val MAX_ZOOM = 6f
+
+    /** The smallest scale at which the photograph still covers the circular window. */
+    fun baseScale(imageWidth: Int, imageHeight: Int, diameter: Float): Float {
+        if (imageWidth <= 0 || imageHeight <= 0 || diameter <= 0f) return 1f
+        return max(diameter / imageWidth, diameter / imageHeight)
+    }
+
+    /**
+     * How far the photograph may be dragged from centre before the window would run off its edge.
+     *
+     * Zero on an axis means the picture is exactly as wide (or tall) as the window there and has
+     * nowhere to go, which is the usual case for one of the two axes.
+     */
+    fun offsetLimit(imageSide: Int, scale: Float, diameter: Float): Float =
+        max(0f, imageSide * scale / 2f - diameter / 2f)
+
+    /**
+     * The square of the original that the circular window is currently over.
+     *
+     * A square, not a circle: the roundness is drawn by every place that shows a face, so storing
+     * a round image would only mean carrying an alpha channel to save a shape we redraw anyway.
+     */
+    fun source(
+        imageWidth: Int,
+        imageHeight: Int,
+        diameter: Float,
+        scale: Float,
+        offsetX: Float,
+        offsetY: Float,
+    ): SquareCrop {
+        if (imageWidth <= 0 || imageHeight <= 0 || scale <= 0f) return SquareCrop(0, 0, 0)
+
+        val side = (diameter / scale)
+        val x = (imageWidth * scale / 2f - diameter / 2f - offsetX) / scale
+        val y = (imageHeight * scale / 2f - diameter / 2f - offsetY) / scale
+
+        // Rounded, then held inside the picture: a pixel of drift at the edge would otherwise
+        // become an IllegalArgumentException out of Bitmap.createBitmap.
+        val size = side.roundToInt().coerceIn(1, minOf(imageWidth, imageHeight))
+        return SquareCrop(
+            x = x.roundToInt().coerceIn(0, imageWidth - size),
+            y = y.roundToInt().coerceIn(0, imageHeight - size),
+            size = size,
+        )
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -53,6 +54,7 @@ import com.vibethroughcode.ftree.ui.common.SectionRule
 import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.addRelativeLabel
 import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.readableMeasure
 import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.common.sectionTitle
 import com.vibethroughcode.ftree.ui.theme.FTreeText
@@ -157,8 +159,9 @@ fun PersonDetailScreen(
 
         Column(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxHeight()
                 .padding(padding)
+                .readableMeasure()
                 .verticalScroll(rememberScrollState()),
         ) {
             PersonHeader(person, Modifier.padding(horizontal = 20.dp))

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditScreen.kt
@@ -8,6 +8,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.filled.AddAPhoto
@@ -61,6 +62,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Gender
 import com.vibethroughcode.ftree.ui.FTreeViewModels
+import com.vibethroughcode.ftree.ui.common.readableMeasure
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 
 const val EditNameFieldTag = "edit-name"
@@ -80,6 +82,7 @@ fun PersonEditScreen(
     viewModel: PersonEditViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val crop by viewModel.crop.collectAsStateWithLifecycle()
     var confirmingDiscard by remember { mutableStateOf(false) }
 
     fun attemptBack() {
@@ -112,8 +115,9 @@ fun PersonEditScreen(
     ) { padding ->
         Column(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxHeight()
                 .padding(padding)
+                .readableMeasure()
                 .verticalScroll(rememberScrollState())
                 .imePadding()
                 .padding(horizontal = 20.dp),
@@ -197,7 +201,14 @@ fun PersonEditScreen(
             title = { Text(stringResource(R.string.edit_discard_title)) },
             text = { Text(stringResource(R.string.edit_discard_body)) },
             confirmButton = {
-                TextButton(onClick = { confirmingDiscard = false; onBack() }) {
+                TextButton(
+                    onClick = {
+                        confirmingDiscard = false
+                        // Any photograph framed but never saved goes with the rest of the form.
+                        viewModel.onDiscarded()
+                        onBack()
+                    },
+                ) {
                     Text(stringResource(R.string.edit_discard_confirm))
                 }
             },
@@ -206,6 +217,16 @@ fun PersonEditScreen(
                     Text(stringResource(R.string.edit_discard_keep))
                 }
             },
+        )
+    }
+
+    // Over the form rather than a screen of its own: the picked image is a live bitmap that cannot
+    // be handed through a route, and cancelling must leave the form exactly as it was.
+    crop?.let { request ->
+        PhotoCropDialog(
+            request = request,
+            onCancel = viewModel::onCropCancelled,
+            onConfirm = viewModel::onCropConfirmed,
         )
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonEditViewModel.kt
@@ -1,5 +1,6 @@
 package com.vibethroughcode.ftree.ui.person
 
+import android.graphics.Bitmap
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
@@ -9,11 +10,26 @@ import com.vibethroughcode.ftree.data.Gender
 import com.vibethroughcode.ftree.data.PartialDate
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.data.PhotoStore
+import com.vibethroughcode.ftree.data.SquareCrop
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+
+/**
+ * A picked image on its way to becoming a portrait.
+ *
+ * Every photograph is framed before it is kept — there is no path that stores one uncropped — so
+ * this is a step in picking a photo rather than an optional extra. The reason is that a face is
+ * shown as a circle everywhere in this app, and letting the app choose the middle of somebody's
+ * holiday snap is how you end up with a chart full of shoulders and hedges.
+ */
+sealed interface CropRequest {
+    data object Loading : CropRequest
+    data class Ready(val bitmap: Bitmap) : CropRequest
+    data object Unreadable : CropRequest
+}
 
 /** Why a date the user typed cannot be saved. */
 enum class DateProblem { MALFORMED, DEATH_BEFORE_BIRTH }
@@ -49,8 +65,23 @@ class PersonEditViewModel(
     private val _uiState = MutableStateFlow(PersonEditUiState(isNew = personId == null))
     val uiState: StateFlow<PersonEditUiState> = _uiState.asStateFlow()
 
+    private val _crop = MutableStateFlow<CropRequest?>(null)
+
+    /** The photograph being framed, if one is. Null the rest of the time, which is most of it. */
+    val crop: StateFlow<CropRequest?> = _crop.asStateFlow()
+
     /** The row being edited, kept so unedited fields (photo, timestamps, id) survive a save. */
     private var original: Person? = null
+
+    /**
+     * Photographs written while this form has been open.
+     *
+     * Framing three photographs and keeping the third writes three files; the two that lost are
+     * cleaned up when the form is left, whichever way it is left. Deleting each one as the next
+     * arrives would be simpler and wrong — backing out of the form must leave the person with the
+     * picture they had.
+     */
+    private val written = mutableSetOf<String>()
 
     init {
         if (personId == null) {
@@ -82,24 +113,41 @@ class PersonEditViewModel(
 
     fun onNameChange(value: String) = _uiState.update { it.copy(name = value, dirty = true) }
 
-    /**
-     * Copies a picked image into the app's own storage.
-     *
-     * The old photo is removed only after the new one is written, so a failed import never leaves
-     * the person with no picture at all.
-     */
+    /** Opens the picked image for framing. Nothing is written until the frame is confirmed. */
     fun onPhotoPicked(uri: Uri) {
+        _crop.value = CropRequest.Loading
         viewModelScope.launch {
-            val saved = photos.save(uri) ?: return@launch
-            val previous = _uiState.value.photoId
+            val bitmap = photos.decodeForCrop(uri)
+            _crop.value = if (bitmap == null) CropRequest.Unreadable else CropRequest.Ready(bitmap)
+        }
+    }
+
+    fun onCropCancelled() {
+        _crop.value = null
+    }
+
+    /** Writes the square the reader framed and hangs it on the form, not yet on the person. */
+    fun onCropConfirmed(square: SquareCrop) {
+        val ready = _crop.value as? CropRequest.Ready ?: return
+        _crop.value = null
+        viewModelScope.launch {
+            val saved = photos.saveCrop(ready.bitmap, square) ?: return@launch
+            written += saved
             _uiState.update { it.copy(photoId = saved, dirty = true) }
-            if (previous != null && previous != saved) photos.delete(previous)
         }
     }
 
     fun onPhotoRemoved() {
         // The file is not deleted until the change is saved, so backing out leaves it intact.
         _uiState.update { it.copy(photoId = null, dirty = true) }
+    }
+
+    /** Leaving without saving: everything written while framing goes, the person keeps what they had. */
+    fun onDiscarded() {
+        val orphans = written.toList()
+        written.clear()
+        _crop.value = null
+        viewModelScope.launch { orphans.forEach { photos.delete(it) } }
     }
     fun onGenderChange(value: Gender) = _uiState.update { it.copy(gender = value, dirty = true) }
     fun onNotesChange(value: String) = _uiState.update { it.copy(notes = value, dirty = true) }
@@ -160,9 +208,12 @@ class PersonEditViewModel(
             )
             if (original == null) repository.addPerson(updated) else repository.updatePerson(updated)
 
-            // Only now is a discarded photo actually removed from disk.
+            // Only now is a discarded photo actually removed from disk: the one the person had if
+            // it has been replaced, and every frame tried on the way to the one being kept.
             val removed = original?.photoId
             if (removed != null && removed != state.photoId) photos.delete(removed)
+            written.filterNot { it == state.photoId }.forEach { photos.delete(it) }
+            written.clear()
 
             onSaved(updated.id)
         }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PhotoCropDialog.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PhotoCropDialog.kt
@@ -1,0 +1,246 @@
+package com.vibethroughcode.ftree.ui.person
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectTransformGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.SquareCrop
+import kotlin.math.roundToInt
+
+const val PhotoCropConfirmTag = "photo-crop-confirm"
+const val PhotoCropCancelTag = "photo-crop-cancel"
+const val PhotoCropAreaTag = "photo-crop-area"
+
+/**
+ * Framing a photograph in the circle it will be shown in.
+ *
+ * The window is fixed and the photograph moves behind it, rather than a rectangle being dragged
+ * over a still picture. It is the same gesture as the charts — drag to move, pinch to zoom — and it
+ * makes the awkward case impossible: the picture can never be smaller than the window, so there is
+ * no way to frame a crescent of empty space and no error message needed to say so.
+ *
+ * The circle is the point. A face is drawn as a circle in every part of this app, so framing it as
+ * a square and hoping would mean the reader choosing one thing and seeing another.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PhotoCropDialog(
+    request: CropRequest,
+    onCancel: () -> Unit,
+    onConfirm: (SquareCrop) -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onCancel,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false,
+        ),
+    ) {
+        Scaffold(
+            modifier = Modifier.fillMaxSize(),
+            topBar = {
+                TopAppBar(
+                    title = { Text(stringResource(R.string.photo_crop_title)) },
+                    navigationIcon = {
+                        IconButton(onClick = onCancel, modifier = Modifier.testTag(PhotoCropCancelTag)) {
+                            Icon(
+                                Icons.Default.Close,
+                                contentDescription = stringResource(R.string.photo_crop_cancel),
+                            )
+                        }
+                    },
+                )
+            },
+        ) { padding ->
+            Box(Modifier.fillMaxSize().padding(padding)) {
+                when (request) {
+                    CropRequest.Loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
+
+                    CropRequest.Unreadable -> Column(
+                        modifier = Modifier.align(Alignment.Center).padding(32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        Text(
+                            stringResource(R.string.photo_crop_unreadable),
+                            style = MaterialTheme.typography.bodyLarge,
+                            textAlign = TextAlign.Center,
+                        )
+                        TextButton(onClick = onCancel, modifier = Modifier.padding(top = 12.dp)) {
+                            Text(stringResource(R.string.photo_crop_cancel))
+                        }
+                    }
+
+                    is CropRequest.Ready -> CropSurface(request, onConfirm)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CropSurface(request: CropRequest.Ready, onConfirm: (SquareCrop) -> Unit) {
+    val image = remember(request) { request.bitmap.asImageBitmap() }
+    val width = request.bitmap.width
+    val height = request.bitmap.height
+
+    val description = stringResource(R.string.a11y_crop_area)
+    var viewport by remember { mutableStateOf(IntSize.Zero) }
+    var zoom by remember { mutableFloatStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+
+    val diameter = remember(viewport) {
+        minOf(viewport.width, viewport.height) * CIRCLE_FRACTION
+    }
+    val baseScale = CircleCrop.baseScale(width, height, diameter)
+    val scale = baseScale * zoom
+
+    // The window can change size under the picture — a rotation, a split screen — and an offset
+    // that was legal before might now put the circle over the edge of it.
+    LaunchedEffect(viewport) {
+        offset = clamp(offset, width, height, scale, diameter)
+    }
+
+    Column(Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+                // The photograph is drawn far larger than the window it is seen through — that is
+                // the whole idea — so without this it spills over the rest of the screen.
+                .clipToBounds()
+                .testTag(PhotoCropAreaTag)
+                .semantics { contentDescription = description }
+                .onSizeChanged { viewport = it }
+                .pointerInput(width, height, diameter) {
+                    detectTransformGestures { _, panChange, zoomChange, _ ->
+                        // Scaled about the circle's own centre, so the face under the window stays
+                        // under it. A pinch centroid would be more literal and, with a window that
+                        // never moves, more surprising.
+                        val next = (zoom * zoomChange).coerceIn(1f, CircleCrop.MAX_ZOOM)
+                        val factor = next / zoom
+                        zoom = next
+                        offset = clamp(
+                            offset * factor + panChange,
+                            width,
+                            height,
+                            baseScale * next,
+                            diameter,
+                        )
+                    }
+                },
+        ) {
+            Canvas(Modifier.fillMaxSize()) {
+                if (diameter <= 0f) return@Canvas
+                val centre = Offset(size.width / 2f, size.height / 2f)
+
+                drawImage(
+                    image = image,
+                    dstOffset = IntOffset(
+                        (centre.x + offset.x - width * scale / 2f).roundToInt(),
+                        (centre.y + offset.y - height * scale / 2f).roundToInt(),
+                    ),
+                    dstSize = IntSize(
+                        (width * scale).roundToInt().coerceAtLeast(1),
+                        (height * scale).roundToInt().coerceAtLeast(1),
+                    ),
+                )
+
+                // Everything outside the circle dimmed in one path with an even-odd fill: it is
+                // one shape rather than four rectangles that have to agree with each other.
+                val mask = Path().apply {
+                    addRect(Rect(Offset.Zero, size))
+                    addOval(Rect(centre, diameter / 2f))
+                    fillType = PathFillType.EvenOdd
+                }
+                drawPath(mask, Color.Black.copy(alpha = 0.62f))
+                drawCircle(
+                    color = Color.White.copy(alpha = 0.85f),
+                    radius = diameter / 2f,
+                    center = centre,
+                    style = Stroke(width = 1.5.dp.toPx()),
+                )
+            }
+        }
+
+        Text(
+            text = stringResource(R.string.photo_crop_hint),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 8.dp),
+        )
+
+        TextButton(
+            onClick = {
+                onConfirm(
+                    CircleCrop.source(width, height, diameter, scale, offset.x, offset.y)
+                )
+            },
+            modifier = Modifier
+                .align(Alignment.CenterHorizontally)
+                .padding(bottom = 24.dp)
+                .testTag(PhotoCropConfirmTag),
+        ) {
+            Text(stringResource(R.string.photo_crop_use))
+        }
+    }
+}
+
+private fun clamp(
+    offset: Offset,
+    width: Int,
+    height: Int,
+    scale: Float,
+    diameter: Float,
+): Offset {
+    val limitX = CircleCrop.offsetLimit(width, scale, diameter)
+    val limitY = CircleCrop.offsetLimit(height, scale, diameter)
+    return Offset(offset.x.coerceIn(-limitX, limitX), offset.y.coerceIn(-limitY, limitY))
+}
+
+/** Leaves a comfortable margin, so the picture outside the window is visible enough to aim with. */
+private const val CIRCLE_FRACTION = 0.78f

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -59,6 +60,7 @@ import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.SectionRule
 import com.vibethroughcode.ftree.ui.common.displayName
 import com.vibethroughcode.ftree.ui.common.kinshipLabel
+import com.vibethroughcode.ftree.ui.common.readableMeasure
 import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.common.asRelativeKind
 import com.vibethroughcode.ftree.ui.theme.FTreeText
@@ -160,7 +162,7 @@ private fun Answer(
     onShowOnChart: () -> Unit,
 ) {
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxHeight().readableMeasure(),
         contentPadding = PaddingValues(bottom = 40.dp),
     ) {
         item {
@@ -429,7 +431,7 @@ private fun PersonPicker(
     val focusRequester = remember { FocusRequester() }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
-    Column(Modifier.fillMaxSize()) {
+    Column(Modifier.fillMaxHeight().readableMeasure()) {
         OutlinedTextField(
             value = query,
             onValueChange = onQueryChange,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relative/AddRelativeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relative/AddRelativeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -48,6 +49,7 @@ import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.SectionRule
 import com.vibethroughcode.ftree.ui.common.addRelativeTitle
 import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.readableMeasure
 import com.vibethroughcode.ftree.ui.common.rejectionMessage
 
 const val AddRelativeNameTag = "add-relative-name"
@@ -88,7 +90,7 @@ fun AddRelativeScreen(
         },
     ) { padding ->
         LazyColumn(
-            modifier = Modifier.fillMaxSize().padding(padding),
+            modifier = Modifier.fillMaxHeight().padding(padding).readableMeasure(),
             contentPadding = PaddingValues(bottom = 32.dp),
         ) {
             item {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
@@ -7,12 +7,14 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CloudDownload
@@ -42,12 +44,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vibethroughcode.ftree.BuildConfig
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.ui.common.SectionRule
+import com.vibethroughcode.ftree.ui.common.readableMeasure
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 import com.vibethroughcode.ftree.update.AvailableUpdate
@@ -55,6 +59,7 @@ import com.vibethroughcode.ftree.update.UpdateFailure
 import com.vibethroughcode.ftree.update.UpdateState
 
 const val SettingsUpdatesToggleTag = "settings-updates-toggle"
+const val SettingsPhotosToggleTag = "settings-photos-toggle"
 const val SettingsExportTag = "settings-export"
 const val SettingsImportTag = "settings-import"
 
@@ -77,6 +82,7 @@ fun SettingsScreen(
     val context = LocalContext.current
     val enabled by viewModel.updatesEnabled.collectAsStateWithLifecycle()
     val state by viewModel.updateState.collectAsStateWithLifecycle()
+    val photosInChart by viewModel.photosInChart.collectAsStateWithLifecycle()
 
     Scaffold(
         modifier = modifier,
@@ -86,36 +92,31 @@ fun SettingsScreen(
     ) { padding ->
     Column(
         modifier = Modifier
-            .fillMaxSize()
+            .fillMaxHeight()
             .padding(padding)
+            .readableMeasure()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp),
     ) {
+        SectionRule(stringResource(R.string.settings_section_chart))
+
+        SettingsSwitch(
+            title = stringResource(R.string.settings_photos_toggle),
+            body = stringResource(R.string.settings_photos_explainer),
+            checked = photosInChart,
+            onCheckedChange = viewModel::setPhotosInChart,
+            tag = SettingsPhotosToggleTag,
+        )
+
         SectionRule(stringResource(R.string.settings_section_updates))
 
-        Row(
-            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Column(Modifier.weight(1f)) {
-                Text(
-                    stringResource(R.string.settings_updates_toggle),
-                    style = MaterialTheme.typography.bodyLarge,
-                )
-                Text(
-                    stringResource(R.string.settings_updates_explainer),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(top = 4.dp),
-                )
-            }
-            Switch(
-                checked = enabled,
-                onCheckedChange = viewModel::setUpdatesEnabled,
-                modifier = Modifier.testTag(SettingsUpdatesToggleTag),
-            )
-        }
+        SettingsSwitch(
+            title = stringResource(R.string.settings_updates_toggle),
+            body = stringResource(R.string.settings_updates_explainer),
+            checked = enabled,
+            onCheckedChange = viewModel::setUpdatesEnabled,
+            tag = SettingsUpdatesToggleTag,
+        )
 
         AnimatedVisibility(visible = enabled) {
             UpdatePanel(
@@ -198,6 +199,48 @@ fun SettingsScreen(
             modifier = Modifier.padding(top = 16.dp, bottom = 40.dp),
         )
     }
+    }
+}
+
+/**
+ * A setting with its explanation, and the switch that turns it.
+ *
+ * The whole row is the target, not just the switch. Reaching a 32dp control at the far edge of a
+ * phone is the sort of thing that is fine in a mock-up and irritating in the hand, and the sentence
+ * explaining a setting is the most natural thing to press.
+ */
+@Composable
+private fun SettingsSwitch(
+    title: String,
+    body: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    tag: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .toggleable(
+                value = checked,
+                onValueChange = onCheckedChange,
+                role = Role.Switch,
+            )
+            .padding(vertical = 8.dp)
+            .testTag(tag),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(Modifier.weight(1f)) {
+            Text(title, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                body,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+        // Driven by the row, so the two cannot disagree and a screen reader hears one control.
+        Switch(checked = checked, onCheckedChange = null)
     }
 }
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.vibethroughcode.ftree.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vibethroughcode.ftree.data.ChartPreferences
 import com.vibethroughcode.ftree.update.AvailableUpdate
 import com.vibethroughcode.ftree.update.UpdatePreferences
 import com.vibethroughcode.ftree.update.UpdateRepository
@@ -13,11 +14,16 @@ import java.io.File
 
 class SettingsViewModel(
     private val preferences: UpdatePreferences,
+    private val chart: ChartPreferences,
     private val updates: UpdateRepository,
 ) : ViewModel() {
 
     val updatesEnabled: StateFlow<Boolean> = preferences.enabled
     val updateState: StateFlow<UpdateState> = updates.state
+
+    val photosInChart: StateFlow<Boolean> = chart.photosInChart
+
+    fun setPhotosInChart(enabled: Boolean) = chart.setPhotosInChart(enabled)
 
     private var work: Job? = null
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/theme/Color.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/theme/Color.kt
@@ -129,7 +129,25 @@ data class FTreeAccents(
      * to read.
      */
     val deceasedSurface: Color,
+    /**
+     * The ground an avatar sits on when there is no photograph.
+     *
+     * Two hues, not four: the pair is there so a chart of a hundred faceless cards still reads as
+     * a family rather than a wall of identical discs, and a third colour for "not recorded" would
+     * imply the app cares more about the answer than it does. [avatarOther] is deliberately the
+     * quietest of the three, since an unspecified gender is a first-class answer and should not
+     * look like a gap.
+     *
+     * Muted on purpose. These sit beside brass, which means "not known" everywhere in the app, and
+     * a saturated blue or pink would shout over the one colour in the chart that carries meaning.
+     */
+    val avatarMale: AvatarInk,
+    val avatarFemale: AvatarInk,
+    val avatarOther: AvatarInk,
 )
+
+/** A fill and the initial written on it. */
+data class AvatarInk(val fill: Color, val ink: Color)
 
 val LightAccents = FTreeAccents(
     unknown = Brass,
@@ -137,6 +155,9 @@ val LightAccents = FTreeAccents(
     spouseLink = Color(0xFF5E8C6D),
     rule = Color(0xFF9AA69B),
     deceasedSurface = Color(0xFFEAE8DE),
+    avatarMale = AvatarInk(fill = Color(0xFFD3E0EA), ink = Color(0xFF2C4657)),
+    avatarFemale = AvatarInk(fill = Color(0xFFF0DDD8), ink = Color(0xFF663D34)),
+    avatarOther = AvatarInk(fill = Color(0xFFDFE3DC), ink = Color(0xFF454C43)),
 )
 
 val DarkAccents = FTreeAccents(
@@ -145,4 +166,7 @@ val DarkAccents = FTreeAccents(
     spouseLink = Sage,
     rule = Color(0xFF5C665C),
     deceasedSurface = Color(0xFF11160F),
+    avatarMale = AvatarInk(fill = Color(0xFF2B3D4B), ink = Color(0xFFBCD4E4)),
+    avatarFemale = AvatarInk(fill = Color(0xFF46312A), ink = Color(0xFFEECAC0)),
+    avatarOther = AvatarInk(fill = Color(0xFF333930), ink = Color(0xFFC3C9C0)),
 )

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
@@ -4,20 +4,29 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
 import androidx.compose.ui.text.TextMeasurer
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.sp
 import com.vibethroughcode.ftree.data.PartialDate
 import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.graph.TreeMetrics
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
 
 /**
  * The chart's notation, in one place.
@@ -26,6 +35,27 @@ import kotlin.math.max
  * is the product's language, not a per-screen decision. A dashed brass edge means the same thing on
  * either, and it can only keep meaning the same thing if it is written once.
  */
+
+/**
+ * The part of the chart currently on screen, in layout units.
+ *
+ * Padded by a couple of cards so a node halfway off the edge is still drawn — and so that a face
+ * is already decoded by the time panning brings it into view. Both charts cull against this and
+ * ask for photographs against it, which is why it is written once rather than twice.
+ */
+internal fun visibleRegion(pan: Offset, zoom: Float, unitPx: Float, width: Float, height: Float): Rect =
+    Rect(
+        left = -pan.x / zoom / unitPx,
+        top = -pan.y / zoom / unitPx,
+        right = (width - pan.x) / zoom / unitPx,
+        bottom = (height - pan.y) / zoom / unitPx,
+    ).inflate(TreeMetrics.NODE_WIDTH * 2f)
+
+internal fun visibleRegion(pan: Offset, zoom: Float, unitPx: Float, viewport: IntSize): Rect =
+    visibleRegion(pan, zoom, unitPx, viewport.width.toFloat(), viewport.height.toFloat())
+
+internal fun visibleRegion(pan: Offset, zoom: Float, unitPx: Float, viewport: Size): Rect =
+    visibleRegion(pan, zoom, unitPx, viewport.width, viewport.height)
 
 /** How much of a card is drawn, which depends on how far out the chart is zoomed. */
 enum class CardDetail {
@@ -43,6 +73,9 @@ data class CardColors(
     val muted: Color,
     val outline: Color,
     val unknown: Color,
+    /** The disc behind an initial when there is no photograph, and the initial written on it. */
+    val avatarFill: Color,
+    val avatarInk: Color,
 )
 
 /**
@@ -65,6 +98,8 @@ fun DrawScope.drawPersonCard(
     rulePx: Float,
     emphasised: Boolean = false,
     alpha: Float = 1f,
+    /** The person's photograph, already cut to a thumbnail. Null draws the initial instead. */
+    photo: ImageBitmap? = null,
 ) {
     val path = Path().apply {
         addRoundRect(
@@ -118,15 +153,20 @@ fun DrawScope.drawPersonCard(
         )
     }
 
+    val radius = height * TreeMetrics.AVATAR_DIAMETER / 2f
+    val centre = Offset(left + height * TreeMetrics.AVATAR_INSET + radius, top + height / 2f)
+    drawAvatar(person, centre, radius, colors, detail, rulePx, alpha, photo, measurer)
+
     if (detail == CardDetail.SHAPE) return
 
-    val textWidth = (width - cornerPx * 2).toInt().coerceAtLeast(1)
+    val textLeft = centre.x + radius + height * TreeMetrics.AVATAR_INSET
+    val textWidth = (left + width - cornerPx * 0.8f - textLeft).toInt().coerceAtLeast(1)
     val name = person.name?.trim()?.takeIf { it.isNotEmpty() }
     val nameResult = measurer.measure(
         text = name ?: "Unknown",
         style = FTreeText.nodeName.copy(
             color = (if (name == null) colors.unknown else colors.onSurface).copy(alpha = alpha),
-            textAlign = TextAlign.Center,
+            textAlign = TextAlign.Start,
         ),
         maxLines = 2,
         overflow = TextOverflow.Ellipsis,
@@ -140,21 +180,117 @@ fun DrawScope.drawPersonCard(
                 text = it,
                 style = FTreeText.nodeYears.copy(
                     color = colors.muted.copy(alpha = alpha),
-                    textAlign = TextAlign.Center,
+                    textAlign = TextAlign.Start,
                 ),
                 maxLines = 1,
                 constraints = Constraints(maxWidth = textWidth),
             )
         }
 
+    // Left-aligned against the avatar rather than centred in what is left over: with a disc at the
+    // start of every card, a ragged left edge would make a row of siblings look misaligned.
     val block = nameResult.size.height + (yearsResult?.size?.height ?: 0)
     var y = top + max(0f, (height - block) / 2f)
-    drawText(nameResult, topLeft = Offset(left + (width - nameResult.size.width) / 2f, y))
+    drawText(nameResult, topLeft = Offset(textLeft, y))
     y += nameResult.size.height
-    yearsResult?.let {
-        drawText(it, topLeft = Offset(left + (width - it.size.width) / 2f, y))
-    }
+    yearsResult?.let { drawText(it, topLeft = Offset(textLeft, y)) }
 }
+
+/**
+ * The disc at the start of a card.
+ *
+ * Always drawn, whether or not there is a photograph and whether or not photographs are switched
+ * on, because it is the card's shape as much as its content: turning faces off must not make a
+ * hundred and fifty people move.
+ *
+ * Without a photograph it carries the initial on a ground coloured by gender — enough for a row of
+ * faceless cards to still read as people rather than as a wall of identical discs. Somebody whose
+ * name was never recorded keeps the dashed brass ring they have everywhere else in the app, since
+ * that is the notation for a gap in the record and it must not quietly become a grey circle here.
+ */
+private fun DrawScope.drawAvatar(
+    person: Person,
+    centre: Offset,
+    radius: Float,
+    colors: CardColors,
+    detail: CardDetail,
+    rulePx: Float,
+    alpha: Float,
+    photo: ImageBitmap?,
+    measurer: TextMeasurer,
+) {
+    if (photo != null) {
+        // Squared about the middle here rather than on the way to disk: a photograph that arrived
+        // in an import was never framed by anybody, and cutting it permanently would throw away
+        // what a later reader might want back.
+        val edge = min(photo.width, photo.height)
+        val diameter = (radius * 2f).roundToInt().coerceAtLeast(1)
+        val topLeft = IntOffset((centre.x - radius).roundToInt(), (centre.y - radius).roundToInt())
+
+        clipPath(Path().apply { addOval(Rect(centre, radius)) }) {
+            drawImage(
+                image = photo,
+                srcOffset = IntOffset((photo.width - edge) / 2, (photo.height - edge) / 2),
+                srcSize = IntSize(edge, edge),
+                dstOffset = topLeft,
+                dstSize = IntSize(diameter, diameter),
+                alpha = alpha,
+            )
+        }
+        drawCircle(
+            color = colors.outline,
+            radius = radius,
+            center = centre,
+            alpha = alpha,
+            style = Stroke(width = rulePx * 0.8f),
+        )
+        return
+    }
+
+    if (person.isUnnamed) {
+        drawCircle(
+            color = colors.unknown,
+            radius = radius,
+            center = centre,
+            alpha = alpha,
+            style = Stroke(
+                width = rulePx,
+                pathEffect = PathEffect.dashPathEffect(floatArrayOf(rulePx * 2.5f, rulePx * 2f)),
+            ),
+        )
+    } else {
+        drawCircle(color = colors.avatarFill, radius = radius, center = centre, alpha = alpha)
+    }
+
+    if (detail == CardDetail.SHAPE) return
+
+    val mark = if (person.isUnnamed) "?" else person.name!!.trim().first().uppercase()
+    val measured = measurer.measure(
+        text = mark,
+        style = FTreeText.nodeName.copy(
+            color = (if (person.isUnnamed) colors.unknown else colors.avatarInk).copy(alpha = alpha),
+            fontSize = pxAsSp(radius * 0.95f),
+        ),
+        maxLines = 1,
+    )
+    drawText(
+        measured,
+        topLeft = Offset(
+            centre.x - measured.size.width / 2f,
+            centre.y - measured.size.height / 2f,
+        ),
+    )
+}
+
+/**
+ * A size in canvas pixels expressed as sp.
+ *
+ * The reader's font scale is divided back out deliberately. Everywhere else in the app text grows
+ * with that setting, but this one glyph has to fit inside a circle of a fixed size, and a letter
+ * that grows past its disc reads as a bug rather than as an accommodation. The names on the card
+ * still scale, and the cards grow to hold them.
+ */
+private fun DrawScope.pxAsSp(px: Float) = (px / (density * fontScale)).sp
 
 /** Years only — a card has room for a span, not a date. */
 fun Person.lifespan(): String? {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartPhotos.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartPhotos.kt
@@ -1,0 +1,113 @@
+package com.vibethroughcode.ftree.ui.tree
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.data.PhotoStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+/**
+ * The faces currently on the chart.
+ *
+ * Coil draws the photographs everywhere else in the app, but the chart is one `Canvas` rather than
+ * a composable per person, so there is nothing for an `AsyncImage` to be attached to. This is the
+ * equivalent for a drawn surface: ask for the faces that are actually on screen, decode them off
+ * the main thread, and hold them in snapshot state so that a face arriving re-runs the *draw*
+ * phase and nothing else.
+ *
+ * Bounded twice over, which is what makes photographs affordable on a chart of a thousand people.
+ * Only what the viewport can see is ever asked for, and what is held is capped at [LIMIT] faces
+ * decoded to [EDGE_PX] in `RGB_565` — about fifty kilobytes each, so the worst case is a few
+ * megabytes and the ordinary case, a screenful of cards, is a few hundred kilobytes.
+ */
+@Stable
+class ChartPhotos(
+    private val store: PhotoStore,
+    private val scope: CoroutineScope,
+) {
+    private val images = mutableStateMapOf<String, ImageBitmap>()
+
+    /** Photos whose file is gone or unreadable; asked for once, then left alone. */
+    private val unreadable = mutableSetOf<String>()
+
+    private var work: Job? = null
+
+    /** Read from inside the draw lambda, so an arriving face invalidates the drawing only. */
+    fun image(photoId: String?): ImageBitmap? = photoId?.let { images[it] }
+
+    /**
+     * Says which faces are on screen, in the order they should appear.
+     *
+     * Anything already held that is no longer wanted is dropped once the cap is reached, so panning
+     * across a large family trades faces in and out rather than accumulating them.
+     */
+    fun request(photoIds: List<String>) {
+        val wanted = photoIds.distinct().take(LIMIT)
+        if (images.size > LIMIT) {
+            val keep = wanted.toSet()
+            images.keys.filterNot { it in keep }
+                .take(images.size - LIMIT)
+                .forEach { images.remove(it) }
+        }
+
+        val todo = wanted.filter { it !in images && it !in unreadable }
+        if (todo.isEmpty()) return
+
+        // One decode at a time, restarted as the viewport moves. Anything already decoded is kept,
+        // so a cancelled pass costs at most the one face it was in the middle of.
+        work?.cancel()
+        work = scope.launch {
+            todo.forEach { id ->
+                val bitmap = store.thumbnail(id, EDGE_PX)
+                if (bitmap == null) unreadable += id else images[id] = bitmap.asImageBitmap()
+            }
+        }
+    }
+
+    fun clear() {
+        work?.cancel()
+        work = null
+        images.clear()
+        unreadable.clear()
+    }
+
+    companion object {
+        /**
+         * Enough for a card at the deepest zoom without carrying a stored photograph's full 512px
+         * into memory once per person.
+         */
+        const val EDGE_PX = 160
+        const val LIMIT = 160
+    }
+}
+
+/**
+ * The chart's face cache, or nothing when the reader has turned photographs off.
+ *
+ * Returning null rather than an empty cache is deliberate: it makes "photos are off" a fact the
+ * drawing code cannot forget to check, and it means a chart with the setting off does not open a
+ * single file.
+ */
+@Composable
+fun rememberChartPhotos(enabled: Boolean): ChartPhotos? {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val photos = remember(context) {
+        ChartPhotos((context.applicationContext as FTreeApplication).container.photoStore, scope)
+    }
+
+    // Turning the setting off gives the memory back straight away rather than at the next
+    // navigation, which is the whole point of somebody reaching for it on a large tree.
+    LaunchedEffect(enabled) { if (!enabled) photos.clear() }
+
+    return photos.takeIf { enabled }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -7,14 +7,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.input.pointer.pointerInput
@@ -31,8 +32,10 @@ import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.graph.TreeLayout
 import com.vibethroughcode.ftree.graph.TreeMetrics
+import com.vibethroughcode.ftree.ui.common.avatarFor
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 const val FamilyChartTag = "family-chart"
 
@@ -51,6 +54,8 @@ fun FamilyChart(
     layout: TreeLayout,
     onSelect: (Person) -> Unit,
     modifier: Modifier = Modifier,
+    /** The face cache, or null when the reader has turned photographs off. */
+    photos: ChartPhotos? = null,
 ) {
     // Text painted onto a canvas is invisible to a screen reader, and giving every node its own
     // semantics would mean composing one per person on every pan. The chart therefore describes
@@ -108,6 +113,30 @@ fun FamilyChart(
     val spouseGapPx = with(density) { 2.dp.toPx() }
     val unitPx = with(density) { 1.dp.toPx() }
 
+    /*
+     * Which faces to decode: the ones on screen, and only those.
+     *
+     * Derived state read from a flow rather than from composition, so panning across a family
+     * recomputes this list and nothing recomposes. Without that, every face on a chart of a
+     * thousand would have to be decoded before the first one could be drawn.
+     */
+    val wantedPhotos = remember(layout, photos, unitPx) {
+        derivedStateOf {
+            if (photos == null || viewport == IntSize.Zero) emptyList() else {
+                val region = visibleRegion(pan, zoom, unitPx, viewport)
+                layout.nodes.asSequence()
+                    .filter { it.x + it.width >= region.left && it.x <= region.right &&
+                        it.y + it.height >= region.top && it.y <= region.bottom }
+                    .mapNotNull { it.person.photoId }
+                    .toList()
+            }
+        }
+    }
+    LaunchedEffect(wantedPhotos, photos) {
+        val cache = photos ?: return@LaunchedEffect
+        snapshotFlow { wantedPhotos.value }.distinctUntilChanged().collect(cache::request)
+    }
+
     Canvas(
         modifier = modifier
             .fillMaxSize()
@@ -137,12 +166,7 @@ fun FamilyChart(
 
         // In layout units, the region currently on screen, padded by a node so partially visible
         // cards are not clipped away.
-        val visible = Rect(
-            left = -currentPan.x / currentZoom / unitPx,
-            top = -currentPan.y / currentZoom / unitPx,
-            right = (size.width - currentPan.x) / currentZoom / unitPx,
-            bottom = (size.height - currentPan.y) / currentZoom / unitPx,
-        ).inflate(TreeMetrics.NODE_WIDTH * 2f)
+        val visible = visibleRegion(currentPan, currentZoom, unitPx, size)
 
         translate(currentPan.x, currentPan.y) {
             scale(currentZoom, currentZoom, Offset.Zero) {
@@ -203,11 +227,14 @@ fun FamilyChart(
                                 else -> accents.rule
                             },
                             unknown = accents.unknown,
+                            avatarFill = accents.avatarFor(node.person.gender).fill,
+                            avatarInk = accents.avatarFor(node.person.gender).ink,
                         ),
                         detail = CardDetail.NAME_AND_YEARS,
                         cornerPx = cornerPx,
                         rulePx = rulePx,
                         emphasised = node.isFocus,
+                        photo = photos?.image(node.person.photoId),
                     )
                 }
             }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
@@ -59,6 +62,7 @@ import com.vibethroughcode.ftree.ui.common.EmptyState
 import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.TreeGlyph
 import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.isShortWindow
 import com.vibethroughcode.ftree.ui.common.relativeKindLabel
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 
@@ -98,6 +102,8 @@ fun TreeScreen(
     wholeTreeViewModel: WholeTreeViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val photosInChart by viewModel.photosInChart.collectAsStateWithLifecycle()
+    val photos = rememberChartPhotos(photosInChart)
     val wholeState by wholeTreeViewModel.uiState.collectAsStateWithLifecycle()
     val highlighted by wholeTreeViewModel.highlighted.collectAsStateWithLifecycle()
     val wholeSelection by wholeTreeViewModel.selected.collectAsStateWithLifecycle()
@@ -131,46 +137,59 @@ fun TreeScreen(
 
     val treeIsEmpty = state.treeIsEmpty && wholeState.isEmpty
 
+    /*
+     * On a short window the chart's own furniture is folded into one row.
+     *
+     * A title bar, a mode switch and a line of counts is a reasonable third of a phone held
+     * upright and most of it held sideways. The title goes first — the chart is the screen you are
+     * on, and the navigation already says so — then the counts, which describe the record rather
+     * than what is being looked at and are a rotation away.
+     */
+    val short = isShortWindow()
+
+    val onModeChange: (ChartMode) -> Unit = {
+        mode = it
+        // Clearing the fade on the way out means the other chart is never entered with two thirds
+        // of it greyed from a selection you cannot see.
+        if (it == ChartMode.FOCUSED) wholeTreeViewModel.select(null)
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = {
             Column {
-                CenterAlignedTopAppBar(
-                    title = { Text(stringResource(R.string.tree_title)) },
-                    actions = {
-                        if (!treeIsEmpty) {
-                            IconButton(
-                                onClick = { onRelate(null) },
-                                modifier = Modifier.testTag(TreeRelateTag),
-                            ) {
-                                Icon(
-                                    Icons.Default.CompareArrows,
-                                    contentDescription = stringResource(R.string.relation_find),
+                if (!short || treeIsEmpty) {
+                    CenterAlignedTopAppBar(
+                        title = { Text(stringResource(R.string.tree_title)) },
+                        actions = {
+                            if (!treeIsEmpty) {
+                                ChartActions(
+                                    showRelate = true,
+                                    showMore = mode == ChartMode.FOCUSED && state.layout.truncated,
+                                    onRelate = { onRelate(null) },
+                                    onMore = viewModel::showMoreGenerations,
                                 )
                             }
-                        }
-                        if (mode == ChartMode.FOCUSED && state.layout.truncated) {
-                            IconButton(onClick = viewModel::showMoreGenerations) {
-                                Icon(
-                                    Icons.Default.UnfoldMore,
-                                    contentDescription = stringResource(R.string.tree_more_generations),
-                                )
-                            }
-                        }
-                    },
-                )
+                        },
+                    )
+                }
                 if (!treeIsEmpty) {
                     ChartModeBar(
                         mode = mode,
-                        onModeChange = {
-                            mode = it
-                            // Clearing the fade on the way out means the other chart is never
-                            // entered with two thirds of it greyed from a selection you cannot see.
-                            if (it == ChartMode.FOCUSED) wholeTreeViewModel.select(null)
-                        },
-                        summary = wholeSummary(wholeState).takeIf { mode == ChartMode.WHOLE },
+                        onModeChange = onModeChange,
+                        summary = wholeSummary(wholeState)
+                            .takeIf { mode == ChartMode.WHOLE && !short },
                         tracing = tracing.isNotEmpty() && mode == ChartMode.WHOLE,
                         onClearTrace = onClearTrace,
+                        compact = short,
+                        actions = if (!short) null else ({
+                            ChartActions(
+                                showRelate = true,
+                                showMore = mode == ChartMode.FOCUSED && state.layout.truncated,
+                                onRelate = { onRelate(null) },
+                                onMore = viewModel::showMoreGenerations,
+                            )
+                        }),
                     )
                 }
             }
@@ -198,7 +217,11 @@ fun TreeScreen(
 
                 mode == ChartMode.FOCUSED -> when {
                     state.loading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
-                    else -> FamilyChart(layout = state.layout, onSelect = { selected = it })
+                    else -> FamilyChart(
+                        layout = state.layout,
+                        onSelect = { selected = it },
+                        photos = photos,
+                    )
                 }
 
                 else -> when {
@@ -212,6 +235,7 @@ fun TreeScreen(
                         // Nothing to fade while tracing: everybody drawn is on the line.
                         highlighted = if (tracing.isNotEmpty()) emptySet() else highlighted,
                         tracing = tracing.isNotEmpty(),
+                        photos = photos,
                         onSelect = {
                             wholeTreeViewModel.select(it)
                             selected = it
@@ -268,13 +292,12 @@ private fun ChartModeBar(
     summary: String?,
     tracing: Boolean,
     onClearTrace: () -> Unit,
+    /** Fold the switch, the app bar's actions and the way out of a trace into a single row. */
+    compact: Boolean = false,
+    actions: (@Composable RowScope.() -> Unit)? = null,
 ) {
-    Column(Modifier.fillMaxWidth()) {
-        SingleChoiceSegmentedButtonRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 24.dp, vertical = 4.dp),
-        ) {
+    val modeSwitch: @Composable (Modifier) -> Unit = { switchModifier ->
+        SingleChoiceSegmentedButtonRow(modifier = switchModifier) {
             SegmentedButton(
                 selected = mode == ChartMode.FOCUSED,
                 onClick = { onModeChange(ChartMode.FOCUSED) },
@@ -289,33 +312,87 @@ private fun ChartModeBar(
                 modifier = Modifier.testTag(TreeModeWholeTag),
             ) { Text(stringResource(R.string.tree_mode_whole)) }
         }
+    }
 
-        // While a line is traced, saying so — and offering the way out — matters more than the
-        // record's counts, which are unchanged and still a chip away.
-        if (tracing) {
+    val clearTrace: @Composable () -> Unit = {
+        TextButton(onClick = onClearTrace, modifier = Modifier.testTag(TreeClearTraceTag)) {
+            Text(stringResource(R.string.relation_clear))
+        }
+    }
+
+    Column(Modifier.fillMaxWidth()) {
+        if (compact) {
             Row(
-                modifier = Modifier.fillMaxWidth().padding(start = 24.dp, end = 12.dp),
+                modifier = Modifier.fillMaxWidth().padding(start = 12.dp, end = 4.dp, top = 4.dp, bottom = 4.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
+                // Capped rather than stretched: the switch is two words wide and a landscape screen
+                // is not, and what is left over belongs to the chart rather than to the furniture.
+                modeSwitch(Modifier.widthIn(min = 340.dp, max = 420.dp))
+                Spacer(Modifier.weight(1f))
+                if (tracing) clearTrace()
+                actions?.invoke(this)
+            }
+        } else {
+            modeSwitch(Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 4.dp))
+
+            // While a line is traced, saying so — and offering the way out — matters more than the
+            // record's counts, which are unchanged and still a chip away.
+            if (tracing) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(start = 24.dp, end = 12.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = stringResource(R.string.relation_tracing),
+                        style = FTreeText.recordSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.weight(1f),
+                    )
+                    clearTrace()
+                }
+            } else summary?.let {
                 Text(
-                    text = stringResource(R.string.relation_tracing),
+                    text = it,
                     style = FTreeText.recordSmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp),
                 )
-                TextButton(onClick = onClearTrace, modifier = Modifier.testTag(TreeClearTraceTag)) {
-                    Text(stringResource(R.string.relation_clear))
-                }
             }
-        } else summary?.let {
-            Text(
-                text = it,
-                style = FTreeText.recordSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(horizontal = 24.dp, vertical = 6.dp),
-            )
         }
         HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant)
+    }
+}
+
+/**
+ * The chart's two app-bar actions, wherever the bar happens to be.
+ *
+ * Written once because on a short window they move out of the title bar and into the mode row, and
+ * an action that changes what it does depending on where it is drawn would be a bug waiting to be
+ * written.
+ */
+@Composable
+private fun ChartActions(
+    showRelate: Boolean,
+    showMore: Boolean,
+    onRelate: () -> Unit,
+    onMore: () -> Unit,
+) {
+    if (showRelate) {
+        IconButton(onClick = onRelate, modifier = Modifier.testTag(TreeRelateTag)) {
+            Icon(
+                Icons.Default.CompareArrows,
+                contentDescription = stringResource(R.string.relation_find),
+            )
+        }
+    }
+    if (showMore) {
+        IconButton(onClick = onMore) {
+            Icon(
+                Icons.Default.UnfoldMore,
+                contentDescription = stringResource(R.string.tree_more_generations),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeViewModel.kt
@@ -3,6 +3,7 @@ package com.vibethroughcode.ftree.ui.tree
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vibethroughcode.ftree.data.ChartPreferences
 import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.graph.TreeLayout
@@ -35,11 +36,20 @@ data class TreeUiState(
 
 class TreeViewModel(
     private val repository: FamilyRepository,
+    chartPreferences: ChartPreferences,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TreeUiState())
     val uiState: StateFlow<TreeUiState> = _uiState.asStateFlow()
+
+    /**
+     * Whether the chart draws photographs.
+     *
+     * Read here rather than by each chart so both of them, and the setting, cannot disagree — and
+     * so that flipping it never touches the layout, which is what keeps the cards still.
+     */
+    val photosInChart: StateFlow<Boolean> = chartPreferences.photosInChart
 
     /**
      * Survives process death, so returning to the app puts you back where you were looking rather

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -38,8 +40,10 @@ import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.graph.TreeMetrics
 import com.vibethroughcode.ftree.graph.WholeTreeLayout
+import com.vibethroughcode.ftree.ui.common.avatarFor
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 const val WholeFamilyChartTag = "whole-family-chart"
 
@@ -64,6 +68,8 @@ fun WholeFamilyChart(
     highlighted: Set<String> = emptySet(),
     /** True when [layout] holds one traced relation rather than the whole record. */
     tracing: Boolean = false,
+    /** The face cache, or null when the reader has turned photographs off. */
+    photos: ChartPhotos? = null,
 ) {
     val description = if (tracing) {
         stringResource(R.string.a11y_traced_chart, layout.nodes.size)
@@ -139,6 +145,30 @@ fun WholeFamilyChart(
     val spouseGapPx = with(density) { 2.dp.toPx() }
     val unitPx = with(density) { 1.dp.toPx() }
 
+    /*
+     * Which faces to decode: the ones on screen, and only when the chart is close enough in for a
+     * card to be more than a shape. Pulled right back, a face would be a handful of pixels and
+     * decoding four hundred of them would buy nothing the coloured discs do not already say.
+     */
+    val wantedPhotos = remember(layout, photos, unitPx) {
+        derivedStateOf {
+            if (photos == null || viewport == IntSize.Zero || zoom < SHOW_NAMES) emptyList() else {
+                val region = visibleRegion(pan, zoom, unitPx, viewport)
+                layout.nodes.asSequence()
+                    .filter {
+                        it.x + TreeMetrics.NODE_WIDTH >= region.left && it.x <= region.right &&
+                            it.y + TreeMetrics.NODE_HEIGHT >= region.top && it.y <= region.bottom
+                    }
+                    .mapNotNull { it.person.photoId }
+                    .toList()
+            }
+        }
+    }
+    LaunchedEffect(wantedPhotos, photos) {
+        val cache = photos ?: return@LaunchedEffect
+        snapshotFlow { wantedPhotos.value }.distinctUntilChanged().collect(cache::request)
+    }
+
     Canvas(
         modifier = modifier
             .fillMaxSize()
@@ -176,12 +206,7 @@ fun WholeFamilyChart(
         val showLabels = currentZoom >= SHOW_LABELS && !tracing
         val dimming = highlighted.isNotEmpty()
 
-        val visible = Rect(
-            left = -currentPan.x / currentZoom / unitPx,
-            top = -currentPan.y / currentZoom / unitPx,
-            right = (size.width - currentPan.x) / currentZoom / unitPx,
-            bottom = (size.height - currentPan.y) / currentZoom / unitPx,
-        ).inflate(TreeMetrics.NODE_WIDTH * 2f)
+        val visible = visibleRegion(currentPan, currentZoom, unitPx, size)
 
         translate(currentPan.x, currentPan.y) {
             scale(currentZoom, currentZoom, Offset.Zero) {
@@ -237,12 +262,22 @@ fun WholeFamilyChart(
                             ),
                             maxLines = 1,
                         )
+                        /*
+                         * Normally the label sits on top of the frame, where it reads as a caption.
+                         * When the frame is against the top of the viewport there is no "on top of"
+                         * left — the label would be clipped, or printed over the header sitting
+                         * directly above the canvas — so it drops inside the frame's own padding
+                         * instead, where there is room by construction.
+                         */
+                        val above = group.y * unitPx - label.size.height - rulePx * 3
+                        val room = above >= -currentPan.y / currentZoom
                         drawText(
                             label,
-                            topLeft = Offset(
-                                group.x * unitPx,
-                                group.y * unitPx - label.size.height - rulePx * 3,
-                            ),
+                            topLeft = if (room) {
+                                Offset(group.x * unitPx, above)
+                            } else {
+                                Offset(group.x * unitPx + rulePx * 4, group.y * unitPx + rulePx * 3)
+                            },
                         )
                     }
                 }
@@ -325,12 +360,16 @@ fun WholeFamilyChart(
                                 else -> accents.rule
                             },
                             unknown = accents.unknown,
+                            avatarFill = accents.avatarFor(node.person.gender).fill,
+                            avatarInk = accents.avatarFor(node.person.gender).ink,
                         ),
                         detail = detail,
                         cornerPx = cornerPx,
                         rulePx = rulePx,
                         emphasised = isSelected,
                         alpha = if (near) 1f else 0.3f,
+                        photo = if (detail == CardDetail.SHAPE) null
+                        else photos?.image(node.person.photoId),
                     )
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,12 @@
     <string name="photo_add">Add a photo</string>
     <string name="photo_change">Change photo</string>
     <string name="photo_remove">Remove photo</string>
+    <string name="photo_crop_title">Frame the photo</string>
+    <string name="photo_crop_hint">Drag to move, pinch to zoom. A photo is always shown as a circle.</string>
+    <string name="photo_crop_use">Use photo</string>
+    <string name="photo_crop_cancel">Cancel</string>
+    <string name="photo_crop_unreadable">That image could not be opened.</string>
+    <string name="a11y_crop_area">The photo being framed. Drag to move it, pinch to zoom.</string>
 
     <!-- Import and export -->
     <string name="export_tree">Export your tree</string>
@@ -250,6 +256,9 @@
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>
+    <string name="settings_section_chart">Chart</string>
+    <string name="settings_photos_toggle">Photos on the chart</string>
+    <string name="settings_photos_explainer">Draws each person\'s photograph on their card. On a very large family this can make the chart slower to pan and zoom, and it uses more memory — turn it off and the chart draws initials instead. Nothing else changes: the cards stay exactly where they are.</string>
     <string name="settings_section_updates">Updates</string>
     <string name="settings_section_data">Your data</string>
     <string name="settings_section_about">About</string>

--- a/app/src/test/java/com/vibethroughcode/ftree/ui/person/CircleCropTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/ui/person/CircleCropTest.kt
@@ -1,0 +1,102 @@
+package com.vibethroughcode.ftree.ui.person
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * What ends up saved when a photograph is framed.
+ *
+ * These are the sums the reader cannot check by eye: they choose a face in a circle and get back a
+ * square of pixels, and being a few percent out is invisible on the crop screen and permanent in
+ * the file. The wide 2000x1000 image is the interesting shape — the circle has room to slide along
+ * one axis and none at all along the other.
+ */
+class CircleCropTest {
+
+    private val wide = 2000 to 1000
+    private val diameter = 500f
+
+    private fun scale(zoom: Float = 1f) =
+        CircleCrop.baseScale(wide.first, wide.second, diameter) * zoom
+
+    @Test
+    fun theSmallestScaleExactlyCoversTheWindow() {
+        val base = CircleCrop.baseScale(wide.first, wide.second, diameter)
+
+        // The short side is what has to reach across the circle; anything less would show a
+        // crescent of nothing, which is the case the crop screen is built never to allow.
+        assertEquals(0.5f, base, 0.0001f)
+        assertEquals(diameter, wide.second * base, 0.01f)
+    }
+
+    @Test
+    fun theShortAxisHasNowhereToGoAndTheLongAxisHasHalfTheOverhang() {
+        assertEquals(0f, CircleCrop.offsetLimit(wide.second, scale(), diameter), 0.0001f)
+        assertEquals(250f, CircleCrop.offsetLimit(wide.first, scale(), diameter), 0.0001f)
+    }
+
+    @Test
+    fun untouchedFramingTakesTheMiddleOfThePicture() {
+        val crop = CircleCrop.source(wide.first, wide.second, diameter, scale(), 0f, 0f)
+
+        assertEquals(1000, crop.size)
+        assertEquals(500, crop.x)
+        assertEquals(0, crop.y)
+    }
+
+    @Test
+    fun draggingToEitherLimitLandsExactlyOnAnEdge() {
+        val left = CircleCrop.source(wide.first, wide.second, diameter, scale(), 250f, 0f)
+        val right = CircleCrop.source(wide.first, wide.second, diameter, scale(), -250f, 0f)
+
+        assertEquals(0, left.x)
+        assertEquals(wide.first - right.size, right.x)
+    }
+
+    @Test
+    fun zoomingInHalvesTheSquareAndKeepsItCentred() {
+        val crop = CircleCrop.source(wide.first, wide.second, diameter, scale(zoom = 2f), 0f, 0f)
+
+        assertEquals(500, crop.size)
+        assertEquals(750, crop.x)
+        assertEquals(250, crop.y)
+    }
+
+    @Test
+    fun theSquareIsAlwaysInsideThePictureHoweverFarItIsPushed() {
+        // Offsets well past what the screen allows, in case a resize ever lets one through: a crop
+        // out of bounds is not a wrong picture, it is a crash out of Bitmap.createBitmap.
+        val offsets = listOf(-9000f, -300f, -1f, 0f, 1f, 300f, 9000f)
+        val zooms = listOf(1f, 1.3f, 2f, 5.5f)
+
+        for (zoom in zooms) {
+            for (x in offsets) {
+                for (y in offsets) {
+                    val crop = CircleCrop.source(
+                        wide.first, wide.second, diameter, scale(zoom), x, y,
+                    )
+                    assertTrue("$crop at zoom $zoom", crop.x >= 0 && crop.y >= 0)
+                    assertTrue("$crop at zoom $zoom", crop.x + crop.size <= wide.first)
+                    assertTrue("$crop at zoom $zoom", crop.y + crop.size <= wide.second)
+                    assertTrue("$crop at zoom $zoom", crop.size > 0)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun aPictureWithNoPixelsAsksForNothingRatherThanFailing() {
+        assertEquals(0, CircleCrop.source(0, 0, diameter, 1f, 0f, 0f).size)
+        assertEquals(1f, CircleCrop.baseScale(0, 0, diameter), 0.0001f)
+    }
+
+    @Test
+    fun aTallPictureSlidesVerticallyInstead() {
+        val crop = CircleCrop.source(1000, 2000, diameter, 0.5f, 0f, 250f)
+
+        assertEquals(1000, crop.size)
+        assertEquals(0, crop.x)
+        assertEquals(0, crop.y)
+    }
+}


### PR DESCRIPTION
Four things, in the order they were asked for.

## A face on every card

Each chart card now opens with a circular portrait — the square the reader framed where there is a
photograph, and the person's initial on a ground coloured by gender where there is not. The second
case is the common one and it is the point: a chart of a hundred faceless cards should still read as
people rather than as a wall of identical discs. A person whose name was never recorded keeps the
dashed brass ring they have everywhere else, because that is the notation for a gap in the record
and it must not quietly become a grey circle here.

Cards widen from 132 to 160 units to hold the disc beside the name. The disc is part of the card at
every zoom and whether or not photographs are switched on, which is what makes the setting below
free of consequences.

## Photographs, affordably

The chart is one `Canvas`, so there is no `AsyncImage` for a face to hang from. `ChartPhotos` is the
equivalent for a drawn surface: it asks only for the faces the viewport can see, decodes them off the
main thread at 160px in `RGB_565` — about fifty kilobytes each — and holds them in snapshot state, so
a face arriving re-runs the *draw* phase and nothing else. What is held is capped, so panning across
a thousand people trades faces in and out rather than accumulating them, and nothing is decoded at a
zoom where a card is only a shape.

**Settings → Photos on the chart** turns them off for a very large tree. On by default, unlike the
updater's switch: nothing here leaves the device or costs anything the reader has not already paid
for. It changes what is drawn inside the disc and never the layout, so it does not rearrange a
hundred and fifty people to save some memory — verified on the real tree, every card in the same
place with it on and off.

## A mandatory circular crop

A face is drawn as a circle everywhere in this app, so letting the app pick the middle of somebody's
holiday snap is how a chart ends up full of shoulders and hedges. Every picked photograph now goes
through a framing step: a fixed circular window with the picture moving behind it. That makes the
awkward case impossible — the picture can never be smaller than the window, so there is no way to
frame a crescent of nothing and no error message needed to say so.

What is stored is the square, not a circle: roundness is redrawn by every place that shows a face, so
a round image would only mean carrying an alpha channel to save a shape we draw anyway. Kept at
512px rather than 1024 — sharper than any circle here can show even on a 4x screen, and about twenty
kilobytes a person instead of several hundred. Measured: a 3000x2000, 280 KB original comes out at
16 KB.

The sums are in `CircleCrop`, free of any Android type, so the part that can be wrong — which pixels
end up saved — is tested on the JVM rather than checked by eye.

Two related bugs went with it: picking a new photograph used to delete the one the person still had
even if you then backed out, and framing several and keeping one used to leave the losers on disk.

## A landscape that is mostly chart

A phone on its side has about 360dp of height and the app was spending a third of it on a title bar,
a mode switch, a line of counts and a navigation bar — all stacked along the axis a family tree is
read down. On a short window the three destinations move to a rail and the chart's furniture folds
into one row. On the real 148-person tree that is the difference between two generations on screen
and four.

Reading matter goes the other way: a list of names stretched across a landscape phone puts the name
at one edge and the date at the other, so the lists, forms and settings are held to a readable
measure and centred. The charts are exempt — they are pictures, not prose.

The settings switches also became targets in their own right, since a 32dp control at the far edge
of a landscape phone is fine in a mock-up and irritating in the hand.

## Also fixed

Bundled into "a face on every card": a group's caption on the whole-tree chart was printing through
the header whenever the frame sat against the top of the viewport. It now drops inside the frame's
own padding, where there is room by construction.

## Verification

- 148 unit tests, 114 instrumented, lint clean.
- Exercised on the emulator against the real 148-person tree, in the **R8-minified release build**:
  import, framing a photograph, faces on both charts, the setting on and off, and landscape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)