### PR TITLE
Keep the middle of the screen over the chart, not just its outline

### DIFF
--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartViewport.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartViewport.kt
@@ -2,15 +2,6 @@ package com.vibethroughcode.ftree.ui.tree
 
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.dp
-
-/**
- * How much of a chart a drag must leave on screen.
- *
- * Roughly a card and a half: enough to see what you are holding on to and to drag back by, without
- * making the edge of a large family feel fenced in.
- */
-internal val KEEP_ON_SCREEN = 96.dp
 
 /**
  * Keeps a chart from being dragged off its own page.
@@ -22,39 +13,37 @@ internal val KEEP_ON_SCREEN = 96.dp
  * says so, and "the family I have been keeping is gone" is the worst sentence this app could put in
  * somebody's head.
  *
- * So a strip of the chart is always held on screen. It is a clamp rather than a bounce because a
- * chart is a document being read, not a list being flung: it should stop where it stops, and the
- * edge should feel like the edge of the paper.
+ * The rule is that **the middle of the screen stays over the chart**. Holding the chart's outline
+ * on screen is not enough: a family tree is a sparse drawing inside a rectangle, so its bottom-right
+ * corner is usually empty paper, and a clamp that only kept the rectangle honest still allowed a
+ * blank screen — which is how this was first written, and what measuring the pixels caught.
  *
- * [keep] is how much of the chart must remain, in pixels. Where a chart is smaller than that in an
- * axis the whole of it is held instead, so a lone person cannot be pushed off either.
+ * Keeping the centre inside the drawing is a real guarantee instead. The outermost cards are what
+ * define the edges of it, so wherever the centre lands, one of them is within half a screen and
+ * therefore in view. It is also the rule a map uses, and it reads the same way: the paper can be
+ * pushed until its edge reaches the middle, and no further.
  */
 internal fun clampPan(
     pan: Offset,
     contentWidth: Float,
     contentHeight: Float,
     viewport: IntSize,
-    keep: Float,
 ): Offset {
     if (viewport.width == 0 || viewport.height == 0) return pan
     return Offset(
-        x = clampAxis(pan.x, contentWidth, viewport.width, keep),
-        y = clampAxis(pan.y, contentHeight, viewport.height, keep),
+        x = clampAxis(pan.x, contentWidth, viewport.width),
+        y = clampAxis(pan.y, contentHeight, viewport.height),
     )
 }
 
 /**
  * The range a single axis may be panned through.
  *
- * The chart occupies `[offset, offset + content]` in screen space. Requiring that span to overlap
- * `[0, viewport]` by at least [keep] gives both ends directly: the chart's trailing edge cannot come
- * in past [keep], and its leading edge cannot go out past the same distance from the far side.
+ * The chart occupies `[offset, offset + content]` in screen space, so the point under the middle of
+ * the screen is `viewport / 2 - offset` in the chart's own coordinates. Requiring that to stay
+ * within `[0, content]` gives both ends at once.
  */
-private fun clampAxis(offset: Float, content: Float, viewport: Int, keep: Float): Float {
-    val visible = minOf(keep, content)
-    val min = visible - content
-    val max = viewport - visible
-    // A chart far larger than the viewport gives min < max; a tiny one can invert the range, and
-    // then the only sensible answer is the one position that satisfies both ends.
-    return if (min <= max) offset.coerceIn(min, max) else (min + max) / 2f
+private fun clampAxis(offset: Float, content: Float, viewport: Int): Float {
+    val middle = viewport / 2f
+    return offset.coerceIn(middle - content, middle)
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -114,7 +114,6 @@ fun FamilyChart(
     val rulePx = with(density) { 1.5.dp.toPx() }
     val spouseGapPx = with(density) { 2.dp.toPx() }
     val unitPx = with(density) { 1.dp.toPx() }
-    val keepOnScreenPx = with(density) { KEEP_ON_SCREEN.toPx() }
 
     /*
      * Which faces to decode: the ones on screen, and only those.
@@ -158,7 +157,6 @@ fun FamilyChart(
                         contentWidth = layout.width * unitPx * next,
                         contentHeight = layout.height * unitPx * next,
                         viewport = viewport,
-                        keep = keepOnScreenPx,
                     )
                 }
             }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -146,7 +146,6 @@ fun WholeFamilyChart(
     val rulePx = with(density) { 1.5.dp.toPx() }
     val spouseGapPx = with(density) { 2.dp.toPx() }
     val unitPx = with(density) { 1.dp.toPx() }
-    val keepOnScreenPx = with(density) { KEEP_ON_SCREEN.toPx() }
 
     /*
      * Which faces to decode: the ones on screen, and only when the chart is close enough in for a
@@ -188,7 +187,6 @@ fun WholeFamilyChart(
                         contentWidth = layout.width * unitPx * next,
                         contentHeight = layout.height * unitPx * next,
                         viewport = viewport,
-                        keep = keepOnScreenPx,
                     )
                 }
             }

--- a/app/src/test/java/com/vibethroughcode/ftree/ui/tree/ChartViewportTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/ui/tree/ChartViewportTest.kt
@@ -6,50 +6,69 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
-/** The rule that stops a chart being dragged off its own page. */
+/**
+ * The rule that stops a chart being dragged off its own page: the middle of the screen stays over
+ * the chart.
+ */
 class ChartViewportTest {
 
     private val viewport = IntSize(1080, 2000)
-    private val keep = 200f
+    private val midX = 540f
+    private val midY = 1000f
 
     private fun clamp(x: Float, y: Float, w: Float = 4000f, h: Float = 6000f) =
-        clampPan(Offset(x, y), w, h, viewport, keep)
+        clampPan(Offset(x, y), w, h, viewport)
+
+    /** Where the middle of the screen falls, in the chart's own coordinates. */
+    private fun centreOver(pan: Offset, viewport: IntSize = this.viewport) =
+        Offset(viewport.width / 2f - pan.x, viewport.height / 2f - pan.y)
 
     @Test
-    fun `a pan that keeps the chart on screen is left alone`() {
+    fun `a pan that keeps the middle over the chart is left alone`() {
         assertEquals(Offset(-500f, -900f), clamp(-500f, -900f))
     }
 
     @Test
-    fun `dragging the chart off to the left stops with a strip of it showing`() {
-        val panned = clamp(-9999f, 0f)
-        assertEquals(keep, panned.x + 4000f, 0.01f)
+    fun `dragging the chart away to the left stops when its far edge reaches the middle`() {
+        val panned = clamp(-99999f, 0f)
+        assertEquals(4000f, centreOver(panned).x, 0.01f)
     }
 
     @Test
-    fun `dragging the chart off to the right stops with a strip of it showing`() {
-        val panned = clamp(9999f, 0f)
-        assertEquals(viewport.width - keep, panned.x, 0.01f)
+    fun `dragging it the other way stops when its near edge reaches the middle`() {
+        val panned = clamp(99999f, 0f)
+        assertEquals(0f, centreOver(panned).x, 0.01f)
     }
 
     @Test
     fun `it holds vertically on the same rule`() {
-        assertEquals(keep, clamp(0f, -9999f).y + 6000f, 0.01f)
-        assertEquals(viewport.height - keep, clamp(0f, 9999f).y, 0.01f)
+        assertEquals(6000f, centreOver(clamp(0f, -99999f)).y, 0.01f)
+        assertEquals(0f, centreOver(clamp(0f, 99999f)).y, 0.01f)
     }
 
     @Test
-    fun `a chart smaller than the strip is held whole rather than by part of itself`() {
-        val panned = clamp(-9999f, -9999f, w = 160f, h = 60f)
-        assertTrue(panned.x + 160f >= 0f)
-        assertTrue(panned.y + 60f >= 0f)
-        assertTrue(panned.x <= viewport.width)
-        assertTrue(panned.y <= viewport.height)
+    fun `the middle stays over the chart however hard it is thrown`() {
+        for (x in listOf(-99999f, -4000f, 0f, 4000f, 99999f)) {
+            for (y in listOf(-99999f, -6000f, 0f, 6000f, 99999f)) {
+                val c = centreOver(clamp(x, y))
+                assertTrue("x=$x y=$y gave $c", c.x in 0f..4000f && c.y in 0f..6000f)
+            }
+        }
+    }
+
+    @Test
+    fun `a lone person cannot be pushed off either`() {
+        // 160 x 60 layout units at roughly 2.6px each.
+        val w = 420f
+        val h = 157f
+        val panned = clampPan(Offset(-99999f, -99999f), w, h, viewport)
+        val c = centreOver(panned)
+        assertTrue(c.x in 0f..w && c.y in 0f..h)
     }
 
     @Test
     fun `it does nothing before the viewport has been measured`() {
-        val pan = Offset(-9999f, -9999f)
-        assertEquals(pan, clampPan(pan, 4000f, 6000f, IntSize.Zero, keep))
+        val pan = Offset(-99999f, -99999f)
+        assertEquals(pan, clampPan(pan, 4000f, 6000f, IntSize.Zero))
     }
 }


### PR DESCRIPTION
A follow-up to #48, found while exercising the release build before tagging.

## What was wrong with the fix

#48 clamped panning so the chart's **bounding box** stayed on screen. That is not the promise it made. A family tree is a sparse drawing inside a rectangle, so the corner of that rectangle is usually empty paper — the clamp dutifully held the outline just off the edge of the viewport and the screen was still blank.

I only caught it by **counting non-background pixels** in the canvas region instead of looking at the screenshot. "Nearly blank" and "blank" look identical at a glance, and only one of them is the bug:

```
old clamp, 8 swipes  (release):      0   ← still the original defect
new clamp, 10 swipes one way  :  5,034
new clamp, 10 swipes the other: 11,198
```

## The rule now

**The middle of the screen stays over the chart.**

The outermost cards define the edges of the drawing, so wherever the centre lands, one of them is within half a screen and therefore in view. That is a real guarantee rather than a proxy for one.

It is also the rule a map uses, and it reads the same way: the paper can be pushed until its edge reaches the middle, and no further.

Simpler code, too — the `keep` distance and its constant are gone, since the viewport's own half-width is the distance that matters.

## Verification

180 unit tests (the clamp suite rewritten against the new rule, including a sweep asserting the centre stays inside the drawing for every extreme throw), 129 instrumented, lint clean. Re-checked on a signed release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)