### PR TITLE
Give the viewer a way in from the chrome

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -39,7 +39,7 @@
     <nav>
       <a class="nav-link" href="#what">What it does</a>
       <a class="nav-link" href="#merge">Sharing</a>
-      <a class="nav-link" href="#viewer">Viewer</a>
+      <a class="nav-link" href="playground/">Viewer</a>
       <a class="nav-link" href="https://github.com/thisisankit27/f-tree">Source</a>
       <a class="nav-cta" href="thanks/">Download</a>
     </nav>
@@ -388,6 +388,7 @@
   <div class="shell">
     <span>f-tree — built by <a href="https://github.com/thisisankit27">thisisankit27</a>. MIT licensed.</span>
     <nav>
+      <a href="playground/">Viewer</a>
       <a href="https://github.com/thisisankit27/f-tree">Source</a>
       <a href="https://github.com/thisisankit27/f-tree/releases">Releases</a>
       <a href="https://github.com/thisisankit27/f-tree/issues">Report a problem</a>

--- a/site/thanks/index.html
+++ b/site/thanks/index.html
@@ -194,6 +194,7 @@
     <span>f-tree — built by <a href="https://github.com/thisisankit27">thisisankit27</a>. MIT licensed.</span>
     <nav>
       <a href="../">Home</a>
+      <a href="../playground/">Viewer</a>
       <a href="https://github.com/thisisankit27/f-tree">Source</a>
       <a href="https://github.com/thisisankit27/f-tree/releases">Releases</a>
     </nav>


### PR DESCRIPTION
The viewer at `/playground/` had exactly **one** route to it: a button halfway down the landing page, inside the section that describes it. Scroll past that section and it does not exist. From the install guide there was no route at all.

- **Header nav: `Viewer` now goes to `playground/`.** It pointed at `#viewer` — a paragraph *about* the viewer. A reasonable anchor on a scroll-through page, but not what a navigation item promises. The section still explains it one scroll away, and still has its own button.
- **Both footers** gain a `Viewer` link.
- **The install guide** gains one too — that is the page somebody lands on from a shared download link, and "there is also a big-screen version" is worth saying there.

Checked locally: every internal link on both pages returns 200, and the viewer still loads and links home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)