### PR TITLE
Stop a chart being dragged off its own page

### DIFF
--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartViewport.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartViewport.kt
@@ -1,0 +1,60 @@
+package com.vibethroughcode.ftree.ui.tree
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+
+/**
+ * How much of a chart a drag must leave on screen.
+ *
+ * Roughly a card and a half: enough to see what you are holding on to and to drag back by, without
+ * making the edge of a large family feel fenced in.
+ */
+internal val KEEP_ON_SCREEN = 96.dp
+
+/**
+ * Keeps a chart from being dragged off its own page.
+ *
+ * Both charts are a canvas the size of the family, panned by a finger with nothing to stop it. Six
+ * ordinary swipes on a phone is enough to push a thirteen-person tree entirely out of the viewport,
+ * and what is left is a blank sheet under a heading that still says thirteen people — with no
+ * control anywhere that brings it back. Leaving the screen and returning re-frames it, but nothing
+ * says so, and "the family I have been keeping is gone" is the worst sentence this app could put in
+ * somebody's head.
+ *
+ * So a strip of the chart is always held on screen. It is a clamp rather than a bounce because a
+ * chart is a document being read, not a list being flung: it should stop where it stops, and the
+ * edge should feel like the edge of the paper.
+ *
+ * [keep] is how much of the chart must remain, in pixels. Where a chart is smaller than that in an
+ * axis the whole of it is held instead, so a lone person cannot be pushed off either.
+ */
+internal fun clampPan(
+    pan: Offset,
+    contentWidth: Float,
+    contentHeight: Float,
+    viewport: IntSize,
+    keep: Float,
+): Offset {
+    if (viewport.width == 0 || viewport.height == 0) return pan
+    return Offset(
+        x = clampAxis(pan.x, contentWidth, viewport.width, keep),
+        y = clampAxis(pan.y, contentHeight, viewport.height, keep),
+    )
+}
+
+/**
+ * The range a single axis may be panned through.
+ *
+ * The chart occupies `[offset, offset + content]` in screen space. Requiring that span to overlap
+ * `[0, viewport]` by at least [keep] gives both ends directly: the chart's trailing edge cannot come
+ * in past [keep], and its leading edge cannot go out past the same distance from the far side.
+ */
+private fun clampAxis(offset: Float, content: Float, viewport: Int, keep: Float): Float {
+    val visible = minOf(keep, content)
+    val min = visible - content
+    val max = viewport - visible
+    // A chart far larger than the viewport gives min < max; a tiny one can invert the range, and
+    // then the only sensible answer is the one position that satisfies both ends.
+    return if (min <= max) offset.coerceIn(min, max) else (min + max) / 2f
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -56,6 +56,8 @@ fun FamilyChart(
     modifier: Modifier = Modifier,
     /** The face cache, or null when the reader has turned photographs off. */
     photos: ChartPhotos? = null,
+    /** Bumped to re-frame the chart on the family, after the reader has panned away from it. */
+    frameSignal: Int = 0,
 ) {
     // Text painted onto a canvas is invisible to a screen reader, and giving every node its own
     // semantics would mean composing one per person on every pan. The chart therefore describes
@@ -81,7 +83,7 @@ fun FamilyChart(
     // A family that fits is shown whole, because seeing the shape of it is the point. Only when it
     // does not fit does the view fall back to centring the focused person, who is then the thing
     // you are most likely to be looking for.
-    LaunchedEffect(layout.focusId, layout.nodes.size, viewport) {
+    LaunchedEffect(layout.focusId, layout.nodes.size, viewport, frameSignal) {
         if (viewport == IntSize.Zero || layout.isEmpty) return@LaunchedEffect
         with(density) {
             val chartWidth = layout.width.dp.toPx()
@@ -112,6 +114,7 @@ fun FamilyChart(
     val rulePx = with(density) { 1.5.dp.toPx() }
     val spouseGapPx = with(density) { 2.dp.toPx() }
     val unitPx = with(density) { 1.dp.toPx() }
+    val keepOnScreenPx = with(density) { KEEP_ON_SCREEN.toPx() }
 
     /*
      * Which faces to decode: the ones on screen, and only those.
@@ -149,8 +152,14 @@ fun FamilyChart(
                     // Scale about the pinch centre, so the chart grows around what the fingers
                     // are on rather than around the corner of the screen.
                     val factor = next / zoom
-                    pan = (pan - centroid) * factor + centroid + panChange
                     zoom = next
+                    pan = clampPan(
+                        pan = (pan - centroid) * factor + centroid + panChange,
+                        contentWidth = layout.width * unitPx * next,
+                        contentHeight = layout.height * unitPx * next,
+                        viewport = viewport,
+                        keep = keepOnScreenPx,
+                    )
                 }
             }
             .pointerInput(layout) {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CenterFocusStrong
 import androidx.compose.material.icons.filled.CompareArrows
+import androidx.compose.material.icons.filled.FitScreen
 import androidx.compose.material.icons.filled.PersonAddAlt
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AssistChip
@@ -41,6 +42,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -76,6 +78,7 @@ const val TreeModeWholeTag = "tree-mode-whole"
 const val TreeRelateTag = "tree-relate"
 const val TreeRelateFromTag = "tree-relate-from"
 const val TreeClearTraceTag = "tree-clear-trace"
+const val TreeFrameTag = "tree-frame"
 
 /**
  * Which view of the tree is on screen.
@@ -112,6 +115,9 @@ private val ChartMode.tag: String
 /** True for the two views centred on one person, which share a focus and a loaded neighbourhood. */
 private val ChartMode.isAroundOnePerson: Boolean get() = this != ChartMode.WHOLE
 
+/** True for the two painted on a canvas, which are the two that can be panned away from. */
+private val ChartMode.isDrawn: Boolean get() = this != ChartMode.COMPACT
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TreeScreen(
@@ -139,6 +145,14 @@ fun TreeScreen(
         mutableStateOf(if (startWhole) ChartMode.WHOLE else ChartMode.FOCUSED)
     }
     var selected by remember { mutableStateOf<Person?>(null) }
+    /*
+     * Bumped to put a chart back on its family.
+     *
+     * Panning is now clamped so the chart can never be lost entirely, but a reader who has zoomed
+     * into one corner of a large record still has a long way back. Re-framing is one tap, and it is
+     * the same framing the chart opens with rather than a second idea of where "home" is.
+     */
+    var frameSignal by remember { mutableIntStateOf(0) }
     val sheetState = rememberModalBottomSheetState()
 
     /*
@@ -193,8 +207,10 @@ fun TreeScreen(
                                 ChartActions(
                                     showRelate = true,
                                     showMore = mode.isAroundOnePerson && state.layout.truncated,
+                                    showFrame = mode.isDrawn,
                                     onRelate = { onRelate(null) },
                                     onMore = viewModel::showMoreGenerations,
+                                    onFrame = { frameSignal++ },
                                 )
                             }
                         },
@@ -213,8 +229,10 @@ fun TreeScreen(
                             ChartActions(
                                 showRelate = true,
                                 showMore = mode.isAroundOnePerson && state.layout.truncated,
+                                showFrame = mode.isDrawn,
                                 onRelate = { onRelate(null) },
                                 onMore = viewModel::showMoreGenerations,
+                                onFrame = { frameSignal++ },
                             )
                         }),
                     )
@@ -263,6 +281,7 @@ fun TreeScreen(
                         layout = state.layout,
                         onSelect = { selected = it },
                         photos = photos,
+                        frameSignal = frameSignal,
                     )
                 }
 
@@ -278,6 +297,7 @@ fun TreeScreen(
                         highlighted = if (tracing.isNotEmpty()) emptySet() else highlighted,
                         tracing = tracing.isNotEmpty(),
                         photos = photos,
+                        frameSignal = frameSignal,
                         onSelect = {
                             wholeTreeViewModel.select(it)
                             selected = it
@@ -422,9 +442,19 @@ private fun ChartModeBar(
 private fun ChartActions(
     showRelate: Boolean,
     showMore: Boolean,
+    showFrame: Boolean,
     onRelate: () -> Unit,
     onMore: () -> Unit,
+    onFrame: () -> Unit,
 ) {
+    if (showFrame) {
+        IconButton(onClick = onFrame, modifier = Modifier.testTag(TreeFrameTag)) {
+            Icon(
+                Icons.Default.FitScreen,
+                contentDescription = stringResource(R.string.tree_recentre),
+            )
+        }
+    }
     if (showRelate) {
         IconButton(onClick = onRelate, modifier = Modifier.testTag(TreeRelateTag)) {
             Icon(

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -70,6 +70,8 @@ fun WholeFamilyChart(
     tracing: Boolean = false,
     /** The face cache, or null when the reader has turned photographs off. */
     photos: ChartPhotos? = null,
+    /** Bumped to re-frame the chart on the family, after the reader has panned away from it. */
+    frameSignal: Int = 0,
 ) {
     val description = if (tracing) {
         stringResource(R.string.a11y_traced_chart, layout.nodes.size)
@@ -102,7 +104,7 @@ fun WholeFamilyChart(
      * a card would be too small to carry a name it stops being a chart and becomes a texture, so
      * beyond that the view opens at a readable scale on the largest family instead.
      */
-    LaunchedEffect(layout, viewport) {
+    LaunchedEffect(layout, viewport, frameSignal) {
         if (viewport == IntSize.Zero || layout.isEmpty) return@LaunchedEffect
         with(density) {
             val chartWidth = layout.width.dp.toPx()
@@ -144,6 +146,7 @@ fun WholeFamilyChart(
     val rulePx = with(density) { 1.5.dp.toPx() }
     val spouseGapPx = with(density) { 2.dp.toPx() }
     val unitPx = with(density) { 1.dp.toPx() }
+    val keepOnScreenPx = with(density) { KEEP_ON_SCREEN.toPx() }
 
     /*
      * Which faces to decode: the ones on screen, and only when the chart is close enough in for a
@@ -179,8 +182,14 @@ fun WholeFamilyChart(
                 detectTransformGestures { centroid, panChange, zoomChange, _ ->
                     val next = (zoom * zoomChange).coerceIn(MIN_ZOOM, MAX_ZOOM)
                     val factor = next / zoom
-                    pan = (pan - centroid) * factor + centroid + panChange
                     zoom = next
+                    pan = clampPan(
+                        pan = (pan - centroid) * factor + centroid + panChange,
+                        contentWidth = layout.width * unitPx * next,
+                        contentHeight = layout.height * unitPx * next,
+                        viewport = viewport,
+                        keep = keepOnScreenPx,
+                    )
                 }
             }
             .pointerInput(layout) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -234,7 +234,7 @@
     <string name="compact_actions_for">What you can do with %1$s</string>
     <string name="a11y_compact_person">%1$s, %2$s</string>
     <string name="tree_focused_on">Centred on %1$s</string>
-    <string name="tree_recentre">Recentre</string>
+    <string name="tree_recentre">Recentre the chart</string>
 
     <!-- The whole-tree chart -->
     <string name="whole_group_family">%1$d people · %2$d generations</string>

--- a/app/src/test/java/com/vibethroughcode/ftree/ui/tree/ChartViewportTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/ui/tree/ChartViewportTest.kt
@@ -1,0 +1,55 @@
+package com.vibethroughcode.ftree.ui.tree
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.IntSize
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** The rule that stops a chart being dragged off its own page. */
+class ChartViewportTest {
+
+    private val viewport = IntSize(1080, 2000)
+    private val keep = 200f
+
+    private fun clamp(x: Float, y: Float, w: Float = 4000f, h: Float = 6000f) =
+        clampPan(Offset(x, y), w, h, viewport, keep)
+
+    @Test
+    fun `a pan that keeps the chart on screen is left alone`() {
+        assertEquals(Offset(-500f, -900f), clamp(-500f, -900f))
+    }
+
+    @Test
+    fun `dragging the chart off to the left stops with a strip of it showing`() {
+        val panned = clamp(-9999f, 0f)
+        assertEquals(keep, panned.x + 4000f, 0.01f)
+    }
+
+    @Test
+    fun `dragging the chart off to the right stops with a strip of it showing`() {
+        val panned = clamp(9999f, 0f)
+        assertEquals(viewport.width - keep, panned.x, 0.01f)
+    }
+
+    @Test
+    fun `it holds vertically on the same rule`() {
+        assertEquals(keep, clamp(0f, -9999f).y + 6000f, 0.01f)
+        assertEquals(viewport.height - keep, clamp(0f, 9999f).y, 0.01f)
+    }
+
+    @Test
+    fun `a chart smaller than the strip is held whole rather than by part of itself`() {
+        val panned = clamp(-9999f, -9999f, w = 160f, h = 60f)
+        assertTrue(panned.x + 160f >= 0f)
+        assertTrue(panned.y + 60f >= 0f)
+        assertTrue(panned.x <= viewport.width)
+        assertTrue(panned.y <= viewport.height)
+    }
+
+    @Test
+    fun `it does nothing before the viewport has been measured`() {
+        val pan = Offset(-9999f, -9999f)
+        assertEquals(pan, clampPan(pan, 4000f, 6000f, IntSize.Zero, keep))
+    }
+}


### PR DESCRIPTION
## What I observed

On the **Everyone** view I swiped six times the way a thumb explores. The result:

> A completely blank page, under a heading still reading **"13 people · 1 family · 2 without a name"**.

No fit control, no recentre, no bounds. The same is true of the **Chart** view. Leaving the tab and returning silently re-frames it — but nothing tells you that, and while you are on the screen there is no way out.

## Why it is significant

This is a product whose entire promise is that a family's record is safe in it. A blank page where the family was is the worst thing it can show, and the reader has no way to tell that it is their scroll position rather than their data. It costs trust out of all proportion to the bug.

## The change

**1. A strip of the chart is always held on screen** (96dp — about a card and a half).

A clamp, not a bounce: a chart is a document being read, not a list being flung, so it should stop where it stops and the edge should feel like the edge of the paper. A chart smaller than the strip is held whole, so a lone person cannot be pushed off either.

The arithmetic is a pure function in `ChartViewport.kt` with its own JVM tests, since that is the part that can be quietly wrong.

**2. One control that puts a chart back on its family.**

Clamping keeps a chart findable; it does not make a large one quick to return to, and the Everyone view cannot fit most real trees on open (by design — it prefers legible cards to a grey wash). So the app bar gains a recentre action that re-runs the framing the chart opens with — not a second idea of where "home" is.

Shown only on the two canvas views. The compact view scrolls and cannot be lost. It reuses `tree_recentre`, a string that was already in the project and unused.

## Trade-offs

- Panning a very large chart now stops at the edges instead of continuing into space. That is the intent, and it matches how every map and document viewer behaves.
- One more icon in the app bar. It earns its place: without it the view named "Everyone" has no way to ever show everyone.

## Verification

180 unit tests (6 new for the clamp), 128 instrumented, lint clean. Verified on device: eight hard swipes now leave the chart's corner on screen, and recentre restores the opening frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)