### PR TITLE
Version 0.5.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 7
-        versionName = "0.4.0"
+        versionCode = 8
+        versionName = "0.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to **0.5.0** and `versionCode` to 8, so the tag can be cut.

0.5.0 adds the **compact view** — a third way to read the tree, composed rather than drawn, for anyone who would rather not pinch a canvas. See #43.

Version last, so the tag never points at a commit where the feature is still in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)