### PR TITLE
Let the delete dialog read in the order it is decided

### DIFF
--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/DeletePersonDialog.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/DeletePersonDialog.kt
@@ -1,9 +1,12 @@
 package com.vibethroughcode.ftree.ui.person
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -14,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.DeletionMode
+import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 
 const val DeleteKeepAsUnknownTag = "delete-keep-as-unknown"
 const val DeleteCompletelyTag = "delete-completely"
@@ -42,20 +46,21 @@ fun DeletePersonDialog(
             )
         },
         text = {
-            Text(
-                if (connected) {
-                    stringResource(
-                        R.string.delete_body_connected,
-                        name?.takeIf { it.isNotBlank() } ?: stringResource(R.string.person_unknown),
-                        relationshipCount,
-                    )
-                } else {
-                    stringResource(R.string.delete_body_isolated)
-                }
-            )
-        },
-        confirmButton = {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = if (connected) {
+                        stringResource(
+                            R.string.delete_body_connected,
+                            name?.takeIf { it.isNotBlank() } ?: stringResource(R.string.person_unknown),
+                            relationshipCount,
+                        )
+                    } else {
+                        stringResource(R.string.delete_body_isolated)
+                    },
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+
                 if (connected) {
                     DeleteChoice(
                         label = stringResource(R.string.delete_keep_shape),
@@ -63,6 +68,7 @@ fun DeletePersonDialog(
                         tag = DeleteKeepAsUnknownTag,
                         onClick = { onConfirm(DeletionMode.KEEP_AS_UNKNOWN) },
                     )
+                    HorizontalDivider(color = FTreeTheme.accents.rule)
                 }
                 DeleteChoice(
                     label = stringResource(R.string.delete_remove),
@@ -77,12 +83,24 @@ fun DeletePersonDialog(
                 )
             }
         },
+        // Nothing goes in the confirm slot. The two choices are the answer to the question and
+        // belong under it, in the order they are read; leaving one of them here would put it
+        // beside Cancel as though it were the expected outcome.
+        confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) { Text(stringResource(R.string.delete_cancel)) }
         },
     )
 }
 
+/**
+ * One answer to "what happens to their connections", as a row rather than a button.
+ *
+ * Full width and divided from its neighbour, because these are two branches of one decision and a
+ * pair of pill buttons would make the destructive one look like the ordinary one. The consequence
+ * is printed under the label rather than left to the title, since that is the part somebody needs
+ * before choosing and not after.
+ */
 @Composable
 private fun DeleteChoice(
     label: String,
@@ -91,19 +109,24 @@ private fun DeleteChoice(
     onClick: () -> Unit,
     destructive: Boolean = false,
 ) {
-    TextButton(onClick = onClick, modifier = Modifier.testTag(tag)) {
-        Column(modifier = Modifier.padding(vertical = 4.dp)) {
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelLarge,
-                color = if (destructive) MaterialTheme.colorScheme.error
-                else MaterialTheme.colorScheme.primary,
-            )
-            Text(
-                text = detail,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-        }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp)
+            .testTag(tag),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.titleSmall,
+            color = if (destructive) MaterialTheme.colorScheme.error
+            else MaterialTheme.colorScheme.primary,
+        )
+        Text(
+            text = detail,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }


### PR DESCRIPTION
## What I observed

Deleting a connected person produced this:

```
Delete Meena?
Meena is connected to 3 other people…

  Keep as unknown
  Clears their details but keeps their place…
                                    Cancel
  Delete completely
  Removes them and their 3 connections…
```

**"Cancel" sits between the two choices.** Both real options were in the dialog's `confirmButton` slot, which Material lays out in a row alongside `dismissButton` — so the tall Column of choices went one side and Cancel the other, landing visually in the middle.

The effect: the two actual decisions read as body copy, and the only thing shaped like a button is the one that does nothing.

## Why it is significant

This is the most destructive action in the app, on a product whose promise is that it can be trusted with a family's history. The copy is excellent — it asks what happens to somebody's *connections* rather than whether you are sure, and it counts them. The layout was undoing that work.

## The change

Choices move into the dialog body, under the explanation, in reading order — full width, divided from each other, the destructive one in the error colour. Cancel is alone in the dismiss slot at the foot.

**No wording changed.** Labels move from the default sans `labelLarge` to the app's serif `titleSmall`, which is the voice the rest of the app uses for a choice about a person.

## Trade-off

The choices are no longer `TextButton`s, so they lose the pill ripple. That is the point: two pills would make the destructive branch look like the ordinary one. They keep full-width click targets and their test tags.

## Verification

20 instrumented tests across the person and relationship flows pass, including the existing delete-completely and keep-as-unknown cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)