### PR TITLE
Make the words under an empty heading the button

### DIFF
--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PersonFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PersonFlowTest.kt
@@ -25,6 +25,8 @@ import com.vibethroughcode.ftree.ui.person.EditSaveTag
 import com.vibethroughcode.ftree.ui.person.PersonDeleteTag
 import com.vibethroughcode.ftree.ui.person.PersonMenuTag
 import com.vibethroughcode.ftree.ui.person.PersonEditTag
+import com.vibethroughcode.ftree.ui.person.emptySectionTag
+import com.vibethroughcode.ftree.data.RelativeKind
 import com.vibethroughcode.ftree.ui.NavPeopleTag
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -201,5 +203,22 @@ class PersonFlowTest {
         // and carries no semantics of its own. The navigation state survives recreation, so the
         // list is still the screen in front of us.
         rule.onNodeWithText("Ankit Kumar").assertIsDisplayed()
+    }
+
+    /**
+     * The words under an empty heading are what a reader taps, because they are the thing shaped
+     * like a sentence about parents. For a while they were inert and only the plus on the rule
+     * worked, which put the next step out of reach on the screen a new person lands on first.
+     */
+    @Test
+    fun theWordsUnderAnEmptyHeadingAreTheButton() {
+        addFirstPerson(name = "Ankit Kumar")
+
+        rule.onNodeWithTag(emptySectionTag(RelativeKind.PARENT)).performScrollTo().performClick()
+
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Add a parent for Ankit Kumar", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -1,13 +1,17 @@
 package com.vibethroughcode.ftree.ui.person
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -310,12 +314,7 @@ private fun RelativeSection(
     )
 
     if (relatives.isEmpty()) {
-        Text(
-            text = stringResource(addRelativeLabel(kind)),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(start = 20.dp, bottom = 4.dp),
-        )
+        EmptySection(kind = kind, onAdd = onAdd)
     } else {
         relatives.forEach { relative ->
             PersonRow(
@@ -330,4 +329,47 @@ private fun RelativeSection(
     }
 }
 
+/**
+ * The row where a relative would be, if one had been recorded.
+ *
+ * It used to be a line of grey helper text reading "Add a parent" — which is what a reader taps,
+ * because it is the thing shaped like a sentence about parents. It did nothing. The only working
+ * control was the small plus at the far end of the rule, which is easy to miss and, on the screen a
+ * new person lands on the moment they have added themselves, is the whole of the next step.
+ *
+ * So the words are the button now. It sits at the height and indent of the rows it stands in for,
+ * with the plus where the face would be, which keeps the section reading as a list that happens to
+ * be empty rather than as a heading with a note under it.
+ */
+@Composable
+private fun EmptySection(kind: RelativeKind, onAdd: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onAdd)
+            .defaultMinSize(minHeight = 56.dp)
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .testTag(emptySectionTag(kind)),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Box(Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+            Icon(
+                imageVector = Icons.Default.Add,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(22.dp),
+            )
+        }
+        Text(
+            text = stringResource(addRelativeLabel(kind)),
+            style = MaterialTheme.typography.titleSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
 fun addSectionTag(kind: RelativeKind): String = "add-relative-" + kind.name.lowercase()
+
+/** The whole-row way into an empty section, as opposed to the plus on its rule. */
+fun emptySectionTag(kind: RelativeKind): String = "empty-section-" + kind.name.lowercase()


### PR DESCRIPTION
## What I observed

On the person screen, an empty section reads:

```
PARENTS ─────────────────────────  +
Add a parent
```

I tapped the words "Add a parent" the way a first-time user would. **Nothing happened.** The text is inert; the only working control is the 24dp plus at the far end of the rule.

Verified in the accessibility tree — the TextView is `clickable=false` with no clickable ancestor.

## Why it is significant

This is the screen somebody lands on **the moment they have added their first person**, and at that point all four sections are empty. The next step in the entire product is a line of text that ignores you, and the thing that works is a small icon at the opposite edge of the screen from the words describing it.

## The change

The row is the button. It sits at the height and indent of the rows it stands in for, with the plus where the face would be — so the section reads as a list that happens to be empty, rather than a heading with a note under it.

The plus on the rule stays: it is the one control whose position holds whether or not a section has anybody in it.

## Trade-off

An empty section now shows two ways in (the row and the rule's plus). I kept both — a stable affordance on every rule is worth more than removing one small icon, and redundancy helps here rather than hurting.

## Verification

11 instrumented person-flow tests pass, including a new one asserting the words themselves open "Add a parent for …". Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)