### PR TITLE
Name relationships in Hindi

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ replacing it**.
   removed", "great-great-grandfather" — and lists every person the line runs through, which is the
   form that can also answer the ones English has no word for. It walks marriages as well as blood,
   and will draw the line across the whole-tree chart.
+- **Relationships in Hindi.** Turn on *Family words → हिन्दी* and the app names relationships the way
+  the family does: your mother's brother is **मामा**, your father's younger brother **चाचा**, his
+  wife **चाची**. Not a translation — Hindi has five words where English has "uncle", and picking the
+  right one needs facts English discards. See [docs/kinship-hindi.md](docs/kinship-hindi.md).
 - **Optional in-app updates.** Off until switched on. Checks GitHub for a newer release and installs
   it over the running copy, so a new version keeps your tree instead of costing an export and an
   import.
@@ -173,6 +177,31 @@ a round image would only mean carrying an alpha channel to save a shape we redra
 at 512px, which is sharper than any circle in the app can show even on a 4x screen, and costs about
 twenty kilobytes a person rather than several hundred.
 
+### Naming a relationship in another language
+
+English kinship is two numbers: how many generations up to a shared ancestor, how many back down.
+"Uncle" needs neither the side of the family nor a birth order, so `termFor(up, down)` throws both
+away. Hindi needs them, and so does most of the world outside western Europe.
+
+So the distances stay exactly as they were and a `KinshipPath` rides alongside, carrying the genders
+the line actually ran through and — where the dates prove it — which of two siblings was born first.
+Nothing about English changed, which is why every existing answer and the web viewer still agree.
+
+`graph/HindiKinship.kt` reads that path and returns an *enum*, not a string, so the risky part —
+which of five words English calls "uncle" — is plain Kotlin under JVM test. The spelling lives in
+`res/values/kinship_hi.xml`, a flat list a Hindi speaker can review in one sitting.
+
+Two properties are worth the tests they get. First, **a word is claimed only when the record earns
+it**: ताऊ is an elder brother and चाचा a younger one, so with no birth years the app says
+पिता के भाई and offers to sharpen it. Second, **every relationship must agree with its opposite
+number** — if B is A's मामा then A must be B's भांजा or भांजी, computed independently from the other
+end of the graph. Over every ordered pair of a whole family that is not a property you can satisfy by
+accident, and cousins are the sharpest case: a फुफेरा भाई must see you as his ममेरा भाई.
+
+Hindi falls back to English where it genuinely has no word — second cousins, great-uncles — because
+that is what Hindi speakers do, and because a Devanagari compound nobody says would be worse than
+the English word.
+
 ### Relating two people
 
 Two questions with different failure modes, so they are answered separately (`graph/Kinship.kt`,
@@ -297,6 +326,9 @@ Re-importing the same file, or the app's own export, is a no-op.
 | No dynamic colour | Brass means "not known" throughout, including in the chart's notation; a wallpaper-derived palette would reassign that meaning |
 | One `Canvas` for the chart | At a few hundred people, a composable per node costs far more than the drawing |
 | Backup file instead of transactional undo | A file the user can re-import is a far simpler promise, and it cannot itself go wrong |
+| The path kept beside the distances, not instead of them | English answers, their tests, and the web viewer are all untouched by adding a second language |
+| Hindi rules return an enum, not a string | Puts the part that can be wrong under JVM test, and leaves the words in a list somebody can review |
+| Descriptive term rather than a guess at चाचा/ताऊ | Guessing is wrong half the time in a way a family notices at once |
 | A mandatory circular crop, stored square | The face is shown in a circle everywhere; framing it as a rectangle and hoping would mean choosing one thing and seeing another |
 | Photographs off changes drawing, never layout | A setting that rearranged a hundred and fifty people would cost more than the memory it saves |
 | A rail on a short window, not a bottom bar | A bottom bar takes eighty of a landscape phone's three hundred and sixty dp from the axis a tree is read along |
@@ -490,6 +522,12 @@ framework, no networking, no analytics.
 - **GEDCOM import/export.** A large format for a lightweight app; the documented `.ftree` schema
   covers sharing between users of this app.
 - **A whole-graph chart.** Unreadable at any real family size; re-focusing is the answer.
+- **A Hindi interface.** Only the family *words* change with the setting; buttons, settings and error
+  messages stay English. Translating those is a separate job needing a fluent reviewer, and a
+  half-translated app reads worse than an English one.
+- **Languages beyond Hindi.** The path model covers Bengali, Marathi, Gujarati, Punjabi, Tamil and
+  Telugu structurally, and each is then a word list plus a small rules file — but kinship terms
+  should not ship in a language without a native speaker checking them.
 
 ## Licence
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -121,3 +121,15 @@ dependencies {
     androidTestImplementation(libs.androidx.room.testing)
     androidTestImplementation(libs.kotlinx.coroutines.test)
 }
+
+/**
+ * Lets the Hindi kinship sweep run against a real exported tree rather than only the built-in one:
+ *
+ *     ./gradlew testDebugUnitTest -Dftree.tree=temp/family-tree.ftree
+ *
+ * Forwarded explicitly because a `-D` on the Gradle command line reaches the daemon, not the JVM the
+ * tests run in. Absent, the sweep uses its own family and the real-tree case is skipped.
+ */
+tasks.withType<Test>().configureEach {
+    System.getProperty("ftree.tree")?.let { systemProperty("ftree.tree", it) }
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,8 +1,8 @@
 # --- Enum names are data ---------------------------------------------------------------------
 #
 # Gender, RelationshipType and RelativeKind are persisted *by name*: in the database, in exported
-# .ftree files, and (for RelativeKind) inside a navigation route that Navigation resolves by fully
-# qualified class name. If R8 renames any of them, previously stored values stop matching and an
+# .ftree files, in a preference (KinshipLanguage), and — for RelativeKind — inside a navigation
+# route that Navigation resolves by fully qualified class name. If R8 renames any of them, previously stored values stop matching and an
 # exported file becomes unreadable — a silent data-loss bug that only appears in release builds.
 #
 # Found the hard way: the first signed build crashed on launch with
@@ -14,6 +14,7 @@
 -keep class com.vibethroughcode.ftree.data.SpouseKind { *; }
 -keep class com.vibethroughcode.ftree.data.SiblingKind { *; }
 -keep class com.vibethroughcode.ftree.data.DeletionMode { *; }
+-keep class com.vibethroughcode.ftree.data.KinshipLanguage { *; }
 
 -keepclassmembers enum * {
     public static **[] values();

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/HindiRelationTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/HindiRelationTest.kt
@@ -1,0 +1,228 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.KinshipLanguage
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.ui.relation.RelationPickListTag
+import com.vibethroughcode.ftree.ui.relation.RelationPickSearchTag
+import com.vibethroughcode.ftree.ui.relation.RelationSlotFromTag
+import com.vibethroughcode.ftree.ui.relation.RelationSlotToTag
+import com.vibethroughcode.ftree.ui.settings.SettingsWordsEnglishTag
+import com.vibethroughcode.ftree.ui.settings.SettingsWordsHindiTag
+import com.vibethroughcode.ftree.ui.tree.FamilyChartTag
+import com.vibethroughcode.ftree.ui.tree.TreeRelateTag
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The family-words setting, end to end.
+ *
+ * Which Hindi word applies is settled on the JVM, over every pair of two whole families. What is
+ * worth an emulator is the join: that the setting reaches the sentence, that the same two people
+ * read differently once it is flipped, and that a relationship the record cannot pin down says so
+ * rather than guessing.
+ */
+@RunWith(AndroidJUnit4::class)
+class HindiRelationTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    @Before
+    fun emptyTheTree() {
+        app.container.kinshipPreferences.setLanguage(KinshipLanguage.ENGLISH)
+        app.container.database.clearAllTables()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Build your family tree").fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    /**
+     * A mother's brother and a father's brother, the pair English calls "uncle" twice.
+     *
+     * The father and his brother carry birth years so one of them is provably the younger; the
+     * whole point of [aBrotherWithNoBirthYearIsNamedDescriptively] is what happens when they do not.
+     */
+    private fun seedBothUncles() {
+        val repository = app.container.familyRepository
+        runBlocking {
+            val nana = Person(name = "Ram Pher", gender = Gender.MALE, birthDate = "1930")
+            val dada = Person(name = "Shyam Lal", gender = Gender.MALE, birthDate = "1928")
+            val mum = Person(name = "Pragya Devi", gender = Gender.FEMALE, birthDate = "1960")
+            val mamaPerson = Person(name = "Kinshuk Kumar", gender = Gender.MALE, birthDate = "1958")
+            val dad = Person(name = "Sandeep Kumar", gender = Gender.MALE, birthDate = "1956")
+            val chacha = Person(name = "Vinod Kumar", gender = Gender.MALE, birthDate = "1962")
+            val me = Person(name = "Ankit Kumar", gender = Gender.MALE, birthDate = "1990")
+            listOf(nana, dada, mum, mamaPerson, dad, chacha, me)
+                .forEach { repository.addPerson(it) }
+            repository.addRelative(mum.id, nana.id, RelativeKind.PARENT)
+            repository.addRelative(mamaPerson.id, nana.id, RelativeKind.PARENT)
+            repository.addRelative(dad.id, dada.id, RelativeKind.PARENT)
+            repository.addRelative(chacha.id, dada.id, RelativeKind.PARENT)
+            repository.addRelative(me.id, mum.id, RelativeKind.PARENT)
+            repository.addRelative(me.id, dad.id, RelativeKind.PARENT)
+        }
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun chooseLanguage(tag: String) {
+        rule.onNodeWithTag(NavSettingsTag).performClick()
+        rule.waitUntil(5_000) { rule.onAllNodesWithTag(tag).fetchSemanticsNodes().isNotEmpty() }
+        rule.onNodeWithTag(tag).performClick()
+        rule.onNodeWithTag(NavTreeTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun pick(slotTag: String, name: String) {
+        rule.onNodeWithTag(slotTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationPickSearchTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(RelationPickSearchTag).performTextInput(name)
+        val row = hasText(name) and hasAnyAncestor(hasTestTag(RelationPickListTag))
+        rule.waitUntil(5_000) { rule.onAllNodes(row).fetchSemanticsNodes().isNotEmpty() }
+        rule.onNode(row).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationSlotFromTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun relate(from: String, to: String) {
+        rule.onNodeWithTag(TreeRelateTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationSlotFromTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        pick(RelationSlotFromTag, from)
+        pick(RelationSlotToTag, to)
+    }
+
+    private fun awaitText(text: String) {
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText(text, substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onAllNodesWithText(text, substring = true)[0].assertIsDisplayed()
+    }
+
+    /**
+     * The case that prompted the feature. English calls both men "uncle"; Hindi calls one मामा and
+     * the other चाचा, and only one of those is right for either of them.
+     */
+    @Test
+    fun theTwoUnclesEnglishCallsTheSameThingAreNamedApartInHindi() {
+        seedBothUncles()
+        chooseLanguage(SettingsWordsHindiTag)
+
+        relate(from = "Ankit Kumar", to = "Kinshuk Kumar")
+        awaitText("मामा")
+
+        rule.onNodeWithTag(RelationSlotToTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(RelationPickSearchTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithTag(RelationPickSearchTag).performTextInput("Vinod Kumar")
+        val row = hasText("Vinod Kumar") and hasAnyAncestor(hasTestTag(RelationPickListTag))
+        rule.waitUntil(5_000) { rule.onAllNodes(row).fetchSemanticsNodes().isNotEmpty() }
+        rule.onNode(row).performClick()
+
+        // Born after the father, so provably the younger brother — चाचा rather than ताऊ.
+        awaitText("चाचा")
+    }
+
+    /** The English gloss rides along, so a reader who does not know the word is not stuck. */
+    @Test
+    fun theHindiWordCarriesItsMeaningInBrackets() {
+        seedBothUncles()
+        chooseLanguage(SettingsWordsHindiTag)
+
+        relate(from = "Ankit Kumar", to = "Kinshuk Kumar")
+
+        awaitText("मामा (mother's brother)")
+    }
+
+    /** And the setting really is a setting: the same pair reads in English when English is chosen. */
+    @Test
+    fun theSamePairReadsInEnglishWhenEnglishIsChosen() {
+        seedBothUncles()
+        chooseLanguage(SettingsWordsEnglishTag)
+
+        relate(from = "Ankit Kumar", to = "Kinshuk Kumar")
+
+        awaitText("uncle")
+        rule.onAllNodesWithText("मामा", substring = true).fetchSemanticsNodes().let {
+            assert(it.isEmpty()) { "a Hindi word appeared while the setting said English" }
+        }
+    }
+
+    /**
+     * ताऊ is an elder brother and चाचा a younger one. With no birth years the record cannot say, so
+     * the app names him descriptively and offers the way to sharpen it rather than picking one.
+     */
+    @Test
+    fun aBrotherWithNoBirthYearIsNamedDescriptively() {
+        val repository = app.container.familyRepository
+        runBlocking {
+            val dada = Person(name = "Shyam Lal", gender = Gender.MALE)
+            val dad = Person(name = "Sandeep Kumar", gender = Gender.MALE)
+            val uncle = Person(name = "Vinod Kumar", gender = Gender.MALE)
+            val me = Person(name = "Ankit Kumar", gender = Gender.MALE)
+            listOf(dada, dad, uncle, me).forEach { repository.addPerson(it) }
+            repository.addRelative(dad.id, dada.id, RelativeKind.PARENT)
+            repository.addRelative(uncle.id, dada.id, RelativeKind.PARENT)
+            repository.addRelative(me.id, dad.id, RelativeKind.PARENT)
+        }
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+        chooseLanguage(SettingsWordsHindiTag)
+
+        relate(from = "Ankit Kumar", to = "Vinod Kumar")
+
+        awaitText("पिता के भाई")
+        // …and says what would settle it.
+        awaitText("Birth years")
+    }
+
+    /** Headings on a person's page follow the setting too, so the app speaks with one voice. */
+    @Test
+    fun theHeadingsOnAPersonsPageFollowTheSetting() {
+        seedBothUncles()
+        chooseLanguage(SettingsWordsHindiTag)
+
+        rule.onNodeWithTag(NavPeopleTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Ankit Kumar").fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onNodeWithText("Ankit Kumar").performClick()
+
+        awaitText("पिता")
+        awaitText("माता")
+    }
+}

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/WholeTreeAndUpdatesTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/WholeTreeAndUpdatesTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.vibethroughcode.ftree.FTreeApplication
@@ -141,11 +142,16 @@ class WholeTreeAndUpdatesTest {
         }
     }
 
+    /**
+     * Scrolled to rather than asserted where they sit: settings has grown sections above these two,
+     * and "you can reach it" is the promise worth testing, not "it happens to be on the first
+     * screenful".
+     */
     @Test
     fun transferMovedToSettingsAndIsReachableThere() {
         rule.onNodeWithTag(NavSettingsTag).performClick()
-        rule.onNodeWithText("Export your tree").assertIsDisplayed()
-        rule.onNodeWithText("Import a tree").assertIsDisplayed()
+        rule.onNodeWithText("Export your tree").performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText("Import a tree").performScrollTo().assertIsDisplayed()
     }
 
     /**

--- a/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.vibethroughcode.ftree.data.ChartPreferences
 import com.vibethroughcode.ftree.data.FTreeDatabase
 import com.vibethroughcode.ftree.data.FamilyRepository
+import com.vibethroughcode.ftree.data.KinshipPreferences
 import com.vibethroughcode.ftree.data.PhotoStore
 import com.vibethroughcode.ftree.transfer.TreeExporter
 import com.vibethroughcode.ftree.transfer.TreeIdentity
@@ -41,6 +42,7 @@ class AppContainer(context: Context) {
 
     val updatePreferences: UpdatePreferences by lazy { UpdatePreferences(context) }
     val chartPreferences: ChartPreferences by lazy { ChartPreferences(context) }
+    val kinshipPreferences: KinshipPreferences by lazy { KinshipPreferences(context) }
 
     /**
      * Built lazily like everything else, which also means the updater's objects do not exist at

--- a/app/src/main/java/com/vibethroughcode/ftree/data/KinshipPreferences.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/KinshipPreferences.kt
@@ -1,0 +1,51 @@
+package com.vibethroughcode.ftree.data
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import android.content.Context
+
+/**
+ * Which language the app names family relationships in.
+ *
+ * Deliberately *not* an app language. Translating the buttons and the settings screen is a separate
+ * and much larger job, and a half-translated interface reads worse than an English one. What this
+ * changes is the family vocabulary — the word for a relationship — which is where a language carries
+ * meaning English cannot: [HINDI] has five words for the one English calls "uncle", and a family
+ * that says मामा does not think "maternal uncle" and translate.
+ */
+enum class KinshipLanguage { ENGLISH, HINDI }
+
+/**
+ * The chosen family vocabulary, remembered.
+ *
+ * English by default, because it is the only one the whole app is written in and a first run should
+ * not guess at somebody's family from their device locale.
+ */
+class KinshipPreferences(context: Context) {
+
+    private val prefs = context.applicationContext
+        .getSharedPreferences("kinship-preferences", Context.MODE_PRIVATE)
+
+    private val _language = MutableStateFlow(read())
+
+    val language: StateFlow<KinshipLanguage> = _language.asStateFlow()
+
+    fun setLanguage(value: KinshipLanguage) {
+        prefs.edit().putString(KEY_LANGUAGE, value.name).apply()
+        _language.value = value
+    }
+
+    /**
+     * Stored by name, never by ordinal — the same rule the database follows, so reordering the enum
+     * can never silently change somebody's setting.
+     */
+    private fun read(): KinshipLanguage {
+        val stored = prefs.getString(KEY_LANGUAGE, null) ?: return KinshipLanguage.ENGLISH
+        return KinshipLanguage.entries.firstOrNull { it.name == stored } ?: KinshipLanguage.ENGLISH
+    }
+
+    private companion object {
+        const val KEY_LANGUAGE = "language"
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/HindiKinship.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/HindiKinship.kt
@@ -1,0 +1,300 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.Gender
+
+/**
+ * A Hindi kinship word, chosen but not yet spelled.
+ *
+ * An enum rather than a string so the *decision* — which of five words English calls "uncle" — is
+ * ordinary Kotlin that runs on the JVM and is tested there. The spelling lives in resources, where a
+ * Hindi speaker can review the whole vocabulary as a flat list without reading any code.
+ *
+ * [needsBirthYears] marks the three descriptive terms the app falls back to when the record cannot
+ * settle a birth order. They are correct as they stand — "पिता के भाई" is what he is — and the screen
+ * uses the flag to offer the reader a way to sharpen them.
+ */
+enum class HindiKinTerm(val needsBirthYears: Boolean = false) {
+    SELF,
+
+    /* ------------------------------------------------------------------------ blood, upward */
+    PITA, MATA,
+    DADA, DADI, NANA, NANI,
+    PARDADA, PARDADI, PARNANA, PARNANI,
+
+    /* ---------------------------------------------------------------------- blood, downward */
+    BETA, BETI,
+    POTA, POTI, NATI, NATIN,
+    PARPOTA, PARPOTI, PARNATI, PARNATIN,
+
+    /* ------------------------------------------------------------------------ blood, beside */
+    BHAI, BEHEN,
+
+    /**
+     * Father's brother, and his wife.
+     *
+     * The one place Hindi asks a question the record often cannot answer: ताऊ is the elder brother
+     * and चाचा the younger, and with no birth years there is no way to tell. Guessing would be wrong
+     * half the time in a way the family notices immediately.
+     */
+    TAU, CHACHA, FATHERS_BROTHER(needsBirthYears = true),
+    TAI, CHACHI, FATHERS_BROTHERS_WIFE(needsBirthYears = true),
+
+    /** Father's sister and her husband; mother's brother and his wife; mother's sister and hers. */
+    BUA, PHUPHA,
+    MAMA, MAMI,
+    MAUSI, MAUSA,
+
+    BHATIJA, BHATIJI, BHANJA, BHANJI,
+
+    /**
+     * First cousins, who in Hindi are brothers and sisters with a qualifier saying which aunt or
+     * uncle they come through. Deliberately blind to birth order: चचेरा covers both ताऊ's children
+     * and चाचा's in ordinary speech, so cousins never depend on a birth year.
+     */
+    CHACHERA_BHAI, CHACHERI_BEHEN,
+    PHUPHERA_BHAI, PHUPHERI_BEHEN,
+    MAMERA_BHAI, MAMERI_BEHEN,
+    MAUSERA_BHAI, MAUSERI_BEHEN,
+
+    /* ------------------------------------------------------------------------- by marriage */
+    PATI, PATNI,
+    SASUR, SAAS,
+    JIJA, BHABHI,
+    BAHU, DAMAD,
+    SALA, SALI,
+    JETH, DEVAR, HUSBANDS_BROTHER(needsBirthYears = true),
+    NANAD,
+    SAUTELA_PITA, SAUTELI_MATA,
+    SAUTELA_BETA, SAUTELI_BETI,
+}
+
+/**
+ * Which Hindi word a relationship takes.
+ *
+ * Pure, and deliberately so: this is the part that can be wrong. English collapses five Hindi terms
+ * into "uncle", so a labelling layer working from [KinshipTerm] alone could only guess. Everything
+ * here reads [KinshipPath] — which parent the line went up through, who it came back down through,
+ * and who was born first — and returns null wherever Hindi genuinely has no word, which is exactly
+ * where a Hindi speaker would reach for the English one anyway.
+ */
+object HindiKinship {
+
+    /**
+     * @param subject the person the relationship is *from*. Hindi in-law terms depend on it: a
+     *   wife's brother is साला to a man, where a husband's brother is जेठ or देवर to a woman.
+     */
+    fun term(
+        term: KinshipTerm,
+        path: KinshipPath?,
+        subject: Gender,
+        target: Gender,
+    ): HindiKinTerm? = when (term) {
+        KinshipTerm.Self -> HindiKinTerm.SELF
+
+        is KinshipTerm.Ancestor -> ancestor(term.generations, path, target)
+        is KinshipTerm.Descendant -> descendant(term.generations, path, target)
+
+        KinshipTerm.Sibling -> byGender(target, HindiKinTerm.BHAI, HindiKinTerm.BEHEN)
+
+        is KinshipTerm.ParentsSibling ->
+            if (term.greats > 0) null else parentsSibling(path, target)
+
+        is KinshipTerm.SiblingsChild ->
+            if (term.greats > 0) null else siblingsChild(path, target)
+
+        is KinshipTerm.Cousin ->
+            if (term.degree != 1 || term.removed != 0) null else firstCousin(path, target)
+
+        KinshipTerm.Spouse -> byGender(target, HindiKinTerm.PATI, HindiKinTerm.PATNI)
+
+        is KinshipTerm.SpouseOf -> marriedIn(term.relative, path, target)
+        is KinshipTerm.OfSpouse -> ofSpouse(term.relative, path, subject, target)
+    }
+
+    /* ------------------------------------------------------------------------------- blood */
+
+    private fun ancestor(generations: Int, path: KinshipPath?, target: Gender): HindiKinTerm? =
+        when (generations) {
+            1 -> byGender(target, HindiKinTerm.PITA, HindiKinTerm.MATA)
+            // दादा is the father's father, नाना the mother's — the side is the whole distinction.
+            2 -> when (path?.side) {
+                Gender.MALE -> byGender(target, HindiKinTerm.DADA, HindiKinTerm.DADI)
+                Gender.FEMALE -> byGender(target, HindiKinTerm.NANA, HindiKinTerm.NANI)
+                else -> null
+            }
+            3 -> when (path?.side) {
+                Gender.MALE -> byGender(target, HindiKinTerm.PARDADA, HindiKinTerm.PARDADI)
+                Gender.FEMALE -> byGender(target, HindiKinTerm.PARNANA, HindiKinTerm.PARNANI)
+                else -> null
+            }
+            // पर- stacks no further in ordinary speech, so the English word serves better.
+            else -> null
+        }
+
+    private fun descendant(generations: Int, path: KinshipPath?, target: Gender): HindiKinTerm? =
+        when (generations) {
+            1 -> byGender(target, HindiKinTerm.BETA, HindiKinTerm.BETI)
+            // A son's children are पोता/पोती, a daughter's नाती/नातिन — the child in between decides.
+            2 -> when (path?.link) {
+                Gender.MALE -> byGender(target, HindiKinTerm.POTA, HindiKinTerm.POTI)
+                Gender.FEMALE -> byGender(target, HindiKinTerm.NATI, HindiKinTerm.NATIN)
+                else -> null
+            }
+            3 -> when (path?.link) {
+                Gender.MALE -> byGender(target, HindiKinTerm.PARPOTA, HindiKinTerm.PARPOTI)
+                Gender.FEMALE -> byGender(target, HindiKinTerm.PARNATI, HindiKinTerm.PARNATIN)
+                else -> null
+            }
+            else -> null
+        }
+
+    private fun parentsSibling(path: KinshipPath?, target: Gender): HindiKinTerm? =
+        when (path?.side) {
+            Gender.MALE -> when (target) {
+                Gender.FEMALE -> HindiKinTerm.BUA
+                Gender.MALE -> elderYounger(
+                    path.seniority, HindiKinTerm.TAU, HindiKinTerm.CHACHA, HindiKinTerm.FATHERS_BROTHER,
+                )
+                else -> null
+            }
+            // Neither मामा nor मौसी cares about birth order, which is why only the father's side
+            // ever has to ask the record for a birth year.
+            Gender.FEMALE -> byGender(target, HindiKinTerm.MAMA, HindiKinTerm.MAUSI)
+            else -> null
+        }
+
+    private fun siblingsChild(path: KinshipPath?, target: Gender): HindiKinTerm? =
+        when (path?.link) {
+            Gender.MALE -> byGender(target, HindiKinTerm.BHATIJA, HindiKinTerm.BHATIJI)
+            Gender.FEMALE -> byGender(target, HindiKinTerm.BHANJA, HindiKinTerm.BHANJI)
+            else -> null
+        }
+
+    private fun firstCousin(path: KinshipPath?, target: Gender): HindiKinTerm? {
+        val side = path?.side ?: return null
+        return when (side to path.link) {
+            Gender.MALE to Gender.MALE ->
+                byGender(target, HindiKinTerm.CHACHERA_BHAI, HindiKinTerm.CHACHERI_BEHEN)
+            Gender.MALE to Gender.FEMALE ->
+                byGender(target, HindiKinTerm.PHUPHERA_BHAI, HindiKinTerm.PHUPHERI_BEHEN)
+            Gender.FEMALE to Gender.MALE ->
+                byGender(target, HindiKinTerm.MAMERA_BHAI, HindiKinTerm.MAMERI_BEHEN)
+            Gender.FEMALE to Gender.FEMALE ->
+                byGender(target, HindiKinTerm.MAUSERA_BHAI, HindiKinTerm.MAUSERI_BEHEN)
+            else -> null
+        }
+    }
+
+    /* -------------------------------------------------------------------------- by marriage */
+
+    /**
+     * Married to one of the subject's blood relatives. [path] runs to that relative.
+     *
+     * Every word here names *both* people: जीजा is a man married to a sister, भाभी a woman married
+     * to a brother. So both genders have to agree before one is used. A record saying otherwise —
+     * a marriage between two people both written down as male, most often a gender entered wrongly —
+     * gets no word rather than a confident falsehood, and the chain still answers the question.
+     */
+    private fun marriedIn(
+        relative: KinshipTerm,
+        path: KinshipPath?,
+        target: Gender,
+    ): HindiKinTerm? = when (relative) {
+        is KinshipTerm.ParentsSibling -> if (relative.greats > 0) null else {
+            when (Triple(path?.side, path?.link, target)) {
+                // Father's sister's husband, and father's brother's wife.
+                Triple(Gender.MALE, Gender.FEMALE, Gender.MALE) -> HindiKinTerm.PHUPHA
+                Triple(Gender.MALE, Gender.MALE, Gender.FEMALE) -> elderYounger(
+                    path!!.seniority,
+                    HindiKinTerm.TAI,
+                    HindiKinTerm.CHACHI,
+                    HindiKinTerm.FATHERS_BROTHERS_WIFE,
+                )
+                // Mother's brother's wife, and mother's sister's husband.
+                Triple(Gender.FEMALE, Gender.MALE, Gender.FEMALE) -> HindiKinTerm.MAMI
+                Triple(Gender.FEMALE, Gender.FEMALE, Gender.MALE) -> HindiKinTerm.MAUSA
+                else -> null
+            }
+        }
+
+        KinshipTerm.Sibling -> spouseOfSibling(path?.link, target)
+
+        is KinshipTerm.Descendant -> if (relative.generations != 1) null else {
+            when (path?.link to target) {
+                Gender.MALE to Gender.FEMALE -> HindiKinTerm.BAHU
+                Gender.FEMALE to Gender.MALE -> HindiKinTerm.DAMAD
+                else -> null
+            }
+        }
+
+        is KinshipTerm.Ancestor -> if (relative.generations != 1) null else {
+            byGender(target, HindiKinTerm.SAUTELA_PITA, HindiKinTerm.SAUTELI_MATA)
+        }
+
+        else -> null
+    }
+
+    /** जीजा married a sister, भाभी married a brother — neither word works without both facts. */
+    private fun spouseOfSibling(sibling: Gender?, target: Gender): HindiKinTerm? =
+        when (sibling to target) {
+            Gender.FEMALE to Gender.MALE -> HindiKinTerm.JIJA
+            Gender.MALE to Gender.FEMALE -> HindiKinTerm.BHABHI
+            else -> null
+        }
+
+    /** A blood relative of the subject's own spouse. [path] runs from the spouse to them. */
+    private fun ofSpouse(
+        relative: KinshipTerm,
+        path: KinshipPath?,
+        subject: Gender,
+        target: Gender,
+    ): HindiKinTerm? = when (relative) {
+        is KinshipTerm.Ancestor -> if (relative.generations != 1) null else {
+            byGender(target, HindiKinTerm.SASUR, HindiKinTerm.SAAS)
+        }
+
+        // The one family of terms that turns on the gender of the person *asking*: a wife's brother
+        // is साला, a husband's brother जेठ or देवर. Without knowing which, there is no word to give.
+        KinshipTerm.Sibling -> when (subject) {
+            Gender.MALE -> byGender(target, HindiKinTerm.SALA, HindiKinTerm.SALI)
+            Gender.FEMALE -> when (target) {
+                Gender.FEMALE -> HindiKinTerm.NANAD
+                Gender.MALE -> elderYounger(
+                    path?.seniority ?: Seniority.UNKNOWN,
+                    HindiKinTerm.JETH,
+                    HindiKinTerm.DEVAR,
+                    HindiKinTerm.HUSBANDS_BROTHER,
+                )
+                else -> null
+            }
+            else -> null
+        }
+
+        is KinshipTerm.Descendant -> if (relative.generations != 1) null else {
+            byGender(target, HindiKinTerm.SAUTELA_BETA, HindiKinTerm.SAUTELI_BETI)
+        }
+
+        else -> null
+    }
+
+    /* ------------------------------------------------------------------------------ helpers */
+
+    private fun byGender(gender: Gender, male: HindiKinTerm, female: HindiKinTerm): HindiKinTerm? =
+        when (gender) {
+            Gender.MALE -> male
+            Gender.FEMALE -> female
+            // Hindi has no neuter kinship word here; the English one is the better answer.
+            else -> null
+        }
+
+    private fun elderYounger(
+        seniority: Seniority,
+        elder: HindiKinTerm,
+        younger: HindiKinTerm,
+        unknown: HindiKinTerm,
+    ): HindiKinTerm = when (seniority) {
+        Seniority.ELDER -> elder
+        Seniority.YOUNGER -> younger
+        Seniority.UNKNOWN -> unknown
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/Kinship.kt
@@ -1,5 +1,9 @@
 package com.vibethroughcode.ftree.graph
 
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.PartialDate
+import com.vibethroughcode.ftree.data.Person
+
 /**
  * How any two people in a tree are related.
  *
@@ -64,6 +68,43 @@ sealed interface KinshipTerm {
     data class OfSpouse(val relative: KinshipTerm) : KinshipTerm
 }
 
+/**
+ * Whether the other person's line is elder or younger where the two lines part.
+ *
+ * Claimed only when the record proves it. Two brothers both recorded as "1962" are [UNKNOWN], not a
+ * coin toss — the whole point of carrying this is to say चाचा only when he really is the younger one.
+ */
+enum class Seniority { ELDER, YOUNGER, UNKNOWN }
+
+/**
+ * The people a relationship was measured *through*, as genders.
+ *
+ * [KinshipTerm] is two distances, which is all English needs: an uncle is an uncle whichever parent
+ * he belongs to. Most of the world's languages are not like that. Hindi has five words where English
+ * has one, and choosing between them needs to know which parent the line went up through, who it
+ * came back down through, and — for चाचा against ताऊ — which of the two was born first.
+ *
+ * So the distances stay exactly as they were and this rides alongside them, carrying the part the
+ * arithmetic threw away. A vocabulary that does not need it can ignore it entirely.
+ *
+ * It describes whatever the term was measured over, which for a relationship through marriage is the
+ * *blood* part of it: for "my uncle's wife" the path runs from the subject to the uncle, because the
+ * uncle is who decides the word.
+ */
+data class KinshipPath(
+    /** Going up from the subject: their own parent first, the shared ancestor last. */
+    val ascent: List<Gender>,
+    /** Coming back down: the ancestor's child first, the other person last. */
+    val descent: List<Gender>,
+    val seniority: Seniority,
+) {
+    /** Which of the subject's parents the line went up through, if the record says. */
+    val side: Gender get() = ascent.firstOrNull() ?: Gender.UNSPECIFIED
+
+    /** Who the line comes back down through on the other side — the linking sibling, child or aunt. */
+    val link: Gender get() = descent.firstOrNull() ?: Gender.UNSPECIFIED
+}
+
 /** The answer to "how are these two related?". */
 sealed interface Relation {
     /** The same person was picked twice. */
@@ -76,11 +117,13 @@ sealed interface Relation {
      * @param chain every step from the subject to the other person, the other person last.
      * @param term the blood term, absent when no shared ancestor exists — in-laws and step-family.
      * @param sharedAncestorId the ancestor [term] was measured through.
+     * @param path the people [term] was measured through, for vocabularies that need them.
      */
     data class Found(
         val chain: List<RelationStep>,
         val term: KinshipTerm?,
         val sharedAncestorId: String?,
+        val path: KinshipPath? = null,
     ) : Relation {
         /** The people the chain passes through, including both ends. */
         fun peopleInvolved(fromId: String): Set<String> =
@@ -131,14 +174,57 @@ object Kinship {
         val chain = shortestChain(snapshot, fromId, toId) ?: return Relation.Unrecorded
         val standIns = standInAncestors(snapshot)
         val shared = nearestSharedAncestor(snapshot, fromId, toId, standIns)
+
+        // Blood first, always: two people who share an ancestor are named through him even if a
+        // marriage happens to join them by a shorter route.
+        val affinal = if (shared == null) affinalTerm(snapshot, fromId, toId, chain, standIns) else null
+
         return Relation.Found(
             chain = chain,
-            // Blood first, always: two people who share an ancestor are named through him even if a
-            // marriage happens to join them by a shorter route.
-            term = shared?.let { termFor(it.up, it.down) }
-                ?: affinalTerm(snapshot, fromId, toId, chain, standIns),
+            term = shared?.let { termFor(it.up, it.down) } ?: affinal?.term,
             sharedAncestorId = shared?.ancestorId,
+            path = shared?.let { pathOf(snapshot, it) } ?: affinal?.path,
         )
+    }
+
+    /** The genders along a measured relationship, and who was born first where it forks. */
+    private fun pathOf(snapshot: FamilySnapshot, shared: Shared): KinshipPath {
+        fun genderOf(id: String) = snapshot.people[id]?.gender ?: Gender.UNSPECIFIED
+        return KinshipPath(
+            ascent = shared.ascent.map(::genderOf),
+            descent = shared.descent.map(::genderOf),
+            seniority = seniorityAt(snapshot, shared),
+        )
+    }
+
+    /**
+     * Which of the two lines leaving the shared ancestor belongs to the elder child.
+     *
+     * The comparison is between the ancestor's two children the lines run through — for an uncle,
+     * the subject's own parent against the uncle himself. When the lines part at the subject (their
+     * own sibling) the subject *is* that child.
+     *
+     * Only an ordering the dates actually prove counts. Two brothers both recorded as "1962" could
+     * be either way round, and the app would rather say "father's brother" than pick one.
+     */
+    private fun seniorityAt(snapshot: FamilySnapshot, shared: Shared): Seniority {
+        if (shared.up < 1 || shared.down < 1) return Seniority.UNKNOWN
+        val mineId =
+            if (shared.up == 1) shared.subjectId else shared.ascent.getOrNull(shared.up - 2)
+        val mine = snapshot.people[mineId] ?: return Seniority.UNKNOWN
+        val theirs = snapshot.people[shared.descent.first()] ?: return Seniority.UNKNOWN
+        return seniorityOf(theirs, mine)
+    }
+
+    /** [other] against [subject]: elder only when the recorded dates cannot overlap. */
+    fun seniorityOf(other: Person, subject: Person): Seniority {
+        val a = PartialDate.parse(other.birthDate) ?: return Seniority.UNKNOWN
+        val b = PartialDate.parse(subject.birthDate) ?: return Seniority.UNKNOWN
+        return when {
+            a.latest().isBefore(b.earliest()) -> Seniority.ELDER
+            b.latest().isBefore(a.earliest()) -> Seniority.YOUNGER
+            else -> Seniority.UNKNOWN
+        }
     }
 
     /**
@@ -153,31 +239,39 @@ object Kinship {
      * So this names the two ends and returns nothing for the rest, which is the honest answer and
      * the one the screen is built to fall back to.
      */
+    /** A term through marriage, with the path over the blood half of it. */
+    private data class Affinal(val term: KinshipTerm, val path: KinshipPath?)
+
     private fun affinalTerm(
         snapshot: FamilySnapshot,
         fromId: String,
         toId: String,
         chain: List<RelationStep>,
         standIns: Map<String, String>,
-    ): KinshipTerm? {
+    ): Affinal? {
         if (chain.count { it.kind == StepKind.SPOUSE } != 1) return null
         val at = chain.indexOfFirst { it.kind == StepKind.SPOUSE }
 
         // The whole line is one marriage: they are simply married to each other.
-        if (chain.size == 1) return KinshipTerm.Spouse
+        if (chain.size == 1) return Affinal(KinshipTerm.Spouse, null)
 
         return when (at) {
-            // ...married to the person the line reaches just before them.
+            // ...married to the person the line reaches just before them. The path runs to *them*,
+            // because it is the blood relative who decides the word: फूफा is the husband of a
+            // father's sister, and nothing about him says so except who he married.
             chain.lastIndex -> {
                 val married = chain[chain.size - 2].personId
-                nearestSharedAncestor(snapshot, fromId, married, standIns)
-                    ?.let { KinshipTerm.SpouseOf(termFor(it.up, it.down)) }
+                nearestSharedAncestor(snapshot, fromId, married, standIns)?.let {
+                    Affinal(KinshipTerm.SpouseOf(termFor(it.up, it.down)), pathOf(snapshot, it))
+                }
             }
-            // ...a blood relative of the subject's own spouse.
+            // ...a blood relative of the subject's own spouse. Measured from the spouse, so
+            // seniority compares the two of them — which is what tells जेठ from देवर.
             0 -> {
                 val spouse = chain.first().personId
-                nearestSharedAncestor(snapshot, spouse, toId, standIns)
-                    ?.let { KinshipTerm.OfSpouse(termFor(it.up, it.down)) }
+                nearestSharedAncestor(snapshot, spouse, toId, standIns)?.let {
+                    Affinal(KinshipTerm.OfSpouse(termFor(it.up, it.down)), pathOf(snapshot, it))
+                }
             }
             else -> null
         }
@@ -202,7 +296,16 @@ object Kinship {
         )
     }
 
-    private data class Shared(val ancestorId: String, val up: Int, val down: Int)
+    private data class Shared(
+        val subjectId: String,
+        val ancestorId: String,
+        val up: Int,
+        val down: Int,
+        /** The subject's parent first, the ancestor last. Empty when the subject *is* the ancestor. */
+        val ascent: List<String>,
+        /** The ancestor's child first, the other person last. Empty when they are the ancestor. */
+        val descent: List<String>,
+    )
 
     /**
      * The shared ancestor that names the relationship.
@@ -216,41 +319,58 @@ object Kinship {
         toId: String,
         standIns: Map<String, String>,
     ): Shared? {
-        val mine = ancestorDistances(snapshot, fromId, standIns)
-        val theirs = ancestorDistances(snapshot, toId, standIns)
+        val mine = ancestorRoutes(snapshot, fromId, standIns)
+        val theirs = ancestorRoutes(snapshot, toId, standIns)
         var best: Shared? = null
-        mine.forEach { (ancestor, up) ->
-            val down = theirs[ancestor] ?: return@forEach
+        mine.forEach { (ancestor, ascent) ->
+            val theirRoute = theirs[ancestor] ?: return@forEach
+            val up = ascent.size
+            val down = theirRoute.size
             val current = best
             if (current == null ||
                 up + down < current.up + current.down ||
                 (up + down == current.up + current.down &&
                     kotlin.math.abs(up - down) < kotlin.math.abs(current.up - current.down))
             ) {
-                best = Shared(ancestor, up, down)
+                best = Shared(
+                    subjectId = fromId,
+                    ancestorId = ancestor,
+                    up = up,
+                    down = down,
+                    ascent = ascent,
+                    // Their route runs upward and stops at the ancestor; the descent is that read
+                    // backwards, the ancestor dropped and the person themself added at the end.
+                    descent = if (down == 0) emptyList() else theirRoute.dropLast(1).reversed() + toId,
+                )
             }
         }
         return best
     }
 
-    /** Everyone at or above [id], with the number of generations up to each. */
-    private fun ancestorDistances(
+    /**
+     * Everyone at or above [id], with the line of people leading up to each.
+     *
+     * The route rather than only its length, because which parent a line went up through is exactly
+     * what separates a मामा from a चाचा. The list excludes [id] and ends with the ancestor, so its
+     * size is the number of generations — the distance this used to return.
+     */
+    private fun ancestorRoutes(
         snapshot: FamilySnapshot,
         id: String,
         standIns: Map<String, String>,
-    ): Map<String, Int> {
-        val distance = linkedMapOf(id to 0)
+    ): Map<String, List<String>> {
+        val routes = linkedMapOf(id to emptyList<String>())
         val queue = ArrayDeque(listOf(id))
         while (queue.isNotEmpty()) {
             val current = queue.removeFirst()
-            val step = distance.getValue(current) + 1
+            val soFar = routes.getValue(current)
             val above = snapshot.parentsOf[current].orEmpty() + listOfNotNull(standIns[current])
             above.forEach { parent ->
                 // The visited check also makes a cycle in bad data terminate rather than hang.
-                if (distance.putIfAbsent(parent, step) == null) queue.addLast(parent)
+                if (routes.putIfAbsent(parent, soFar + parent) == null) queue.addLast(parent)
             }
         }
-        return distance
+        return routes
     }
 
     /**

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -23,7 +23,9 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -40,8 +42,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import com.vibethroughcode.ftree.FTreeApplication
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.transfer.TreeDocument
+import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.isShortWindow
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
 import com.vibethroughcode.ftree.ui.person.PersonDetailScreen
@@ -90,6 +94,9 @@ private val destinations = listOf(
 @Composable
 fun FTreeApp() {
     val navController = rememberNavController()
+    // Named once here and read by every screen that says a relationship out loud.
+    val kinshipLanguage by (LocalContext.current.applicationContext as FTreeApplication)
+        .container.kinshipPreferences.language.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val transferViewModel: TransferViewModel = viewModel(factory = FTreeViewModels.Factory)
 
@@ -120,166 +127,168 @@ fun FTreeApp() {
      */
     val useRail = onTopLevel && isShortWindow()
 
-    Scaffold(
-        snackbarHost = { SnackbarHost(snackbarHostState) },
-        bottomBar = {
-            if (onTopLevel && !useRail) {
-                NavigationBar {
-                    destinations.forEach { item ->
-                        val selected = destination?.hasRoute(item.type) == true
-                        NavigationBarItem(
-                            selected = selected,
-                            onClick = { navController.switchTo(item.route) },
-                            icon = { Icon(item.icon, contentDescription = null) },
-                            label = { Text(stringResource(item.label)) },
-                            modifier = Modifier.testTag(item.tag),
-                        )
+    CompositionLocalProvider(LocalKinshipLanguage provides kinshipLanguage) {
+        Scaffold(
+            snackbarHost = { SnackbarHost(snackbarHostState) },
+            bottomBar = {
+                if (onTopLevel && !useRail) {
+                    NavigationBar {
+                        destinations.forEach { item ->
+                            val selected = destination?.hasRoute(item.type) == true
+                            NavigationBarItem(
+                                selected = selected,
+                                onClick = { navController.switchTo(item.route) },
+                                icon = { Icon(item.icon, contentDescription = null) },
+                                label = { Text(stringResource(item.label)) },
+                                modifier = Modifier.testTag(item.tag),
+                            )
+                        }
                     }
                 }
-            }
-        },
-    ) { padding ->
-        Row(Modifier.fillMaxSize().padding(padding)) {
-            if (useRail) {
-                // Held to the standard rail width. Left to size itself it takes a quarter of a
-            // landscape phone, which is the opposite of the point of moving off the bottom edge.
-            NavigationRail(modifier = Modifier.fillMaxHeight().width(112.dp)) {
-                    destinations.forEach { item ->
-                        val selected = destination?.hasRoute(item.type) == true
-                        NavigationRailItem(
-                            selected = selected,
-                            onClick = { navController.switchTo(item.route) },
-                            icon = { Icon(item.icon, contentDescription = null) },
-                            label = { Text(stringResource(item.label)) },
-                            modifier = Modifier.testTag(item.tag),
-                        )
+            },
+        ) { padding ->
+            Row(Modifier.fillMaxSize().padding(padding)) {
+                if (useRail) {
+                    // Held to the standard rail width. Left to size itself it takes a quarter of a
+                // landscape phone, which is the opposite of the point of moving off the bottom edge.
+                NavigationRail(modifier = Modifier.fillMaxHeight().width(112.dp)) {
+                        destinations.forEach { item ->
+                            val selected = destination?.hasRoute(item.type) == true
+                            NavigationRailItem(
+                                selected = selected,
+                                onClick = { navController.switchTo(item.route) },
+                                icon = { Icon(item.icon, contentDescription = null) },
+                                label = { Text(stringResource(item.label)) },
+                                modifier = Modifier.testTag(item.tag),
+                            )
+                        }
                     }
                 }
-            }
-            NavHost(
-                navController = navController,
-                startDestination = TreeRoute(),
-                modifier = Modifier.weight(1f).fillMaxHeight(),
-            ) {
-                composable<TreeRoute> { entry ->
-                    TreeScreen(
-                        trace = entry.toRoute<TreeRoute>().trace,
-                        startWhole = entry.toRoute<TreeRoute>().whole,
-                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                        onAddPerson = { navController.navigate(EditPersonRoute()) },
-                        onAddRelative = { anchorId, kind ->
-                            navController.navigate(AddRelativeRoute(anchorId, kind))
-                        },
-                        onRelate = { navController.navigate(RelationRoute(fromId = it)) },
-                        // Dropping the trace means going back to the plain chart, which is where
-                        // clearing a highlight should leave you — not one screen further back.
-                        onClearTrace = {
-                            navController.navigate(TreeRoute(whole = true)) {
-                                popUpTo<TreeRoute> { inclusive = true }
-                            }
-                        },
-                    )
-                }
-
-                composable<RelationRoute> {
-                    RelationScreen(
-                        onBack = { navController.popBackStack() },
-                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                        onShowOnChart = { trace ->
-                            navController.navigate(TreeRoute(trace = trace)) {
-                                popUpTo<TreeRoute> { inclusive = true }
-                            }
-                        },
-                    )
-                }
-
-                composable<PeopleRoute> {
-                    PeopleScreen(
-                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                        onAddPerson = { navController.navigate(EditPersonRoute()) },
-                    )
-                }
-
-                composable<SettingsRoute> {
-                    val settingsViewModel: SettingsViewModel =
-                        viewModel(factory = FTreeViewModels.Factory)
-                    SettingsScreen(
-                        onExport = { exportPicker.launch(defaultExportName()) },
-                        onImport = { importPicker.launch(arrayOf("*/*")) },
-                        viewModel = settingsViewModel,
-                    )
-                }
-
-                composable<PersonRoute> {
-                    PersonDetailScreen(
-                        onBack = { navController.popBackStack() },
-                        onEdit = { navController.navigate(EditPersonRoute(it)) },
-                        onOpenPerson = { navController.navigate(PersonRoute(it)) },
-                        onAddRelative = { anchorId, kind ->
-                            navController.navigate(AddRelativeRoute(anchorId, kind))
-                        },
-                        onShowOnTree = { personId ->
-                            navController.navigate(TreeRoute(focusId = personId)) {
-                                popUpTo<TreeRoute> { inclusive = true }
-                            }
-                        },
-                        onRelate = { personId ->
-                            navController.navigate(RelationRoute(fromId = personId))
-                        },
-                    )
-                }
-
-                composable<AddRelativeRoute> {
-                    AddRelativeScreen(onBack = { navController.popBackStack() })
-                }
-
-                composable<EditPersonRoute> { entry ->
-                    val route = entry.toRoute<EditPersonRoute>()
-                    PersonEditScreen(
-                        onBack = { navController.popBackStack() },
-                        onSaved = { personId ->
-                            if (route.personId == null) {
-                                // A newly added person opens straight onto their own page, which is
-                                // where the next thing you want to do — add a relative — lives. Only
-                                // the form is dropped from the back stack, so going back returns to
-                                // wherever the add started rather than always to the chart.
-                                navController.navigate(PersonRoute(personId)) {
-                                    popUpTo<EditPersonRoute> { inclusive = true }
+                NavHost(
+                    navController = navController,
+                    startDestination = TreeRoute(),
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                ) {
+                    composable<TreeRoute> { entry ->
+                        TreeScreen(
+                            trace = entry.toRoute<TreeRoute>().trace,
+                            startWhole = entry.toRoute<TreeRoute>().whole,
+                            onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                            onAddPerson = { navController.navigate(EditPersonRoute()) },
+                            onAddRelative = { anchorId, kind ->
+                                navController.navigate(AddRelativeRoute(anchorId, kind))
+                            },
+                            onRelate = { navController.navigate(RelationRoute(fromId = it)) },
+                            // Dropping the trace means going back to the plain chart, which is where
+                            // clearing a highlight should leave you — not one screen further back.
+                            onClearTrace = {
+                                navController.navigate(TreeRoute(whole = true)) {
+                                    popUpTo<TreeRoute> { inclusive = true }
                                 }
-                            } else {
-                                navController.popBackStack()
-                            }
-                        },
-                    )
+                            },
+                        )
+                    }
+
+                    composable<RelationRoute> {
+                        RelationScreen(
+                            onBack = { navController.popBackStack() },
+                            onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                            onShowOnChart = { trace ->
+                                navController.navigate(TreeRoute(trace = trace)) {
+                                    popUpTo<TreeRoute> { inclusive = true }
+                                }
+                            },
+                        )
+                    }
+
+                    composable<PeopleRoute> {
+                        PeopleScreen(
+                            onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                            onAddPerson = { navController.navigate(EditPersonRoute()) },
+                        )
+                    }
+
+                    composable<SettingsRoute> {
+                        val settingsViewModel: SettingsViewModel =
+                            viewModel(factory = FTreeViewModels.Factory)
+                        SettingsScreen(
+                            onExport = { exportPicker.launch(defaultExportName()) },
+                            onImport = { importPicker.launch(arrayOf("*/*")) },
+                            viewModel = settingsViewModel,
+                        )
+                    }
+
+                    composable<PersonRoute> {
+                        PersonDetailScreen(
+                            onBack = { navController.popBackStack() },
+                            onEdit = { navController.navigate(EditPersonRoute(it)) },
+                            onOpenPerson = { navController.navigate(PersonRoute(it)) },
+                            onAddRelative = { anchorId, kind ->
+                                navController.navigate(AddRelativeRoute(anchorId, kind))
+                            },
+                            onShowOnTree = { personId ->
+                                navController.navigate(TreeRoute(focusId = personId)) {
+                                    popUpTo<TreeRoute> { inclusive = true }
+                                }
+                            },
+                            onRelate = { personId ->
+                                navController.navigate(RelationRoute(fromId = personId))
+                            },
+                        )
+                    }
+
+                    composable<AddRelativeRoute> {
+                        AddRelativeScreen(onBack = { navController.popBackStack() })
+                    }
+
+                    composable<EditPersonRoute> { entry ->
+                        val route = entry.toRoute<EditPersonRoute>()
+                        PersonEditScreen(
+                            onBack = { navController.popBackStack() },
+                            onSaved = { personId ->
+                                if (route.personId == null) {
+                                    // A newly added person opens straight onto their own page, which is
+                                    // where the next thing you want to do — add a relative — lives. Only
+                                    // the form is dropped from the back stack, so going back returns to
+                                    // wherever the add started rather than always to the chart.
+                                    navController.navigate(PersonRoute(personId)) {
+                                        popUpTo<EditPersonRoute> { inclusive = true }
+                                    }
+                                } else {
+                                    navController.popBackStack()
+                                }
+                            },
+                        )
+                    }
                 }
             }
         }
-    }
 
-    // Shown over whatever started it rather than as a navigation destination: the plan is a live
-    // object that cannot be handed through a route, and backing out must leave the tree untouched.
-    val importPlan by transferViewModel.plan.collectAsStateWithLifecycle()
-    val importDecisions by transferViewModel.decisions.collectAsStateWithLifecycle()
-    val allPeople by transferViewModel.localPeople.collectAsStateWithLifecycle()
+        // Shown over whatever started it rather than as a navigation destination: the plan is a live
+        // object that cannot be handed through a route, and backing out must leave the tree untouched.
+        val importPlan by transferViewModel.plan.collectAsStateWithLifecycle()
+        val importDecisions by transferViewModel.decisions.collectAsStateWithLifecycle()
+        val allPeople by transferViewModel.localPeople.collectAsStateWithLifecycle()
 
-    importPlan?.let { plan ->
-        Dialog(
-            onDismissRequest = transferViewModel::cancelImport,
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                // Fills the screen properly instead of leaving the scrim showing behind the status
-                // and navigation bars.
-                decorFitsSystemWindows = false,
-            ),
-        ) {
-            ImportReviewScreen(
-                plan = plan,
-                decisions = importDecisions,
-                localPeople = allPeople,
-                onDecision = transferViewModel::setDecision,
-                onConfirm = transferViewModel::confirmImport,
-                onCancel = transferViewModel::cancelImport,
-            )
+        importPlan?.let { plan ->
+            Dialog(
+                onDismissRequest = transferViewModel::cancelImport,
+                properties = DialogProperties(
+                    usePlatformDefaultWidth = false,
+                    // Fills the screen properly instead of leaving the scrim showing behind the status
+                    // and navigation bars.
+                    decorFitsSystemWindows = false,
+                ),
+            ) {
+                ImportReviewScreen(
+                    plan = plan,
+                    decisions = importDecisions,
+                    localPeople = allPeople,
+                    onDecision = transferViewModel::setDecision,
+                    onConfirm = transferViewModel::confirmImport,
+                    onCancel = transferViewModel::cancelImport,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -45,6 +45,7 @@ object FTreeViewModels {
             SettingsViewModel(
                 preferences = app.container.updatePreferences,
                 chart = app.container.chartPreferences,
+                kinship = app.container.kinshipPreferences,
                 updates = app.container.updateRepository,
             )
         }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/HindiKinshipLabels.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/HindiKinshipLabels.kt
@@ -1,0 +1,85 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.annotation.StringRes
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.graph.HindiKinTerm
+
+/**
+ * How a Hindi kinship term is spelled, and what it means in English.
+ *
+ * Only the spelling. Which term applies is decided in
+ * [com.vibethroughcode.ftree.graph.HindiKinship], on the JVM and under test, precisely so that the
+ * risky half of this feature is not buried in a resource lookup.
+ *
+ * Generated from one table, so a word and its gloss cannot drift apart.
+ */
+data class HindiWord(@StringRes val term: Int, @StringRes val gloss: Int)
+
+@Suppress("CyclomaticComplexMethod")
+fun HindiKinTerm.word(): HindiWord = when (this) {
+    HindiKinTerm.SELF -> HindiWord(R.string.kin_hi_self, R.string.kin_hi_self_gloss)
+    HindiKinTerm.PITA -> HindiWord(R.string.kin_hi_pita, R.string.kin_hi_pita_gloss)
+    HindiKinTerm.MATA -> HindiWord(R.string.kin_hi_mata, R.string.kin_hi_mata_gloss)
+    HindiKinTerm.DADA -> HindiWord(R.string.kin_hi_dada, R.string.kin_hi_dada_gloss)
+    HindiKinTerm.DADI -> HindiWord(R.string.kin_hi_dadi, R.string.kin_hi_dadi_gloss)
+    HindiKinTerm.NANA -> HindiWord(R.string.kin_hi_nana, R.string.kin_hi_nana_gloss)
+    HindiKinTerm.NANI -> HindiWord(R.string.kin_hi_nani, R.string.kin_hi_nani_gloss)
+    HindiKinTerm.PARDADA -> HindiWord(R.string.kin_hi_pardada, R.string.kin_hi_pardada_gloss)
+    HindiKinTerm.PARDADI -> HindiWord(R.string.kin_hi_pardadi, R.string.kin_hi_pardadi_gloss)
+    HindiKinTerm.PARNANA -> HindiWord(R.string.kin_hi_parnana, R.string.kin_hi_parnana_gloss)
+    HindiKinTerm.PARNANI -> HindiWord(R.string.kin_hi_parnani, R.string.kin_hi_parnani_gloss)
+    HindiKinTerm.BETA -> HindiWord(R.string.kin_hi_beta, R.string.kin_hi_beta_gloss)
+    HindiKinTerm.BETI -> HindiWord(R.string.kin_hi_beti, R.string.kin_hi_beti_gloss)
+    HindiKinTerm.POTA -> HindiWord(R.string.kin_hi_pota, R.string.kin_hi_pota_gloss)
+    HindiKinTerm.POTI -> HindiWord(R.string.kin_hi_poti, R.string.kin_hi_poti_gloss)
+    HindiKinTerm.NATI -> HindiWord(R.string.kin_hi_nati, R.string.kin_hi_nati_gloss)
+    HindiKinTerm.NATIN -> HindiWord(R.string.kin_hi_natin, R.string.kin_hi_natin_gloss)
+    HindiKinTerm.PARPOTA -> HindiWord(R.string.kin_hi_parpota, R.string.kin_hi_parpota_gloss)
+    HindiKinTerm.PARPOTI -> HindiWord(R.string.kin_hi_parpoti, R.string.kin_hi_parpoti_gloss)
+    HindiKinTerm.PARNATI -> HindiWord(R.string.kin_hi_parnati, R.string.kin_hi_parnati_gloss)
+    HindiKinTerm.PARNATIN -> HindiWord(R.string.kin_hi_parnatin, R.string.kin_hi_parnatin_gloss)
+    HindiKinTerm.BHAI -> HindiWord(R.string.kin_hi_bhai, R.string.kin_hi_bhai_gloss)
+    HindiKinTerm.BEHEN -> HindiWord(R.string.kin_hi_behen, R.string.kin_hi_behen_gloss)
+    HindiKinTerm.TAU -> HindiWord(R.string.kin_hi_tau, R.string.kin_hi_tau_gloss)
+    HindiKinTerm.CHACHA -> HindiWord(R.string.kin_hi_chacha, R.string.kin_hi_chacha_gloss)
+    HindiKinTerm.FATHERS_BROTHER -> HindiWord(R.string.kin_hi_fathers_brother, R.string.kin_hi_fathers_brother_gloss)
+    HindiKinTerm.TAI -> HindiWord(R.string.kin_hi_tai, R.string.kin_hi_tai_gloss)
+    HindiKinTerm.CHACHI -> HindiWord(R.string.kin_hi_chachi, R.string.kin_hi_chachi_gloss)
+    HindiKinTerm.FATHERS_BROTHERS_WIFE -> HindiWord(R.string.kin_hi_fathers_brothers_wife, R.string.kin_hi_fathers_brothers_wife_gloss)
+    HindiKinTerm.BUA -> HindiWord(R.string.kin_hi_bua, R.string.kin_hi_bua_gloss)
+    HindiKinTerm.PHUPHA -> HindiWord(R.string.kin_hi_phupha, R.string.kin_hi_phupha_gloss)
+    HindiKinTerm.MAMA -> HindiWord(R.string.kin_hi_mama, R.string.kin_hi_mama_gloss)
+    HindiKinTerm.MAMI -> HindiWord(R.string.kin_hi_mami, R.string.kin_hi_mami_gloss)
+    HindiKinTerm.MAUSI -> HindiWord(R.string.kin_hi_mausi, R.string.kin_hi_mausi_gloss)
+    HindiKinTerm.MAUSA -> HindiWord(R.string.kin_hi_mausa, R.string.kin_hi_mausa_gloss)
+    HindiKinTerm.BHATIJA -> HindiWord(R.string.kin_hi_bhatija, R.string.kin_hi_bhatija_gloss)
+    HindiKinTerm.BHATIJI -> HindiWord(R.string.kin_hi_bhatiji, R.string.kin_hi_bhatiji_gloss)
+    HindiKinTerm.BHANJA -> HindiWord(R.string.kin_hi_bhanja, R.string.kin_hi_bhanja_gloss)
+    HindiKinTerm.BHANJI -> HindiWord(R.string.kin_hi_bhanji, R.string.kin_hi_bhanji_gloss)
+    HindiKinTerm.CHACHERA_BHAI -> HindiWord(R.string.kin_hi_chachera_bhai, R.string.kin_hi_chachera_bhai_gloss)
+    HindiKinTerm.CHACHERI_BEHEN -> HindiWord(R.string.kin_hi_chacheri_behen, R.string.kin_hi_chacheri_behen_gloss)
+    HindiKinTerm.PHUPHERA_BHAI -> HindiWord(R.string.kin_hi_phuphera_bhai, R.string.kin_hi_phuphera_bhai_gloss)
+    HindiKinTerm.PHUPHERI_BEHEN -> HindiWord(R.string.kin_hi_phupheri_behen, R.string.kin_hi_phupheri_behen_gloss)
+    HindiKinTerm.MAMERA_BHAI -> HindiWord(R.string.kin_hi_mamera_bhai, R.string.kin_hi_mamera_bhai_gloss)
+    HindiKinTerm.MAMERI_BEHEN -> HindiWord(R.string.kin_hi_mameri_behen, R.string.kin_hi_mameri_behen_gloss)
+    HindiKinTerm.MAUSERA_BHAI -> HindiWord(R.string.kin_hi_mausera_bhai, R.string.kin_hi_mausera_bhai_gloss)
+    HindiKinTerm.MAUSERI_BEHEN -> HindiWord(R.string.kin_hi_mauseri_behen, R.string.kin_hi_mauseri_behen_gloss)
+    HindiKinTerm.PATI -> HindiWord(R.string.kin_hi_pati, R.string.kin_hi_pati_gloss)
+    HindiKinTerm.PATNI -> HindiWord(R.string.kin_hi_patni, R.string.kin_hi_patni_gloss)
+    HindiKinTerm.SASUR -> HindiWord(R.string.kin_hi_sasur, R.string.kin_hi_sasur_gloss)
+    HindiKinTerm.SAAS -> HindiWord(R.string.kin_hi_saas, R.string.kin_hi_saas_gloss)
+    HindiKinTerm.JIJA -> HindiWord(R.string.kin_hi_jija, R.string.kin_hi_jija_gloss)
+    HindiKinTerm.BHABHI -> HindiWord(R.string.kin_hi_bhabhi, R.string.kin_hi_bhabhi_gloss)
+    HindiKinTerm.BAHU -> HindiWord(R.string.kin_hi_bahu, R.string.kin_hi_bahu_gloss)
+    HindiKinTerm.DAMAD -> HindiWord(R.string.kin_hi_damad, R.string.kin_hi_damad_gloss)
+    HindiKinTerm.SALA -> HindiWord(R.string.kin_hi_sala, R.string.kin_hi_sala_gloss)
+    HindiKinTerm.SALI -> HindiWord(R.string.kin_hi_sali, R.string.kin_hi_sali_gloss)
+    HindiKinTerm.JETH -> HindiWord(R.string.kin_hi_jeth, R.string.kin_hi_jeth_gloss)
+    HindiKinTerm.DEVAR -> HindiWord(R.string.kin_hi_devar, R.string.kin_hi_devar_gloss)
+    HindiKinTerm.HUSBANDS_BROTHER -> HindiWord(R.string.kin_hi_husbands_brother, R.string.kin_hi_husbands_brother_gloss)
+    HindiKinTerm.NANAD -> HindiWord(R.string.kin_hi_nanad, R.string.kin_hi_nanad_gloss)
+    HindiKinTerm.SAUTELA_PITA -> HindiWord(R.string.kin_hi_sautela_pita, R.string.kin_hi_sautela_pita_gloss)
+    HindiKinTerm.SAUTELI_MATA -> HindiWord(R.string.kin_hi_sauteli_mata, R.string.kin_hi_sauteli_mata_gloss)
+    HindiKinTerm.SAUTELA_BETA -> HindiWord(R.string.kin_hi_sautela_beta, R.string.kin_hi_sautela_beta_gloss)
+    HindiKinTerm.SAUTELI_BETI -> HindiWord(R.string.kin_hi_sauteli_beti, R.string.kin_hi_sauteli_beti_gloss)
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/KinshipLabels.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/KinshipLabels.kt
@@ -5,7 +5,10 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.KinshipLanguage
 import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.graph.HindiKinship
+import com.vibethroughcode.ftree.graph.KinshipPath
 import com.vibethroughcode.ftree.graph.KinshipTerm
 import com.vibethroughcode.ftree.graph.StepKind
 
@@ -154,4 +157,49 @@ fun StepKind.asRelativeKind(): RelativeKind = when (this) {
     StepKind.CHILD -> RelativeKind.CHILD
     StepKind.SPOUSE -> RelativeKind.SPOUSE
     StepKind.SIBLING -> RelativeKind.SIBLING
+}
+
+/**
+ * A relationship as it is finally read, in whichever vocabulary the reader chose.
+ *
+ * [gloss] is what the term means in English, shown in brackets after it. Hindi carries one and
+ * English does not, which is the whole asymmetry: "मामा (maternal uncle)" is how a bilingual family
+ * actually speaks, and it lets a younger relative who has not learned the word still read the
+ * answer. The gloss is more precise than English's own kinship words on purpose — English says
+ * "uncle" five different ways, and the gloss says which one — so nothing is lost by reading it.
+ */
+data class KinshipName(
+    val term: String,
+    val gloss: String? = null,
+    /** A descriptive stand-in that a birth year would sharpen — पिता के भाई rather than चाचा. */
+    val needsBirthYears: Boolean = false,
+)
+
+/**
+ * The word for a relationship in the chosen family vocabulary.
+ *
+ * Hindi falls back to English wherever it genuinely has no term — second cousins, great-uncles,
+ * anyone far enough out that a family stops having a name for them. That is not a gap being papered
+ * over: it is what Hindi speakers themselves do, and inventing a Devanagari compound nobody says
+ * would be worse than the English word.
+ */
+@Composable
+fun kinshipName(
+    term: KinshipTerm,
+    path: KinshipPath?,
+    subject: Gender,
+    target: Gender,
+    language: KinshipLanguage = LocalKinshipLanguage.current,
+): KinshipName? {
+    if (language == KinshipLanguage.HINDI) {
+        HindiKinship.term(term, path, subject, target)?.let { hindi ->
+            val word = hindi.word()
+            return KinshipName(
+                term = stringResource(word.term),
+                gloss = stringResource(word.gloss),
+                needsBirthYears = hindi.needsBirthYears,
+            )
+        }
+    }
+    return kinshipLabel(term, target)?.let { KinshipName(it) }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/LocalKinshipLanguage.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/LocalKinshipLanguage.kt
@@ -1,0 +1,18 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.vibethroughcode.ftree.data.KinshipLanguage
+
+/**
+ * The family vocabulary in force, available to anything that names a relationship.
+ *
+ * A composition local rather than a parameter because the answer is needed in a dozen leaves — the
+ * relation sentence, every section heading on a person's page, the chips on the add-relative screen —
+ * and threading a language argument through every screen to reach them would put the setting in the
+ * signature of code that has nothing else to do with it.
+ *
+ * Provided once, in `FTreeApp`.
+ */
+val LocalKinshipLanguage: ProvidableCompositionLocal<KinshipLanguage> =
+    staticCompositionLocalOf { KinshipLanguage.ENGLISH }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/RelativeLabels.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/RelativeLabels.kt
@@ -6,10 +6,38 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.KinshipLanguage
 import com.vibethroughcode.ftree.data.RelativeKind
 
 /**
- * How a relationship is named to the reader.
+ * The heading beside a relative's name, in the chosen family vocabulary.
+ *
+ * Hindi uses the same words the relation finder does — पिता, बेटा, भाई — because a reader who has
+ * asked for Hindi should not meet "Father" as a heading and मामा in a sentence on the next screen.
+ *
+ * There is no neuter kinship word in Hindi, so an unrecorded gender falls back to the English
+ * heading rather than leaving the row unlabelled.
+ */
+@StringRes
+fun relativeRoleLabel(kind: RelativeKind, gender: Gender, language: KinshipLanguage): Int =
+    hindiRoleLabel(kind, gender).takeIf { language == KinshipLanguage.HINDI && it != 0 }
+        ?: relativeRoleLabel(kind, gender)
+
+@StringRes
+private fun hindiRoleLabel(kind: RelativeKind, gender: Gender): Int = when (kind to gender) {
+    RelativeKind.PARENT to Gender.MALE -> R.string.kin_hi_pita
+    RelativeKind.PARENT to Gender.FEMALE -> R.string.kin_hi_mata
+    RelativeKind.SPOUSE to Gender.MALE -> R.string.kin_hi_pati
+    RelativeKind.SPOUSE to Gender.FEMALE -> R.string.kin_hi_patni
+    RelativeKind.CHILD to Gender.MALE -> R.string.kin_hi_beta
+    RelativeKind.CHILD to Gender.FEMALE -> R.string.kin_hi_beti
+    RelativeKind.SIBLING to Gender.MALE -> R.string.kin_hi_bhai
+    RelativeKind.SIBLING to Gender.FEMALE -> R.string.kin_hi_behen
+    else -> 0
+}
+
+/**
+ * The English heading, and what every other vocabulary falls back to.
  *
  * The graph stores one PARENT edge; a person reads "Father". Gender is only ever used to pick the
  * more specific word, and falls back to the neutral one whenever it is not recorded — the label is

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -55,6 +55,7 @@ import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.addRelativeLabel
 import com.vibethroughcode.ftree.ui.common.displayName
 import com.vibethroughcode.ftree.ui.common.readableMeasure
+import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.common.sectionTitle
 import com.vibethroughcode.ftree.ui.theme.FTreeText
@@ -321,7 +322,9 @@ private fun RelativeSection(
                 person = relative,
                 onClick = { onOpen(relative.id) },
                 onLongClick = { onRemove(relative) },
-                supporting = stringResource(relativeRoleLabel(kind, relative.gender)),
+                supporting = stringResource(
+                    relativeRoleLabel(kind, relative.gender, LocalKinshipLanguage.current)
+                ),
             )
         }
     }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
@@ -60,7 +60,9 @@ import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.SectionRule
 import com.vibethroughcode.ftree.ui.common.displayName
 import com.vibethroughcode.ftree.ui.common.kinshipLabel
+import com.vibethroughcode.ftree.ui.common.kinshipName
 import com.vibethroughcode.ftree.ui.common.readableMeasure
+import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.common.asRelativeKind
 import com.vibethroughcode.ftree.ui.theme.FTreeText
@@ -256,7 +258,9 @@ private fun Answer(
  */
 @Composable
 private fun ChainRow(link: ChainLink, previous: Person, onClick: () -> Unit) {
-    val role = stringResource(relativeRoleLabel(link.kind.asRelativeKind(), link.person.gender))
+    val role = stringResource(
+        relativeRoleLabel(link.kind.asRelativeKind(), link.person.gender, LocalKinshipLanguage.current)
+    )
     PersonRow(
         person = link.person,
         onClick = onClick,
@@ -326,8 +330,21 @@ private fun Verdict(state: RelationUiState) {
                     // two are related somehow" tells a reader nothing the chain below does not tell
                     // them exactly, and "related by marriage" was worse than nothing: every
                     // relative anybody married into the family came back under the same flat phrase.
-                    answerSentence(state, relation)?.let {
-                        Text(text = it, style = MaterialTheme.typography.titleMedium)
+                    val answer = answerSentence(state, relation)
+                    answer?.let {
+                        Text(text = it.sentence, style = MaterialTheme.typography.titleMedium)
+                    }
+                    /*
+                     * ताऊ is an elder brother and चाचा a younger one, and only a date says which.
+                     * Rather than guess, the app says "father's brother" and offers the way to
+                     * sharpen it — a gap in the record turned into an invitation to fill it.
+                     */
+                    if (answer?.needsBirthYears == true) {
+                        Text(
+                            text = stringResource(R.string.relation_birth_years_nudge),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
                     }
                     Text(
                         text = pluralStringResource(
@@ -462,6 +479,9 @@ private fun PersonPicker(
     }
 }
 
+/** The answer, and whether a birth year would sharpen it. */
+private data class Answer(val sentence: String, val needsBirthYears: Boolean = false)
+
 /**
  * How the relationship reads as a sentence, or nothing when the record cannot say.
  *
@@ -471,23 +491,36 @@ private fun PersonPicker(
  * Ankit's first cousin once removed" — same fact, said the way a person would say it.
  */
 @Composable
-private fun answerSentence(state: RelationUiState, relation: Relation.Found): String? {
+private fun answerSentence(state: RelationUiState, relation: Relation.Found): Answer? {
     val to = state.to ?: return null
     val from = state.from ?: return null
     val term = relation.term ?: return null
     val toName = to.displayName()
     val fromName = from.displayName()
 
-    kinshipLabel(term, to.gender)?.let {
-        return stringResource(R.string.relation_answer_term, toName, fromName, it)
+    /*
+     * The chosen vocabulary first, whole. Hindi returns a word plus what it means in English, shown
+     * in brackets after it — "मामा (maternal uncle)" — which is how a bilingual family speaks and
+     * what lets a younger relative who has not learned the word still read the answer.
+     */
+    kinshipName(term, relation.path, from.gender, to.gender)?.let { name ->
+        val word = name.gloss?.let { stringResource(R.string.kin_with_gloss, name.term, it) }
+            ?: name.term
+        return Answer(
+            sentence = stringResource(R.string.relation_answer_term, toName, fromName, word),
+            needsBirthYears = name.needsBirthYears,
+        )
     }
 
+    // Past that, the sentence turns round and says who somebody married. Left in English on both
+    // settings: these are the shapes no language here has a single word for, so there is nothing
+    // to translate — only a phrase, and an English phrase is the one the app already writes well.
     return when (term) {
         // Married to somebody English has a word for, even though the marriage itself is not one.
         is KinshipTerm.SpouseOf -> {
             val married = state.chain.getOrNull(state.chain.lastIndex - 1)?.person ?: return null
             kinshipLabel(term.relative, married.gender)?.let {
-                stringResource(R.string.relation_answer_married_to, toName, fromName, it)
+                Answer(stringResource(R.string.relation_answer_married_to, toName, fromName, it))
             }
         }
 
@@ -496,7 +529,11 @@ private fun answerSentence(state: RelationUiState, relation: Relation.Found): St
             val spouse = state.chain.firstOrNull()?.person ?: return null
             val relative = kinshipLabel(term.relative, to.gender) ?: return null
             val spouseWord = kinshipLabel(KinshipTerm.Spouse, spouse.gender) ?: return null
-            stringResource(R.string.relation_answer_of_spouse, toName, fromName, relative, spouseWord)
+            Answer(
+                stringResource(
+                    R.string.relation_answer_of_spouse, toName, fromName, relative, spouseWord,
+                )
+            )
         }
 
         else -> null

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
@@ -26,6 +26,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
@@ -50,6 +53,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.vibethroughcode.ftree.BuildConfig
 import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.KinshipLanguage
 import com.vibethroughcode.ftree.ui.common.SectionRule
 import com.vibethroughcode.ftree.ui.common.readableMeasure
 import com.vibethroughcode.ftree.ui.theme.FTreeText
@@ -60,6 +64,8 @@ import com.vibethroughcode.ftree.update.UpdateState
 
 const val SettingsUpdatesToggleTag = "settings-updates-toggle"
 const val SettingsPhotosToggleTag = "settings-photos-toggle"
+const val SettingsWordsEnglishTag = "settings-words-english"
+const val SettingsWordsHindiTag = "settings-words-hindi"
 const val SettingsExportTag = "settings-export"
 const val SettingsImportTag = "settings-import"
 
@@ -83,6 +89,7 @@ fun SettingsScreen(
     val enabled by viewModel.updatesEnabled.collectAsStateWithLifecycle()
     val state by viewModel.updateState.collectAsStateWithLifecycle()
     val photosInChart by viewModel.photosInChart.collectAsStateWithLifecycle()
+    val kinshipLanguage by viewModel.kinshipLanguage.collectAsStateWithLifecycle()
 
     Scaffold(
         modifier = modifier,
@@ -98,6 +105,30 @@ fun SettingsScreen(
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp),
     ) {
+        SectionRule(stringResource(R.string.settings_section_words))
+
+        Text(
+            stringResource(R.string.settings_words_body),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = 4.dp, bottom = 12.dp),
+        )
+        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+            SegmentedButton(
+                selected = kinshipLanguage == KinshipLanguage.ENGLISH,
+                onClick = { viewModel.setKinshipLanguage(KinshipLanguage.ENGLISH) },
+                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                modifier = Modifier.testTag(SettingsWordsEnglishTag),
+            ) { Text(stringResource(R.string.settings_words_english)) }
+
+            SegmentedButton(
+                selected = kinshipLanguage == KinshipLanguage.HINDI,
+                onClick = { viewModel.setKinshipLanguage(KinshipLanguage.HINDI) },
+                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                modifier = Modifier.testTag(SettingsWordsHindiTag),
+            ) { Text(stringResource(R.string.settings_words_hindi)) }
+        }
+
         SectionRule(stringResource(R.string.settings_section_chart))
 
         SettingsSwitch(

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsViewModel.kt
@@ -3,6 +3,8 @@ package com.vibethroughcode.ftree.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.vibethroughcode.ftree.data.ChartPreferences
+import com.vibethroughcode.ftree.data.KinshipLanguage
+import com.vibethroughcode.ftree.data.KinshipPreferences
 import com.vibethroughcode.ftree.update.AvailableUpdate
 import com.vibethroughcode.ftree.update.UpdatePreferences
 import com.vibethroughcode.ftree.update.UpdateRepository
@@ -15,6 +17,7 @@ import java.io.File
 class SettingsViewModel(
     private val preferences: UpdatePreferences,
     private val chart: ChartPreferences,
+    private val kinship: KinshipPreferences,
     private val updates: UpdateRepository,
 ) : ViewModel() {
 
@@ -24,6 +27,10 @@ class SettingsViewModel(
     val photosInChart: StateFlow<Boolean> = chart.photosInChart
 
     fun setPhotosInChart(enabled: Boolean) = chart.setPhotosInChart(enabled)
+
+    val kinshipLanguage: StateFlow<KinshipLanguage> = kinship.language
+
+    fun setKinshipLanguage(value: KinshipLanguage) = kinship.setLanguage(value)
 
     private var work: Job? = null
 

--- a/app/src/main/res/values/kinship_hi.xml
+++ b/app/src/main/res/values/kinship_hi.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    The Hindi family vocabulary.
+
+    Kept apart from strings.xml so the whole word list can be read, and reviewed by a Hindi speaker,
+    without wading through the app's own English. Each term has a gloss: the app shows it in brackets
+    after the word, which is how bilingual families actually speak and which lets a younger relative
+    who does not know फूफा can still read the answer.
+
+    The glosses are more precise than English's own kinship words on purpose. English says "uncle"
+    five different ways; the gloss says which one, so nothing is lost by reading it in English.
+
+    Not translatable: these are Hindi, and a translator reaching them would be translating the
+    content rather than the interface. Which word is chosen is decided in graph/HindiKinship.kt and
+    tested on the JVM; this file only spells them.
+-->
+<resources>
+    <string name="kin_hi_self" translatable="false">स्वयं</string>
+    <string name="kin_hi_self_gloss">themselves</string>
+    <string name="kin_hi_pita" translatable="false">पिता</string>
+    <string name="kin_hi_pita_gloss">father</string>
+    <string name="kin_hi_mata" translatable="false">माता</string>
+    <string name="kin_hi_mata_gloss">mother</string>
+    <string name="kin_hi_dada" translatable="false">दादा</string>
+    <string name="kin_hi_dada_gloss">father\'s father</string>
+    <string name="kin_hi_dadi" translatable="false">दादी</string>
+    <string name="kin_hi_dadi_gloss">father\'s mother</string>
+    <string name="kin_hi_nana" translatable="false">नाना</string>
+    <string name="kin_hi_nana_gloss">mother\'s father</string>
+    <string name="kin_hi_nani" translatable="false">नानी</string>
+    <string name="kin_hi_nani_gloss">mother\'s mother</string>
+    <string name="kin_hi_pardada" translatable="false">परदादा</string>
+    <string name="kin_hi_pardada_gloss">father\'s grandfather</string>
+    <string name="kin_hi_pardadi" translatable="false">परदादी</string>
+    <string name="kin_hi_pardadi_gloss">father\'s grandmother</string>
+    <string name="kin_hi_parnana" translatable="false">परनाना</string>
+    <string name="kin_hi_parnana_gloss">mother\'s grandfather</string>
+    <string name="kin_hi_parnani" translatable="false">परनानी</string>
+    <string name="kin_hi_parnani_gloss">mother\'s grandmother</string>
+    <string name="kin_hi_beta" translatable="false">बेटा</string>
+    <string name="kin_hi_beta_gloss">son</string>
+    <string name="kin_hi_beti" translatable="false">बेटी</string>
+    <string name="kin_hi_beti_gloss">daughter</string>
+    <string name="kin_hi_pota" translatable="false">पोता</string>
+    <string name="kin_hi_pota_gloss">son\'s son</string>
+    <string name="kin_hi_poti" translatable="false">पोती</string>
+    <string name="kin_hi_poti_gloss">son\'s daughter</string>
+    <string name="kin_hi_nati" translatable="false">नाती</string>
+    <string name="kin_hi_nati_gloss">daughter\'s son</string>
+    <string name="kin_hi_natin" translatable="false">नातिन</string>
+    <string name="kin_hi_natin_gloss">daughter\'s daughter</string>
+    <string name="kin_hi_parpota" translatable="false">परपोता</string>
+    <string name="kin_hi_parpota_gloss">son\'s grandson</string>
+    <string name="kin_hi_parpoti" translatable="false">परपोती</string>
+    <string name="kin_hi_parpoti_gloss">son\'s granddaughter</string>
+    <string name="kin_hi_parnati" translatable="false">परनाती</string>
+    <string name="kin_hi_parnati_gloss">daughter\'s grandson</string>
+    <string name="kin_hi_parnatin" translatable="false">परनातिन</string>
+    <string name="kin_hi_parnatin_gloss">daughter\'s granddaughter</string>
+    <string name="kin_hi_bhai" translatable="false">भाई</string>
+    <string name="kin_hi_bhai_gloss">brother</string>
+    <string name="kin_hi_behen" translatable="false">बहन</string>
+    <string name="kin_hi_behen_gloss">sister</string>
+    <string name="kin_hi_tau" translatable="false">ताऊ</string>
+    <string name="kin_hi_tau_gloss">father\'s elder brother</string>
+    <string name="kin_hi_chacha" translatable="false">चाचा</string>
+    <string name="kin_hi_chacha_gloss">father\'s younger brother</string>
+    <string name="kin_hi_fathers_brother" translatable="false">पिता के भाई</string>
+    <string name="kin_hi_fathers_brother_gloss">father\'s brother</string>
+    <string name="kin_hi_tai" translatable="false">ताई</string>
+    <string name="kin_hi_tai_gloss">father\'s elder brother\'s wife</string>
+    <string name="kin_hi_chachi" translatable="false">चाची</string>
+    <string name="kin_hi_chachi_gloss">father\'s younger brother\'s wife</string>
+    <string name="kin_hi_fathers_brothers_wife" translatable="false">पिता के भाई की पत्नी</string>
+    <string name="kin_hi_fathers_brothers_wife_gloss">father\'s brother\'s wife</string>
+    <string name="kin_hi_bua" translatable="false">बुआ</string>
+    <string name="kin_hi_bua_gloss">father\'s sister</string>
+    <string name="kin_hi_phupha" translatable="false">फूफा</string>
+    <string name="kin_hi_phupha_gloss">father\'s sister\'s husband</string>
+    <string name="kin_hi_mama" translatable="false">मामा</string>
+    <string name="kin_hi_mama_gloss">mother\'s brother</string>
+    <string name="kin_hi_mami" translatable="false">मामी</string>
+    <string name="kin_hi_mami_gloss">mother\'s brother\'s wife</string>
+    <string name="kin_hi_mausi" translatable="false">मौसी</string>
+    <string name="kin_hi_mausi_gloss">mother\'s sister</string>
+    <string name="kin_hi_mausa" translatable="false">मौसा</string>
+    <string name="kin_hi_mausa_gloss">mother\'s sister\'s husband</string>
+    <string name="kin_hi_bhatija" translatable="false">भतीजा</string>
+    <string name="kin_hi_bhatija_gloss">brother\'s son</string>
+    <string name="kin_hi_bhatiji" translatable="false">भतीजी</string>
+    <string name="kin_hi_bhatiji_gloss">brother\'s daughter</string>
+    <string name="kin_hi_bhanja" translatable="false">भांजा</string>
+    <string name="kin_hi_bhanja_gloss">sister\'s son</string>
+    <string name="kin_hi_bhanji" translatable="false">भांजी</string>
+    <string name="kin_hi_bhanji_gloss">sister\'s daughter</string>
+    <string name="kin_hi_chachera_bhai" translatable="false">चचेरा भाई</string>
+    <string name="kin_hi_chachera_bhai_gloss">father\'s brother\'s son</string>
+    <string name="kin_hi_chacheri_behen" translatable="false">चचेरी बहन</string>
+    <string name="kin_hi_chacheri_behen_gloss">father\'s brother\'s daughter</string>
+    <string name="kin_hi_phuphera_bhai" translatable="false">फुफेरा भाई</string>
+    <string name="kin_hi_phuphera_bhai_gloss">father\'s sister\'s son</string>
+    <string name="kin_hi_phupheri_behen" translatable="false">फुफेरी बहन</string>
+    <string name="kin_hi_phupheri_behen_gloss">father\'s sister\'s daughter</string>
+    <string name="kin_hi_mamera_bhai" translatable="false">ममेरा भाई</string>
+    <string name="kin_hi_mamera_bhai_gloss">mother\'s brother\'s son</string>
+    <string name="kin_hi_mameri_behen" translatable="false">ममेरी बहन</string>
+    <string name="kin_hi_mameri_behen_gloss">mother\'s brother\'s daughter</string>
+    <string name="kin_hi_mausera_bhai" translatable="false">मौसेरा भाई</string>
+    <string name="kin_hi_mausera_bhai_gloss">mother\'s sister\'s son</string>
+    <string name="kin_hi_mauseri_behen" translatable="false">मौसेरी बहन</string>
+    <string name="kin_hi_mauseri_behen_gloss">mother\'s sister\'s daughter</string>
+    <string name="kin_hi_pati" translatable="false">पति</string>
+    <string name="kin_hi_pati_gloss">husband</string>
+    <string name="kin_hi_patni" translatable="false">पत्नी</string>
+    <string name="kin_hi_patni_gloss">wife</string>
+    <string name="kin_hi_sasur" translatable="false">ससुर</string>
+    <string name="kin_hi_sasur_gloss">father-in-law</string>
+    <string name="kin_hi_saas" translatable="false">सास</string>
+    <string name="kin_hi_saas_gloss">mother-in-law</string>
+    <string name="kin_hi_jija" translatable="false">जीजा</string>
+    <string name="kin_hi_jija_gloss">sister\'s husband</string>
+    <string name="kin_hi_bhabhi" translatable="false">भाभी</string>
+    <string name="kin_hi_bhabhi_gloss">brother\'s wife</string>
+    <string name="kin_hi_bahu" translatable="false">बहू</string>
+    <string name="kin_hi_bahu_gloss">son\'s wife</string>
+    <string name="kin_hi_damad" translatable="false">दामाद</string>
+    <string name="kin_hi_damad_gloss">daughter\'s husband</string>
+    <string name="kin_hi_sala" translatable="false">साला</string>
+    <string name="kin_hi_sala_gloss">wife\'s brother</string>
+    <string name="kin_hi_sali" translatable="false">साली</string>
+    <string name="kin_hi_sali_gloss">wife\'s sister</string>
+    <string name="kin_hi_jeth" translatable="false">जेठ</string>
+    <string name="kin_hi_jeth_gloss">husband\'s elder brother</string>
+    <string name="kin_hi_devar" translatable="false">देवर</string>
+    <string name="kin_hi_devar_gloss">husband\'s younger brother</string>
+    <string name="kin_hi_husbands_brother" translatable="false">पति के भाई</string>
+    <string name="kin_hi_husbands_brother_gloss">husband\'s brother</string>
+    <string name="kin_hi_nanad" translatable="false">ननद</string>
+    <string name="kin_hi_nanad_gloss">husband\'s sister</string>
+    <string name="kin_hi_sautela_pita" translatable="false">सौतेला पिता</string>
+    <string name="kin_hi_sautela_pita_gloss">stepfather</string>
+    <string name="kin_hi_sauteli_mata" translatable="false">सौतेली माता</string>
+    <string name="kin_hi_sauteli_mata_gloss">stepmother</string>
+    <string name="kin_hi_sautela_beta" translatable="false">सौतेला बेटा</string>
+    <string name="kin_hi_sautela_beta_gloss">stepson</string>
+    <string name="kin_hi_sauteli_beti" translatable="false">सौतेली बेटी</string>
+    <string name="kin_hi_sauteli_beti_gloss">stepdaughter</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -256,6 +256,12 @@
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>
+    <string name="settings_section_words">Family words</string>
+    <string name="settings_words_body">Which language the app names relationships in. Hindi has a word for each relationship where English has one for several — your mother\'s brother is मामा, your father\'s brother चाचा — so this changes the answer, not just the spelling. The rest of the app stays in English.</string>
+    <string name="settings_words_english">English</string>
+    <string name="settings_words_hindi">हिन्दी</string>
+    <string name="kin_with_gloss">%1$s (%2$s)</string>
+    <string name="relation_birth_years_nudge">Birth years for both brothers would tell चाचा from ताऊ.</string>
     <string name="settings_section_chart">Chart</string>
     <string name="settings_photos_toggle">Photos on the chart</string>
     <string name="settings_photos_explainer">Draws each person\'s photograph on their card. On a very large family this can make the chart slower to pan and zoom, and it uses more memory — turn it off and the chart draws initials instead. Nothing else changes: the cards stay exactly where they are.</string>

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/HindiEveryPairTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/HindiEveryPairTest.kt
@@ -1,0 +1,393 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.transfer.TreeDocument
+import kotlinx.serialization.json.Json
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+import java.util.zip.ZipInputStream
+
+/**
+ * Every member related to every other, in Hindi.
+ *
+ * A vocabulary this size cannot be checked by reading it. Forty-five hand-written cases prove the
+ * rules on the shapes somebody thought of; this proves them on every shape a real family contains,
+ * by asking a question the code cannot answer twice the same way by accident:
+ *
+ * **if B is A's मामा, then A must be B's भांजा or भांजी.**
+ *
+ * The two answers are computed independently, from opposite ends of the graph, through different
+ * branches of the rules. A mistake in "which side of the family" or "who links them" makes them
+ * disagree, and there is no way to satisfy the whole table by luck. Cousins are the sharpest test
+ * of all: a फुफेरा भाई must see you as his ममेरा भाई, never as another फुफेरा — the relationship
+ * inverts as it crosses.
+ *
+ * Runs on a built-in family in CI, and on a real exported tree when one is named:
+ *
+ *     ./gradlew testDebugUnitTest -Dftree.tree=temp/family-tree.ftree
+ */
+class HindiEveryPairTest {
+
+    /** If B is A's key, A must be one of the values from B. */
+    private val reciprocal: Map<HindiKinTerm, Set<HindiKinTerm>> = buildMap {
+        fun pair(a: Set<HindiKinTerm>, b: Set<HindiKinTerm>) {
+            a.forEach { put(it, b) }
+            b.forEach { put(it, a) }
+        }
+        val parents = setOf(HindiKinTerm.PITA, HindiKinTerm.MATA)
+        val children = setOf(HindiKinTerm.BETA, HindiKinTerm.BETI)
+        val siblings = setOf(HindiKinTerm.BHAI, HindiKinTerm.BEHEN)
+        val fathersSiblings = setOf(
+            HindiKinTerm.TAU, HindiKinTerm.CHACHA, HindiKinTerm.FATHERS_BROTHER, HindiKinTerm.BUA,
+        )
+        val mothersSiblings = setOf(HindiKinTerm.MAMA, HindiKinTerm.MAUSI)
+        val brothersChildren = setOf(HindiKinTerm.BHATIJA, HindiKinTerm.BHATIJI)
+        val sistersChildren = setOf(HindiKinTerm.BHANJA, HindiKinTerm.BHANJI)
+
+        pair(parents, children)
+        pair(siblings, siblings)
+        pair(setOf(HindiKinTerm.DADA, HindiKinTerm.DADI), setOf(HindiKinTerm.POTA, HindiKinTerm.POTI))
+        pair(setOf(HindiKinTerm.NANA, HindiKinTerm.NANI), setOf(HindiKinTerm.NATI, HindiKinTerm.NATIN))
+        // A father's sibling sees you as their brother's child; a mother's, as their sister's.
+        pair(fathersSiblings, brothersChildren)
+        pair(mothersSiblings, sistersChildren)
+        // Cousins invert as they cross: your father's sister's son is, to him, your mother's
+        // brother's son. The two that come through a same-sex sibling stay themselves.
+        pair(
+            setOf(HindiKinTerm.PHUPHERA_BHAI, HindiKinTerm.PHUPHERI_BEHEN),
+            setOf(HindiKinTerm.MAMERA_BHAI, HindiKinTerm.MAMERI_BEHEN),
+        )
+        pair(
+            setOf(HindiKinTerm.CHACHERA_BHAI, HindiKinTerm.CHACHERI_BEHEN),
+            setOf(HindiKinTerm.CHACHERA_BHAI, HindiKinTerm.CHACHERI_BEHEN),
+        )
+        pair(
+            setOf(HindiKinTerm.MAUSERA_BHAI, HindiKinTerm.MAUSERI_BEHEN),
+            setOf(HindiKinTerm.MAUSERA_BHAI, HindiKinTerm.MAUSERI_BEHEN),
+        )
+        // Through marriage.
+        pair(setOf(HindiKinTerm.PATI), setOf(HindiKinTerm.PATNI))
+        pair(
+            setOf(HindiKinTerm.SASUR, HindiKinTerm.SAAS),
+            setOf(HindiKinTerm.DAMAD, HindiKinTerm.BAHU),
+        )
+        pair(setOf(HindiKinTerm.JIJA), setOf(HindiKinTerm.SALA, HindiKinTerm.SALI))
+        pair(
+            setOf(HindiKinTerm.BHABHI),
+            setOf(
+                HindiKinTerm.JETH, HindiKinTerm.DEVAR, HindiKinTerm.HUSBANDS_BROTHER,
+                HindiKinTerm.NANAD,
+            ),
+        )
+    }
+
+    /**
+     * Whether Hindi has a word for this *shape* of relationship at all.
+     *
+     * English names every blood relation however far out — "second cousin twice removed" — by
+     * building a phrase out of two numbers. Hindi does not work that way: it has a precise word for
+     * each of the relationships a family talks about and nothing beyond them, which is why a raw
+     * percentage over every pair in a six-generation tree says more about the tree's depth than about
+     * the vocabulary. This is the honest denominator.
+     */
+    private fun hindiCovers(term: KinshipTerm): Boolean = when (term) {
+        KinshipTerm.Self, KinshipTerm.Sibling, KinshipTerm.Spouse -> true
+        is KinshipTerm.Ancestor -> term.generations <= 3
+        is KinshipTerm.Descendant -> term.generations <= 3
+        is KinshipTerm.ParentsSibling -> term.greats == 0
+        is KinshipTerm.SiblingsChild -> term.greats == 0
+        is KinshipTerm.Cousin -> term.degree == 1 && term.removed == 0
+        is KinshipTerm.SpouseOf -> when (val r = term.relative) {
+            KinshipTerm.Sibling -> true
+            is KinshipTerm.ParentsSibling -> r.greats == 0
+            is KinshipTerm.Ancestor -> r.generations == 1
+            is KinshipTerm.Descendant -> r.generations == 1
+            else -> false
+        }
+        is KinshipTerm.OfSpouse -> when (val r = term.relative) {
+            KinshipTerm.Sibling -> true
+            is KinshipTerm.Ancestor -> r.generations == 1
+            is KinshipTerm.Descendant -> r.generations == 1
+            else -> false
+        }
+    }
+
+    private fun hindiOf(snapshot: FamilySnapshot, from: String, to: String): HindiKinTerm? {
+        val found = Kinship.relate(snapshot, from, to) as? Relation.Found ?: return null
+        val term = found.term ?: return null
+        return HindiKinship.term(
+            term = term,
+            path = found.path,
+            subject = snapshot.people.getValue(from).gender,
+            target = snapshot.people.getValue(to).gender,
+        )
+    }
+
+    private data class Report(
+        val pairs: Int,
+        /** Pairs English can name with a structured term at all. */
+        val related: Int,
+        /** …of those, the ones whose shape Hindi has a word for when the record is complete. */
+        val coverable: Int,
+        val named: Int,
+        val descriptive: Int,
+        /** Named one way but not the other, because somebody on the line has no recorded gender. */
+        val excusedByGender: Int,
+        /** …or because the line runs through a marriage the record has recorded inconsistently. */
+        val excusedByContradiction: Int,
+        val contradictions: List<String>,
+        val breaches: List<String>,
+        val counts: Map<HindiKinTerm, Int>,
+    )
+
+    /**
+     * Whether an unrecorded gender explains why no word came back.
+     *
+     * Hindi has no gender-neutral kinship word — there is no neuter for भाई or बहन — so a person
+     * whose gender nobody wrote down genuinely has no term, and saying nothing is the right answer.
+     * That is a fact about the record rather than a fault in the rules, and this is what separates
+     * the two so the test can still fail on the second.
+     */
+    private fun genderIsMissing(snapshot: FamilySnapshot, from: String, to: String): Boolean {
+        val found = Kinship.relate(snapshot, from, to) as? Relation.Found ?: return false
+        val involved = found.peopleInvolved(from)
+        return involved.any { snapshot.people[it]?.gender != Gender.MALE &&
+            snapshot.people[it]?.gender != Gender.FEMALE }
+    }
+
+    /**
+     * Marriages the record states inconsistently — both partners written down with the same gender.
+     *
+     * Almost always one gender entered wrongly rather than anything about the marriage. Every Hindi
+     * in-law word names both partners (जीजा married a sister, भाभी married a brother), so a line
+     * running through such a marriage genuinely has no word, and the rules are right to decline. The
+     * test separates these from real disagreements so a mistake in somebody's tree cannot be mistaken
+     * for a mistake in the vocabulary — and names them, because they are worth fixing.
+     */
+    private fun contradictoryMarriages(snapshot: FamilySnapshot): Set<Set<String>> =
+        snapshot.spouseEdges.filter { (a, b) ->
+            val one = snapshot.people[a]?.gender
+            val two = snapshot.people[b]?.gender
+            one != null && one == two && one != Gender.UNSPECIFIED && one != Gender.OTHER
+        }.map { setOf(it.first, it.second) }.toSet()
+
+    /** Whether the line joining two people passes through one of those marriages. */
+    private fun crossesContradiction(
+        snapshot: FamilySnapshot,
+        from: String,
+        to: String,
+        bad: Set<Set<String>>,
+    ): Boolean {
+        if (bad.isEmpty()) return false
+        val found = Kinship.relate(snapshot, from, to) as? Relation.Found ?: return false
+        var previous = from
+        return found.chain.any { step ->
+            val crosses = step.kind == StepKind.SPOUSE && setOf(previous, step.personId) in bad
+            previous = step.personId
+            crosses
+        }
+    }
+
+    private fun sweep(snapshot: FamilySnapshot): Report {
+        val ids = snapshot.people.keys.toList()
+        var pairs = 0
+        var related = 0
+        var coverable = 0
+        var named = 0
+        var descriptive = 0
+        var excused = 0
+        var contradicted = 0
+        val breaches = mutableListOf<String>()
+        val counts = mutableMapOf<HindiKinTerm, Int>()
+        val bad = contradictoryMarriages(snapshot)
+
+        fun name(id: String) = snapshot.people[id]?.name ?: id
+
+        ids.forEach { a ->
+            ids.forEach inner@{ b ->
+                if (a == b) return@inner
+                pairs++
+                (Kinship.relate(snapshot, a, b) as? Relation.Found)?.term?.let {
+                    related++
+                    if (hindiCovers(it)) coverable++
+                }
+
+                val forward = hindiOf(snapshot, a, b) ?: return@inner
+                named++
+                if (forward.needsBirthYears) descriptive++
+                counts[forward] = (counts[forward] ?: 0) + 1
+
+                val expected = reciprocal[forward] ?: return@inner
+                val back = hindiOf(snapshot, b, a)
+                when {
+                    back == null && genderIsMissing(snapshot, b, a) -> excused++
+                    crossesContradiction(snapshot, a, b, bad) ||
+                        crossesContradiction(snapshot, b, a, bad) -> contradicted++
+                    back == null -> breaches +=
+                        "${name(b)} is ${name(a)}'s $forward, and nothing comes back the other way " +
+                            "— yet every gender on that line is recorded"
+                    back !in expected -> breaches +=
+                        "${name(b)} is ${name(a)}'s $forward, so ${name(a)} should be one of " +
+                            "$expected to ${name(b)} — got $back"
+                }
+            }
+        }
+        return Report(
+            pairs = pairs,
+            related = related,
+            coverable = coverable,
+            named = named,
+            descriptive = descriptive,
+            excusedByGender = excused,
+            excusedByContradiction = contradicted,
+            contradictions = bad.map { it.joinToString(" and ") { id -> name(id) } },
+            breaches = breaches,
+            counts = counts,
+        )
+    }
+
+    /**
+     * The built-in family: four generations, both sides recorded, every kind of aunt and uncle with
+     * children of their own, and marriages at both ends.
+     */
+    private fun family(): FamilySnapshot {
+        val people = mutableMapOf<String, Person>()
+        val parents = mutableListOf<Pair<String, String>>()
+        val spouses = mutableListOf<Pair<String, String>>()
+
+        fun add(id: String, gender: Gender, born: String) {
+            people[id] = Person(id = id, name = id, gender = gender, birthDate = born)
+        }
+        fun kids(a: String, b: String, vararg children: String) {
+            children.forEach { parents += a to it; parents += b to it }
+        }
+
+        add("dada", Gender.MALE, "1930"); add("dadi", Gender.FEMALE, "1934")
+        add("nana", Gender.MALE, "1932"); add("nani", Gender.FEMALE, "1936")
+        add("tau", Gender.MALE, "1952"); add("tai", Gender.FEMALE, "1955")
+        add("dad", Gender.MALE, "1958"); add("mum", Gender.FEMALE, "1960")
+        add("chacha", Gender.MALE, "1963"); add("chachi", Gender.FEMALE, "1966")
+        add("bua", Gender.FEMALE, "1955"); add("phupha", Gender.MALE, "1952")
+        add("mama", Gender.MALE, "1956"); add("mami", Gender.FEMALE, "1959")
+        add("mausi", Gender.FEMALE, "1962"); add("mausa", Gender.MALE, "1960")
+        add("me", Gender.MALE, "1985"); add("wife", Gender.FEMALE, "1987")
+        add("brother", Gender.MALE, "1988"); add("bhabhi", Gender.FEMALE, "1989")
+        add("sister", Gender.FEMALE, "1990"); add("jija", Gender.MALE, "1986")
+        add("son", Gender.MALE, "2012"); add("daughter", Gender.FEMALE, "2015")
+        add("sasur", Gender.MALE, "1958"); add("saas", Gender.FEMALE, "1961")
+        add("sala", Gender.MALE, "1990"); add("sali", Gender.FEMALE, "1992")
+        listOf(
+            "tau-son" to Gender.MALE, "tau-daughter" to Gender.FEMALE,
+            "chacha-son" to Gender.MALE, "chacha-daughter" to Gender.FEMALE,
+            "bua-son" to Gender.MALE, "bua-daughter" to Gender.FEMALE,
+            "mama-son" to Gender.MALE, "mama-daughter" to Gender.FEMALE,
+            "mausi-son" to Gender.MALE, "mausi-daughter" to Gender.FEMALE,
+            "brother-son" to Gender.MALE, "sister-daughter" to Gender.FEMALE,
+        ).forEach { (id, g) -> add(id, g, "1990") }
+
+        spouses += listOf(
+            "dada" to "dadi", "nana" to "nani", "tau" to "tai", "dad" to "mum",
+            "chacha" to "chachi", "bua" to "phupha", "mama" to "mami", "mausi" to "mausa",
+            "me" to "wife", "brother" to "bhabhi", "sister" to "jija", "sasur" to "saas",
+        )
+        kids("dada", "dadi", "tau", "dad", "chacha", "bua")
+        kids("nana", "nani", "mum", "mama", "mausi")
+        kids("dad", "mum", "me", "brother", "sister")
+        kids("me", "wife", "son", "daughter")
+        kids("sasur", "saas", "wife", "sala", "sali")
+        kids("tau", "tai", "tau-son", "tau-daughter")
+        kids("chacha", "chachi", "chacha-son", "chacha-daughter")
+        kids("bua", "phupha", "bua-son", "bua-daughter")
+        kids("mama", "mami", "mama-son", "mama-daughter")
+        kids("mausi", "mausa", "mausi-son", "mausi-daughter")
+        kids("brother", "bhabhi", "brother-son")
+        kids("sister", "jija", "sister-daughter")
+
+        return FamilySnapshot(people, parents, spouses, emptyList())
+    }
+
+    @Test
+    fun everyPairAgreesWithItsOppositeNumber() {
+        val report = sweep(family())
+        println(summary("built-in family", report))
+        report.counts.entries.sortedByDescending { it.value }
+            .forEach { println("  ${it.key}: ${it.value}") }
+
+        if (report.breaches.isNotEmpty()) {
+            throw AssertionError(
+                "${report.breaches.size} relationships disagree with their reverse:\n" +
+                    report.breaches.take(25).joinToString("\n")
+            )
+        }
+    }
+
+    /** The same sweep over a real exported tree, when one is named on the command line. */
+    @Test
+    fun everyPairOfARealTreeAgreesToo() {
+        val path = System.getProperty("ftree.tree")
+        assumeTrue("no -Dftree.tree given", path != null)
+
+        val snapshot = load(File(path))
+        val report = sweep(snapshot)
+        println(summary("real tree, ${snapshot.people.size} people", report))
+        report.counts.entries.sortedByDescending { it.value }
+            .forEach { println("  ${it.key}: ${it.value}") }
+
+        if (report.breaches.isNotEmpty()) {
+            throw AssertionError(
+                "${report.breaches.size} relationships disagree with their reverse:\n" +
+                    report.breaches.take(25).joinToString("\n")
+            )
+        }
+    }
+
+    private fun summary(label: String, r: Report) = buildString {
+        appendLine("$label — ${r.pairs} ordered pairs")
+        appendLine("  ${r.related} have a relationship English can name at all")
+        appendLine("  ${r.coverable} of those are a shape Hindi has a word for")
+        appendLine("  ${r.named} get a Hindi word — ${r.named * 100 / maxOf(r.coverable, 1)}% of the")
+        appendLine("     shapes it covers, ${r.named * 100 / maxOf(r.related, 1)}% of every named pair")
+        appendLine("  ${r.descriptive} of those are descriptive, for want of a birth year")
+        appendLine("  ${r.excusedByGender} have no word coming back, because a gender is unrecorded")
+        if (r.contradictions.isNotEmpty()) {
+            appendLine(
+                "  ${r.excusedByContradiction} run through a marriage recorded inconsistently:"
+            )
+            r.contradictions.forEach { appendLine("     $it — both recorded with the same gender") }
+        }
+    }
+
+    private fun load(file: File): FamilySnapshot {
+        val json = ZipInputStream(file.inputStream()).use { zip ->
+            generateSequence { zip.nextEntry }
+                .firstOrNull { it.name == TreeDocument.ENTRY_JSON }
+                ?: error("no ${TreeDocument.ENTRY_JSON} in ${file.name}")
+            zip.readBytes().decodeToString()
+        }
+        val doc = Json { ignoreUnknownKeys = true }.decodeFromString<TreeDocument>(json)
+        val people = doc.people.associate { record ->
+            record.id to Person(
+                id = record.id,
+                name = record.name,
+                gender = Gender.entries.firstOrNull { it.name == record.gender }
+                    ?: Gender.UNSPECIFIED,
+                birthDate = record.birthDate,
+                deathDate = record.deathDate,
+                deceased = record.deceased,
+            )
+        }
+        val parents = mutableListOf<Pair<String, String>>()
+        val spouses = mutableListOf<Pair<String, String>>()
+        val siblings = mutableListOf<Pair<String, String>>()
+        doc.relationships.forEach {
+            when (it.type) {
+                "PARENT" -> parents += it.from to it.to
+                "SPOUSE" -> spouses += it.from to it.to
+                "SIBLING" -> siblings += it.from to it.to
+            }
+        }
+        return FamilySnapshot(people, parents, spouses, siblings)
+    }
+}

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/HindiKinshipTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/HindiKinshipTest.kt
@@ -1,0 +1,369 @@
+package com.vibethroughcode.ftree.graph
+
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The Hindi vocabulary, pinned relationship by relationship.
+ *
+ * This is the file that decides whether the feature is right. English collapses five Hindi words
+ * into "uncle", so every one of these could be quietly wrong in a way no English test would catch —
+ * and a Hindi speaker reading "चाचा" for their mother's brother sees the mistake instantly, where
+ * "uncle" was merely vague. Each case names the family shape it comes from so the table can be
+ * checked against how a family actually speaks rather than against the code.
+ *
+ * The tree below is built to reach every term at once: both grandfathers, all four kinds of
+ * parent's sibling with their spouses, both kinds of cousin-through-a-brother and through a sister,
+ * nieces and nephews on both sides, and a marriage on each end.
+ */
+class HindiKinshipTest {
+
+    private class Builder {
+        val people = mutableMapOf<String, Person>()
+        val parents = mutableListOf<Pair<String, String>>()
+        val spouses = mutableListOf<Pair<String, String>>()
+        val siblings = mutableListOf<Pair<String, String>>()
+
+        fun man(id: String, born: String? = null) = person(id, Gender.MALE, born)
+        fun woman(id: String, born: String? = null) = person(id, Gender.FEMALE, born)
+
+        fun person(id: String, gender: Gender, born: String? = null) = apply {
+            people[id] = Person(id = id, name = id, gender = gender, birthDate = born)
+        }
+
+        fun childrenOf(a: String, b: String, vararg children: String) = apply {
+            children.forEach { parents += a to it; parents += b to it }
+        }
+
+        fun married(a: String, b: String) = apply { spouses += a to b }
+        fun build() = FamilySnapshot(people, parents, spouses, siblings)
+    }
+
+    /**
+     * "me" at the centre, with both sides of the family recorded and birth years where the order
+     * matters — the father's brothers, because ताऊ and चाचा are told apart by nothing else.
+     */
+    private fun family() = Builder()
+        // Father's parents, and his siblings: an elder brother, a younger brother, a sister.
+        .man("dada", "1930").woman("dadi", "1934")
+        .man("tau", "1952").woman("tau-wife", "1955")
+        .man("dad", "1958").woman("mum", "1960")
+        .man("chacha", "1963").woman("chacha-wife", "1966")
+        .woman("bua", "1955").man("bua-husband", "1952")
+        // Mother's parents, and her siblings: a brother and a sister.
+        .man("nana", "1932").woman("nani", "1936")
+        .man("mama", "1956").woman("mama-wife", "1959")
+        .woman("mausi", "1962").man("mausi-husband", "1960")
+        // Me, my wife, my brother and sister, my children.
+        .man("me", "1985").woman("wife", "1987")
+        .man("brother", "1988").woman("sister", "1990")
+        .man("son", "2012").woman("daughter", "2015")
+        .man("grandson", "2040").woman("granddaughter", "2042")
+        // The cousins, one set from each aunt and uncle.
+        .man("chachera", "1990").woman("chacheri", "1992")
+        .man("phuphera", "1988").woman("phupheri", "1991")
+        .man("mamera", "1989").woman("mameri", "1993")
+        .man("mausera", "1994").woman("mauseri", "1996")
+        // Nieces and nephews, through my brother and through my sister.
+        .man("bhatija", "2014").woman("bhatiji", "2016")
+        .man("bhanja", "2018").woman("bhanji", "2020")
+        // My wife's family, for the in-law terms.
+        .man("sasur", "1958").woman("saas", "1961")
+        .man("sala", "1990").woman("sali", "1992")
+        // Spouses of my own siblings.
+        .man("jija", "1986").woman("bhabhi", "1989")
+
+        .married("dada", "dadi").married("nana", "nani")
+        .married("dad", "mum").married("me", "wife")
+        .married("tau", "tau-wife").married("chacha", "chacha-wife")
+        .married("bua", "bua-husband").married("mama", "mama-wife")
+        .married("mausi", "mausi-husband")
+        .married("sasur", "saas")
+        .married("sister", "jija").married("brother", "bhabhi")
+
+        .childrenOf("dada", "dadi", "tau", "dad", "chacha", "bua")
+        .childrenOf("nana", "nani", "mum", "mama", "mausi")
+        .childrenOf("dad", "mum", "me", "brother", "sister")
+        .childrenOf("me", "wife", "son", "daughter")
+        .childrenOf("son", "daughter-in-law-unused", "grandson")
+        .childrenOf("chacha", "chacha-wife", "chachera", "chacheri")
+        .childrenOf("bua", "bua-husband", "phuphera", "phupheri")
+        .childrenOf("mama", "mama-wife", "mamera", "mameri")
+        .childrenOf("mausi", "mausi-husband", "mausera", "mauseri")
+        .childrenOf("brother", "bhabhi", "bhatija", "bhatiji")
+        .childrenOf("sister", "jija", "bhanja", "bhanji")
+        .childrenOf("sasur", "saas", "wife", "sala", "sali")
+        .build()
+
+    /** The word for [other] as seen from [subject]. */
+    private fun word(
+        snapshot: FamilySnapshot,
+        subject: String,
+        other: String,
+    ): HindiKinTerm? {
+        val relation = Kinship.relate(snapshot, subject, other) as? Relation.Found
+            ?: error("$subject and $other are not related in the fixture")
+        val term = relation.term ?: return null
+        return HindiKinship.term(
+            term = term,
+            path = relation.path,
+            subject = snapshot.people.getValue(subject).gender,
+            target = snapshot.people.getValue(other).gender,
+        )
+    }
+
+    private fun assertWord(expected: HindiKinTerm, other: String, subject: String = "me") {
+        assertEquals("$other, seen from $subject", expected, word(family(), subject, other))
+    }
+
+    /* --------------------------------------------------------------------------- the sides */
+
+    /**
+     * The distinction the whole feature exists for. English says "grandfather" twice; Hindi says
+     * दादा for the father's father and नाना for the mother's, and they are not interchangeable.
+     */
+    @Test
+    fun theTwoGrandfathersHaveDifferentWords() {
+        assertWord(HindiKinTerm.DADA, "dada")
+        assertWord(HindiKinTerm.DADI, "dadi")
+        assertWord(HindiKinTerm.NANA, "nana")
+        assertWord(HindiKinTerm.NANI, "nani")
+    }
+
+    /** The reported case: Ankit's mother's brother is his मामा, never his चाचा. */
+    @Test
+    fun mothersBrotherIsMamaAndFathersBrotherIsNot() {
+        assertWord(HindiKinTerm.MAMA, "mama")
+        assertWord(HindiKinTerm.CHACHA, "chacha")
+    }
+
+    @Test
+    fun allFourKindsOfParentsSiblingAreDistinguished() {
+        assertWord(HindiKinTerm.TAU, "tau")          // father's elder brother
+        assertWord(HindiKinTerm.CHACHA, "chacha")    // father's younger brother
+        assertWord(HindiKinTerm.BUA, "bua")          // father's sister
+        assertWord(HindiKinTerm.MAMA, "mama")        // mother's brother
+        assertWord(HindiKinTerm.MAUSI, "mausi")      // mother's sister
+    }
+
+    @Test
+    fun theirSpousesTakeTheWordThatBelongsToThem() {
+        assertWord(HindiKinTerm.TAI, "tau-wife")
+        assertWord(HindiKinTerm.CHACHI, "chacha-wife")
+        assertWord(HindiKinTerm.PHUPHA, "bua-husband")
+        assertWord(HindiKinTerm.MAMI, "mama-wife")
+        assertWord(HindiKinTerm.MAUSA, "mausi-husband")
+    }
+
+    /* ------------------------------------------------------------------------ birth order */
+
+    /**
+     * ताऊ is the elder brother and चाचा the younger, and nothing but a date says which. With the
+     * years removed the app says "father's brother" rather than picking one — the same rule that
+     * removed "related by marriage": claim precision only where the record supports it.
+     */
+    @Test
+    fun withoutBirthYearsFathersBrotherIsNamedDescriptively() {
+        val undated = Builder()
+            .man("dada").woman("dadi")
+            .man("dad").woman("mum")
+            .man("uncle").woman("uncle-wife")
+            .man("me")
+            .married("dad", "mum").married("uncle", "uncle-wife")
+            .childrenOf("dada", "dadi", "dad", "uncle")
+            .childrenOf("dad", "mum", "me")
+            .build()
+
+        assertEquals(HindiKinTerm.FATHERS_BROTHER, word(undated, "me", "uncle"))
+        assertEquals(HindiKinTerm.FATHERS_BROTHERS_WIFE, word(undated, "me", "uncle-wife"))
+    }
+
+    /** And the descriptive terms say so, which is how the screen knows to offer the nudge. */
+    @Test
+    fun theDescriptiveTermsAskForBirthYears() {
+        assertTrue(HindiKinTerm.FATHERS_BROTHER.needsBirthYears)
+        assertTrue(HindiKinTerm.FATHERS_BROTHERS_WIFE.needsBirthYears)
+        assertTrue(HindiKinTerm.HUSBANDS_BROTHER.needsBirthYears)
+        assertEquals(
+            "no other term should be claiming it needs a birth year",
+            3,
+            HindiKinTerm.entries.count { it.needsBirthYears },
+        )
+    }
+
+    /** Years that overlap prove nothing. "1958" and "1958" could be either way round. */
+    @Test
+    fun yearsThatCouldOverlapDoNotSettleTheOrder() {
+        val ambiguous = Builder()
+            .man("dada").woman("dadi")
+            .man("dad", "1958").man("uncle", "1958")
+            .woman("mum").man("me")
+            .married("dad", "mum")
+            .childrenOf("dada", "dadi", "dad", "uncle")
+            .childrenOf("dad", "mum", "me")
+            .build()
+
+        assertEquals(HindiKinTerm.FATHERS_BROTHER, word(ambiguous, "me", "uncle"))
+    }
+
+    /** Only the father's brothers ever need a date. मामा and मौसी never do. */
+    @Test
+    fun theOtherSidesNeverNeedABirthYear() {
+        val undated = Builder()
+            .man("nana").woman("nani")
+            .man("dad").woman("mum")
+            .man("mama").woman("mausi")
+            .man("me")
+            .married("dad", "mum")
+            .childrenOf("nana", "nani", "mum", "mama", "mausi")
+            .childrenOf("dad", "mum", "me")
+            .build()
+
+        assertEquals(HindiKinTerm.MAMA, word(undated, "me", "mama"))
+        assertEquals(HindiKinTerm.MAUSI, word(undated, "me", "mausi"))
+    }
+
+    /* ------------------------------------------------------------------------- downward */
+
+    @Test
+    fun grandchildrenAreNamedByWhichChildTheyComeThrough() {
+        assertWord(HindiKinTerm.BETA, "son")
+        assertWord(HindiKinTerm.BETI, "daughter")
+        // A son's son is पोता; a daughter's would be नाती.
+        assertWord(HindiKinTerm.POTA, "grandson")
+    }
+
+    @Test
+    fun niecesAndNephewsAreNamedByTheSiblingNotByThemselves() {
+        assertWord(HindiKinTerm.BHATIJA, "bhatija")   // brother's son
+        assertWord(HindiKinTerm.BHATIJI, "bhatiji")   // brother's daughter
+        assertWord(HindiKinTerm.BHANJA, "bhanja")     // sister's son
+        assertWord(HindiKinTerm.BHANJI, "bhanji")     // sister's daughter
+    }
+
+    /* -------------------------------------------------------------------------- cousins */
+
+    /**
+     * Hindi has no separate word for a cousin — they are brothers and sisters with a qualifier
+     * naming the aunt or uncle they come through, which is four different words where English has
+     * one.
+     */
+    @Test
+    fun cousinsAreNamedThroughTheAuntOrUncle() {
+        assertWord(HindiKinTerm.CHACHERA_BHAI, "chachera")
+        assertWord(HindiKinTerm.CHACHERI_BEHEN, "chacheri")
+        assertWord(HindiKinTerm.PHUPHERA_BHAI, "phuphera")
+        assertWord(HindiKinTerm.PHUPHERI_BEHEN, "phupheri")
+        assertWord(HindiKinTerm.MAMERA_BHAI, "mamera")
+        assertWord(HindiKinTerm.MAMERI_BEHEN, "mameri")
+        assertWord(HindiKinTerm.MAUSERA_BHAI, "mausera")
+        assertWord(HindiKinTerm.MAUSERI_BEHEN, "mauseri")
+    }
+
+    /* ------------------------------------------------------------------------ by marriage */
+
+    @Test
+    fun theImmediateFamilyAndTheInLawsBesideIt() {
+        assertWord(HindiKinTerm.PITA, "dad")
+        assertWord(HindiKinTerm.MATA, "mum")
+        assertWord(HindiKinTerm.BHAI, "brother")
+        assertWord(HindiKinTerm.BEHEN, "sister")
+        assertWord(HindiKinTerm.PATNI, "wife")
+        assertWord(HindiKinTerm.SASUR, "sasur")
+        assertWord(HindiKinTerm.SAAS, "saas")
+    }
+
+    /** जीजा is a sister's husband and भाभी a brother's wife — the sibling picks the word. */
+    @Test
+    fun aSiblingsSpouseIsNamedThroughTheSibling() {
+        assertWord(HindiKinTerm.JIJA, "jija")
+        assertWord(HindiKinTerm.BHABHI, "bhabhi")
+    }
+
+    /**
+     * The terms that depend on who is asking. A wife's brother is साला to a man; a husband's
+     * brother is जेठ or देवर to a woman, and which one depends on his age against her husband's.
+     */
+    @Test
+    fun spousesSiblingsDependOnTheGenderOfThePersonAsking() {
+        assertWord(HindiKinTerm.SALA, "sala")
+        assertWord(HindiKinTerm.SALI, "sali")
+
+        // The same two people, asked from the wife's side: her husband's brother and sister.
+        assertEquals(HindiKinTerm.DEVAR, word(family(), "wife", "brother"))
+        assertEquals(HindiKinTerm.NANAD, word(family(), "wife", "sister"))
+    }
+
+    @Test
+    fun aHusbandsElderBrotherIsJethAndAYoungerOneDevar() {
+        val f = family()
+        // "brother" is born 1988, after "me" in 1985, so to my wife he is the younger — देवर.
+        assertEquals(HindiKinTerm.DEVAR, word(f, "wife", "brother"))
+
+        val elder = Builder()
+            .man("dad").woman("mum")
+            .man("husband", "1985").man("his-brother", "1980")
+            .woman("her")
+            .married("husband", "her")
+            .childrenOf("dad", "mum", "husband", "his-brother")
+            .build()
+        assertEquals(HindiKinTerm.JETH, word(elder, "her", "his-brother"))
+    }
+
+    /* ------------------------------------------------------------- where Hindi has no word */
+
+    /**
+     * Second cousins, removed cousins and great-uncles have no everyday Hindi word, and inventing a
+     * Devanagari compound nobody says would be worse than the English one the screen falls back to.
+     */
+    @Test
+    fun relationshipsHindiHasNoWordForComeBackEmpty() {
+        val distant = Builder()
+            .man("great").woman("great-wife")
+            .man("grandad").man("granduncle")
+            .man("dad").man("cousin-parent")
+            .man("me").man("second-cousin")
+            .childrenOf("great", "great-wife", "grandad", "granduncle")
+            .childrenOf("grandad", "unknown-a", "dad")
+            .childrenOf("granduncle", "unknown-b", "cousin-parent")
+            .childrenOf("dad", "unknown-c", "me")
+            .childrenOf("cousin-parent", "unknown-d", "second-cousin")
+            .build()
+
+        assertNull(word(distant, "me", "second-cousin"))
+        assertNull(word(distant, "me", "granduncle"))
+    }
+
+    /** A gender nobody recorded is not a word Hindi can supply, so it declines rather than guesses. */
+    @Test
+    fun anUnrecordedGenderMeansNoHindiWord() {
+        val unknown = Builder()
+            .person("dad", Gender.UNSPECIFIED)
+            .person("me", Gender.UNSPECIFIED)
+            .childrenOf("dad", "dad", "me")
+            .build()
+
+        assertNull(word(unknown, "me", "dad"))
+    }
+
+    /**
+     * And a side the record cannot supply — a grandparent reached through a parent whose gender
+     * was never written down — is left to English rather than guessed at.
+     */
+    @Test
+    fun anUnknownSideLeavesTheGrandparentToEnglish() {
+        val unknown = Builder()
+            .man("grandad")
+            .person("parent", Gender.UNSPECIFIED)
+            .man("me")
+            .childrenOf("grandad", "grandad", "parent")
+            .childrenOf("parent", "parent", "me")
+            .build()
+
+        assertNull(word(unknown, "me", "grandad"))
+    }
+}

--- a/docs/kinship-hindi.md
+++ b/docs/kinship-hindi.md
@@ -1,0 +1,130 @@
+# The Hindi family vocabulary
+
+f-tree can name relationships in Hindi instead of English — **Settings → Family words**. This page
+is the whole vocabulary, so a Hindi speaker can check the words without reading any Kotlin.
+
+## Why this is not a translation
+
+English has one word where Hindi has five. "Uncle" is चाचा, ताऊ, मामा, फूफा or मौसा depending on
+facts English throws away, so a label-swap would confidently print the wrong word — and a wrong
+Hindi word is worse than a vague English one, because a Hindi speaker sees the mistake instantly.
+
+Choosing correctly needs three things the app now keeps alongside every relationship
+(`graph/Kinship.kt`, `KinshipPath`):
+
+| | example |
+|---|---|
+| **which side** the line goes up through | मामा is a mother's brother, चाचा a father's |
+| **who links** the two people | भतीजा is a *brother's* son, भांजा a *sister's* |
+| **who was born first** | ताऊ is a father's elder brother, चाचा the younger |
+
+## What happens when the record cannot say
+
+Only one distinction depends on a birth year — a father's brother — and only there does the app fall
+back. With no years to compare it says **पिता के भाई** (father's brother), which is true, and offers
+to sharpen it if the years are added. It never guesses between चाचा and ताऊ: that would be wrong
+about half the time, in a way the family notices immediately.
+
+Cousins deliberately ignore birth order: चचेरा covers both ताऊ's children and चाचा's in ordinary
+speech, so no cousin ever depends on a date.
+
+Hindi has no gender-neutral kinship word, so a person whose gender was never recorded gets no Hindi
+term and the English one is used instead.
+
+## Where Hindi stops
+
+Second cousins, cousins once removed, great-uncles — Hindi has no everyday word for these, and the
+app falls back to the English one rather than inventing a Devanagari compound nobody says. That is
+what Hindi speakers do themselves.
+
+## The words
+
+Each is shown with its meaning in brackets: **मामा (mother's brother)**. The meanings are more
+precise than English's own kinship words on purpose — "uncle" would not say which one.
+
+| Word | Means | Reached by |
+|---|---|---|
+| **स्वयं** | themselves | `SELF` |
+| **पिता** | father | `PITA` |
+| **माता** | mother | `MATA` |
+| **दादा** | father's father | `DADA` |
+| **दादी** | father's mother | `DADI` |
+| **नाना** | mother's father | `NANA` |
+| **नानी** | mother's mother | `NANI` |
+| **परदादा** | father's grandfather | `PARDADA` |
+| **परदादी** | father's grandmother | `PARDADI` |
+| **परनाना** | mother's grandfather | `PARNANA` |
+| **परनानी** | mother's grandmother | `PARNANI` |
+| **बेटा** | son | `BETA` |
+| **बेटी** | daughter | `BETI` |
+| **पोता** | son's son | `POTA` |
+| **पोती** | son's daughter | `POTI` |
+| **नाती** | daughter's son | `NATI` |
+| **नातिन** | daughter's daughter | `NATIN` |
+| **परपोता** | son's grandson | `PARPOTA` |
+| **परपोती** | son's granddaughter | `PARPOTI` |
+| **परनाती** | daughter's grandson | `PARNATI` |
+| **परनातिन** | daughter's granddaughter | `PARNATIN` |
+| **भाई** | brother | `BHAI` |
+| **बहन** | sister | `BEHEN` |
+| **ताऊ** | father's elder brother | `TAU` |
+| **चाचा** | father's younger brother | `CHACHA` |
+| **पिता के भाई** | father's brother | `FATHERS_BROTHER` |
+| **ताई** | father's elder brother's wife | `TAI` |
+| **चाची** | father's younger brother's wife | `CHACHI` |
+| **पिता के भाई की पत्नी** | father's brother's wife | `FATHERS_BROTHERS_WIFE` |
+| **बुआ** | father's sister | `BUA` |
+| **फूफा** | father's sister's husband | `PHUPHA` |
+| **मामा** | mother's brother | `MAMA` |
+| **मामी** | mother's brother's wife | `MAMI` |
+| **मौसी** | mother's sister | `MAUSI` |
+| **मौसा** | mother's sister's husband | `MAUSA` |
+| **भतीजा** | brother's son | `BHATIJA` |
+| **भतीजी** | brother's daughter | `BHATIJI` |
+| **भांजा** | sister's son | `BHANJA` |
+| **भांजी** | sister's daughter | `BHANJI` |
+| **चचेरा भाई** | father's brother's son | `CHACHERA_BHAI` |
+| **चचेरी बहन** | father's brother's daughter | `CHACHERI_BEHEN` |
+| **फुफेरा भाई** | father's sister's son | `PHUPHERA_BHAI` |
+| **फुफेरी बहन** | father's sister's daughter | `PHUPHERI_BEHEN` |
+| **ममेरा भाई** | mother's brother's son | `MAMERA_BHAI` |
+| **ममेरी बहन** | mother's brother's daughter | `MAMERI_BEHEN` |
+| **मौसेरा भाई** | mother's sister's son | `MAUSERA_BHAI` |
+| **मौसेरी बहन** | mother's sister's daughter | `MAUSERI_BEHEN` |
+| **पति** | husband | `PATI` |
+| **पत्नी** | wife | `PATNI` |
+| **ससुर** | father-in-law | `SASUR` |
+| **सास** | mother-in-law | `SAAS` |
+| **जीजा** | sister's husband | `JIJA` |
+| **भाभी** | brother's wife | `BHABHI` |
+| **बहू** | son's wife | `BAHU` |
+| **दामाद** | daughter's husband | `DAMAD` |
+| **साला** | wife's brother | `SALA` |
+| **साली** | wife's sister | `SALI` |
+| **जेठ** | husband's elder brother | `JETH` |
+| **देवर** | husband's younger brother | `DEVAR` |
+| **पति के भाई** | husband's brother | `HUSBANDS_BROTHER` |
+| **ननद** | husband's sister | `NANAD` |
+| **सौतेला पिता** | stepfather | `SAUTELA_PITA` |
+| **सौतेली माता** | stepmother | `SAUTELI_MATA` |
+| **सौतेला बेटा** | stepson | `SAUTELA_BETA` |
+| **सौतेली बेटी** | stepdaughter | `SAUTELI_BETI` |
+## Checking these
+
+Two suites, both on the JVM:
+
+- `HindiKinshipTest` — every word above, pinned to the family shape it comes from.
+- `HindiEveryPairTest` — every ordered pair of a whole family, asserting that each relationship
+  agrees with its opposite number: **if B is A's मामा, then A must be B's भांजा or भांजी.** The two
+  answers are computed independently from opposite ends of the graph, so a mistake in "which side"
+  or "who links them" makes them disagree. Cousins are the sharpest case — a फुफेरा भाई must see you
+  as his ममेरा भाई, never as another फुफेरा.
+
+Run it against a real exported tree with:
+
+```bash
+./gradlew testDebugUnitTest -Dftree.tree=/path/to/family.ftree
+```
+
+It reports coverage and names any marriage the record states inconsistently — both partners with the
+same recorded gender — which is usually a gender entered wrongly and worth fixing.


### PR DESCRIPTION
> *Kinshuk is Ankit's maternal uncle — in Hindi he's Mama*

**Settings → Family words → हिन्दी.** Verified on the signed release build with the real 148-person
tree:

> **Kinshuk Srivastava is Ankit Srivastava's मामा (mother's brother).**

## This was not a translation job

English has one word where Hindi has five, and choosing between them needs facts the model discarded:

| distinction | needs |
|---|---|
| मामा vs चाचा | which side — mother's brother vs father's |
| चाचा vs ताऊ | birth order — father's younger vs elder brother |
| भतीजा vs भांजा | gender of the **linking sibling**, not of the nephew |
| पोता vs नाती | gender of the **linking child** |
| साला vs देवर | the gender of the person **asking** |

`ParentsSibling(greats = 0)` was *all* of chacha, tau, mama, phupha and mausa collapsed into one
value. A label swap would have confidently printed the wrong word — worse than English, because
"uncle" is merely vague where "चाचा" for a mother's brother is plainly wrong to any Hindi speaker.

## The one idea

Keep the *path*, not just its length. `termFor(up, down)` is **untouched**, so every English answer,
its tests and `site/playground/model.js` still agree; a `KinshipPath` rides alongside carrying the
genders the line ran through and — where the dates prove it — who was born first.

Seniority is claimed only when the record earns it: two brothers both recorded "1962" are UNKNOWN,
not a coin toss.

## Two things worth the tests they get

**A word is claimed only when the record supports it.** No birth years means पिता के भाई
(father's brother) plus a quiet line offering to sharpen it — never a guess between चाचा and ताऊ.

**Every relationship must agree with its opposite number.** If B is A's मामा, A must be B's भांजा or
भांजी — computed independently, from the other end of the graph, through different branches of the
rules. Over every ordered pair that is not satisfiable by accident. Cousins are the sharpest case: a
फुफेरा भाई must see you as his ममेरा भाई, never as another फुफेरा.

Run over Ankit's real tree — **21,756 ordered pairs, zero disagreements.** It also caught a genuine
data error (a marriage recorded with both partners the same gender), which is reported by name
rather than papered over.

## Design decisions

- **The rules return an enum, not a string**, so the part that can be wrong is plain Kotlin under
  JVM test. The spelling lives in `res/values/kinship_hi.xml`, a flat list a Hindi speaker can
  review in one sitting — see [docs/kinship-hindi.md](docs/kinship-hindi.md).
- **The gloss rides along** — "मामा (mother's brother)" — which is how bilingual families speak and
  which teaches the word to a relative who does not know it.
- **Hindi falls back to English** for second cousins and great-uncles, because that is what Hindi
  speakers do; a Devanagari compound nobody says would be worse than the English word.
- **Family words, not app language.** The chrome stays English. Translating ~250 strings is a
  separate job needing a fluent reviewer, and a half-translated app reads worse than an English one.
- **No bundled Devanagari font.** I planned to measure before spending 264 KB; on screen the system
  fallback sits well beside Literata, so it stays unbundled.
- **English is unchanged in this release.** The precision goes where it is load-bearing; enriching
  English with "maternal uncle" is a follow-up, done together with mirroring the path model into the
  web viewer so the two keep giving one answer.

## Verification

- **168 unit tests** (18 Hindi vocabulary cases, plus the every-pair sweep), **119 instrumented**,
  lint clean.
- `KinshipLanguage` is persisted by name, so it joins the enums `proguard-rules.pro` keeps —
  verified on a signed build by setting Hindi, force-stopping and relaunching.
- Both the मामा case and the descriptive fallback confirmed in the **R8-minified release build**
  against the real tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)