### PR TITLE
Version 0.5.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 8
-        versionName = "0.5.0"
+        versionCode = 9
+        versionName = "0.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to **0.5.1** and `versionCode` to 9, so the tag can be cut.

0.5.1 is repair work found by using the app rather than reading it — see #46, #47, #48, #49. A patch release rather than a minor one: three of the four are fixes, and the one control it adds (recentre) exists because a chart could otherwise be dragged off the page with no way back.

Version last, so the tag never points at a commit where the fixes are still in review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)