### PR TITLE
Let a compact card hold its words, and inset the relation rule

### DIFF
--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
@@ -100,7 +100,17 @@ object TreeMetrics {
      * full, remains the readable route through a large family.
      */
     fun nodeSizeFor(textScale: Float): Pair<Float, Float> {
-        val eased = 1f + (textScale.coerceIn(1f, 2f) - 1f) * 0.7f
+        val eased = cardScaleFor(textScale)
         return NODE_WIDTH * eased to NODE_HEIGHT * eased
     }
+
+    /**
+     * How much a card grows at the reader's text size, as a multiplier.
+     *
+     * Shared with the compact view so the two ways of showing a person agree about how much room a
+     * larger word needs. Tempered rather than full scale for the reason above: a chart is a spatial
+     * overview, and a card that doubles leaves almost nothing on screen.
+     */
+    fun cardScaleFor(textScale: Float): Float =
+        1f + (textScale.coerceIn(1f, 2f) - 1f) * 0.7f
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
@@ -212,9 +212,12 @@ private fun Answer(
 
         if (state.chain.isNotEmpty() && state.from != null) {
             item {
-                Column(Modifier.padding(top = 8.dp)) {
-                    SectionRule(stringResource(R.string.relation_chain_title))
-                }
+                // Inset to the measure everything else on this screen keeps. The rule ran to the
+                // screen edge while the cards above it stood twenty dp in, which read as a seam.
+                SectionRule(
+                    label = stringResource(R.string.relation_chain_title),
+                    modifier = Modifier.padding(top = 8.dp, start = 20.dp, end = 20.dp),
+                )
             }
             item {
                 PersonRow(

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/CompactFamilyView.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/CompactFamilyView.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -60,6 +61,7 @@ import com.vibethroughcode.ftree.data.RelativeKind
 import com.vibethroughcode.ftree.graph.CompactBand
 import com.vibethroughcode.ftree.graph.CompactFamily
 import com.vibethroughcode.ftree.graph.CompactMember
+import com.vibethroughcode.ftree.graph.TreeMetrics
 import com.vibethroughcode.ftree.ui.common.PersonAvatar
 import com.vibethroughcode.ftree.ui.common.addRelativeLabel
 import com.vibethroughcode.ftree.ui.common.displayName
@@ -474,6 +476,13 @@ private fun PersonCard(
     val accents = FTreeTheme.accents
     val years = person.lifespanLabel(stringResource(R.string.person_late))
     val spoken = spokenName(person)
+    /*
+     * A card is a fixed width, so at a large text size the words have nowhere to go: at 1.6x a
+     * lifespan came out as "1905-197", which is not a clipped label but a wrong date. The card grows
+     * with the reader's setting on the same curve the chart's cards use, so the two agree about how
+     * much room a larger word needs.
+     */
+    val grown = TreeMetrics.cardScaleFor(LocalDensity.current.fontScale)
 
     val frame = Modifier
         .clip(RoundedCornerShape(16.dp))
@@ -509,13 +518,16 @@ private fun PersonCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = align,
                 maxLines = 1,
+                // Ellipsis rather than the default clip: a year cut short still reads as a year,
+                // and "1905-197" is a date this family never had.
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }
 
     if (short) {
         Row(
-            modifier = frame.width(180.dp).fillMaxHeight().padding(horizontal = 10.dp, vertical = 8.dp),
+            modifier = frame.width(180.dp * grown).fillMaxHeight().padding(horizontal = 10.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
@@ -528,7 +540,7 @@ private fun PersonCard(
     } else {
         Column(
             modifier = frame
-                .width(104.dp)
+                .width(104.dp * grown)
                 .fillMaxHeight()
                 .padding(horizontal = 8.dp, vertical = 10.dp),
             horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
Two things found by turning the text size up and looking closely.

## 1. A compact card clipped data at large text sizes

At **1.6× text** the compact view rendered:

- `Unkno` / `wn` — the app's own word for an unrecorded person, broken across two lines mid-word
- `1905–197` — **a lifespan silently truncated into a different, plausible-looking date**

The card is a fixed 104dp regardless of text scale, so the words had nowhere to go.

**Why it matters more than it looks:** the compact view exists so that somebody who cannot read a pinch-and-zoom canvas still can. Breaking it at exactly the setting those readers use defeats the point — and a truncated year that still *looks* like a year is a data-integrity illusion in an app about records.

**The change:** the card grows on the same curve the chart's cards already use (`TreeMetrics.cardScaleFor`, extracted from the existing `nodeSizeFor` so there is one rule, not two). The lifespan also ellipsises instead of clipping, so if it ever does run out of room the reader can see that it did.

## 2. The relation screen had one rule out of measure

"THE LINE BETWEEN THEM" ran to the screen edge while the cards above it and the button below stood 20dp in — a seam across an otherwise calm page. The same `SectionRule` is already inset on the person screen; this call site just never passed the padding.

## Trade-off

At a large text size a compact band shows fewer people per row. That is the correct trade: the view's job is to be readable, and the row scrolls.

## Verification

180 unit tests, 128 instrumented, lint clean. Checked on device at 1.0× and 1.6×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)