### PR TITLE
Send one person's family, rather than the whole archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ replacing it**.
   it over the running copy, so a new version keeps your tree instead of costing an export and an
   import.
 - **Export and import as a single `.ftree` file**, with merge semantics that never overwrite.
+- **Share one person's family.** Tap somebody and send their household — their partner, their
+  children, and everyone below them — as a small `.ftree` over WhatsApp or anything else. The people
+  *above* them stay behind. The recipient imports it and it merges into their own tree, which is
+  also how you graft a relative's branch onto yours: import it, then marry the two families together
+  with one relationship.
 - **Faces on the chart.** Every card carries a portrait, framed in a circle when the photograph was
   added and a coloured initial when it was not. Photographs can be switched off for a very large
   tree without a single card moving.
@@ -328,6 +333,56 @@ they equal their defaults, because they are how a reader knows what it is holdin
 `sourceTreeId` identifies the installation that wrote the file. With a person's id it forms a stable
 identity across exports; each person also carries the `origins` they were imported with, so a tree
 that has already been merged once still matches exactly on a later import.
+
+## Sharing one branch
+
+Export writes the whole archive, because it is the user's archive and they are keeping it. Sharing
+is a different act with a different shape: it is a message, it goes to somebody who may not have the
+app, and it should carry a part of the family rather than all of it.
+
+**What travels is a household and the households under it** — the person, everyone descended from
+them, and the partners of all of them. Sandeep's share is Sandeep, his wife, his children and their
+partners, and so on down. What stays behind is everything *above* and *beside* him: his parents, his
+siblings, their children. Sending somebody a branch should not quietly hand over the rest of the
+sharer's family, and a recipient starting their own tree from a relative's file wants the people
+below that relative, not the archive they came from.
+
+Partners come along at every level, because a couple is how a family is read and a child arriving
+without the parent they married is a hole in the story. Their *parents* do not: they are the doorway
+back into another whole family, which is exactly what this is not.
+
+A relationship travels only when **both** ends do. A shared branch therefore never carries an edge
+pointing at somebody who is not in the file — the reader could not resolve it, and it would leak the
+existence of a person deliberately left behind.
+
+The rule is [`FamilyGraph.branchFrom`](app/src/main/java/com/vibethroughcode/ftree/graph/FamilyGraph.kt),
+which is an ordinary function over adjacency lookups and is tested as one.
+
+### The file, and the message with it
+
+The whole-tree export asks where to put the file. A share does not: nobody wants to name a message.
+It is written to the cache as `Sandeep-Kumar-family.ftree`, handed over as a content URI for the
+length of one intent, and the previous one is deleted on the next share rather than leaving copies of
+a family in a temporary directory. It has its own `FileProvider` — a subclass, because two
+`<provider>` entries naming the same class are one component to Android, and the first version of
+this shipped URIs that arrived at the updater's provider and were refused.
+
+The message that goes with it has to work for somebody looking at an attachment in a chat who has
+never heard of this app: whose family it is, how many people, where to get the app, and that
+importing will not overwrite anything they already have. Whether a given chat app *shows* that
+message beside the document is that app's decision — which is why the file is named after whose
+family it is. The name is the part that always arrives.
+
+### Joining a shared branch to your own tree
+
+This is the other half of why it exists. Import the branch, then create one relationship between
+somebody in it and somebody in yours, and the two families are one graph: your wife's father is your
+father-in-law, her brother your brother-in-law, and the relation finder can walk between them. There
+is no special "merge two trees" mode, because there does not need to be — a tree is a graph and a
+marriage is an edge.
+
+Re-importing the same file is a no-op. Every record carries where it came from, so the second import
+recognises those people outright rather than proposing them as duplicates.
 
 ## Merge behaviour
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,13 @@ android {
             "RELEASES_PAGE_URL",
             "\"https://github.com/thisisankit27/f-tree/releases\"",
         )
+        // Where somebody who has been sent a family goes to get the app. Here for the same reason
+        // as the two above: a fork points at its own place by editing one line.
+        buildConfigField(
+            "String",
+            "SITE_URL",
+            "\"https://ftree.vibethroughcode.com\"",
+        )
     }
 
     signingConfigs {

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/transfer/ShareBranchTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/transfer/ShareBranchTest.kt
@@ -1,0 +1,259 @@
+package com.vibethroughcode.ftree.transfer
+
+import android.content.Intent
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.BuildConfig
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.graph.Kinship
+import com.vibethroughcode.ftree.graph.KinshipTerm
+import com.vibethroughcode.ftree.graph.Relation
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Sharing one person's family, and joining it to somebody else's tree.
+ *
+ * This is the whole point of the feature and it only means anything end to end: a branch written on
+ * one device has to arrive on another as people who can be married into an existing family and
+ * reasoned about afterwards. So the test does the real round trip — export the branch, wipe the
+ * tree, import the file, connect it — and then asks the relation finder questions it could only
+ * answer if every edge survived.
+ */
+@RunWith(AndroidJUnit4::class)
+class ShareBranchTest {
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    private val repository get() = app.container.familyRepository
+    private val resolver get() = app.applicationContext.contentResolver
+
+    @Before
+    fun emptyTheTree() {
+        app.container.database.clearAllTables()
+    }
+
+    private fun person(name: String, gender: Gender, born: String? = null) =
+        Person(name = name, gender = gender, birthDate = born)
+
+    /**
+     * Sandeep's household, inside a larger family.
+     *
+     * His father and his brother exist so the test can prove they stay behind: a share that quietly
+     * carried the sharer's parents and siblings would be handing over far more than was offered.
+     */
+    private data class Seeded(
+        val sandeep: Person, val pragya: Person, val ankit: Person, val sarika: Person,
+        val father: Person, val brother: Person,
+    )
+
+    private fun seedSandeepsFamily(): Seeded = runBlocking {
+        val sandeep = person("Sandeep Kumar", Gender.MALE, "1965")
+        val pragya = person("Pragya Kumar", Gender.FEMALE, "1968")
+        val ankit = person("Ankit Kumar", Gender.MALE, "1992")
+        val sarika = person("Sarika Kumar", Gender.FEMALE, "1995")
+        val father = person("Shushil Kumar", Gender.MALE, "1938")
+        val brother = person("Rajesh Kumar", Gender.MALE, "1970")
+        listOf(sandeep, pragya, ankit, sarika, father, brother).forEach { repository.addPerson(it) }
+
+        repository.addRelative(sandeep.id, pragya.id, RelativeKind.SPOUSE)
+        repository.addRelative(sandeep.id, ankit.id, RelativeKind.CHILD)
+        repository.addRelative(pragya.id, ankit.id, RelativeKind.CHILD)
+        repository.addRelative(sandeep.id, sarika.id, RelativeKind.CHILD)
+        repository.addRelative(pragya.id, sarika.id, RelativeKind.CHILD)
+        repository.addRelative(sandeep.id, father.id, RelativeKind.PARENT)
+        repository.addRelative(brother.id, father.id, RelativeKind.PARENT)
+        Seeded(sandeep, pragya, ankit, sarika, father, brother)
+    }
+
+    private fun shareBranchOf(personId: String): ByteArray = runBlocking {
+        val shared = app.container.branchShare.prepare(personId)
+        assertNotNull("nothing was written to share", shared)
+        resolver.openInputStream(shared!!.uri)!!.use { it.readBytes() }
+    }
+
+    private fun importInto(archive: ByteArray) = runBlocking {
+        val plan = app.container.importer.prepare(archive.inputStream())
+        app.container.importer.apply(plan, plan.defaultDecisions)
+    }
+
+    private suspend fun namesInTree(): Set<String?> =
+        repository.observeAllPeople().first().map { it.name }.toSet()
+
+    private suspend fun idOf(name: String): String =
+        repository.observeAllPeople().first().first { it.name == name }.id
+
+    private suspend fun relate(fromName: String, toName: String): Relation {
+        val graph = repository.observeWholeGraph().first()
+        return Kinship.relate(graph, idOf(fromName), idOf(toName))
+    }
+
+    @Test
+    fun aSharedBranchCarriesTheHouseholdAndNothingAbove() {
+        val seeded = seedSandeepsFamily()
+        val archive = shareBranchOf(seeded.sandeep.id)
+
+        runBlocking { app.container.database.clearAllTables() }
+        importInto(archive)
+
+        runBlocking {
+            assertEquals(
+                setOf("Sandeep Kumar", "Pragya Kumar", "Ankit Kumar", "Sarika Kumar"),
+                namesInTree(),
+            )
+        }
+    }
+
+    @Test
+    fun theRelationshipsInsideTheBranchSurviveTheJourney() {
+        val seeded = seedSandeepsFamily()
+        val archive = shareBranchOf(seeded.sandeep.id)
+        runBlocking { app.container.database.clearAllTables() }
+        importInto(archive)
+
+        runBlocking {
+            // The marriage.
+            assertEquals(KinshipTerm.Spouse, (relate("Sandeep Kumar", "Pragya Kumar") as Relation.Found).term)
+            // Both children, through both parents.
+            listOf("Ankit Kumar", "Sarika Kumar").forEach { child ->
+                val found = relate("Sandeep Kumar", child) as Relation.Found
+                assertEquals(KinshipTerm.Descendant(1), found.term)
+                assertEquals(KinshipTerm.Descendant(1), (relate("Pragya Kumar", child) as Relation.Found).term)
+            }
+            // And the siblings the import had to derive rather than read.
+            assertEquals(
+                KinshipTerm.Sibling,
+                (relate("Ankit Kumar", "Sarika Kumar") as Relation.Found).term,
+            )
+        }
+    }
+
+    /**
+     * The reason to want this: somebody sends you their family, you import it, and you marry into
+     * it. Every question afterwards has to be answerable across the join.
+     */
+    @Test
+    fun animportedBranchCanBeMarriedIntoAnExistingTree() {
+        val seeded = seedSandeepsFamily()
+        val archive = shareBranchOf(seeded.sandeep.id)
+
+        // A different device, with a tree of its own.
+        runBlocking { app.container.database.clearAllTables() }
+        val me = person("Ankit Srivastava", Gender.MALE, "1990")
+        val myFather = person("Vinod Srivastava", Gender.MALE, "1962")
+        runBlocking {
+            listOf(me, myFather).forEach { repository.addPerson(it) }
+            repository.addRelative(me.id, myFather.id, RelativeKind.PARENT)
+        }
+
+        importInto(archive)
+
+        runBlocking {
+            // Six people now: my two and their four, still separate.
+            assertEquals(6, repository.observeAllPeople().first().size)
+            assertTrue(relate("Ankit Srivastava", "Sarika Kumar") is Relation.Unrecorded)
+
+            // Marry her.
+            repository.addRelative(me.id, idOf("Sarika Kumar"), RelativeKind.SPOUSE)
+
+            assertEquals(
+                KinshipTerm.Spouse,
+                (relate("Ankit Srivastava", "Sarika Kumar") as Relation.Found).term,
+            )
+            // Her father is now my father-in-law, which is a relationship the app can only name if
+            // the imported edges and the new one are read as one graph.
+            val fatherInLaw = relate("Ankit Srivastava", "Sandeep Kumar") as Relation.Found
+            assertEquals(KinshipTerm.OfSpouse(KinshipTerm.Ancestor(1)), fatherInLaw.term)
+            val motherInLaw = relate("Ankit Srivastava", "Pragya Kumar") as Relation.Found
+            assertEquals(KinshipTerm.OfSpouse(KinshipTerm.Ancestor(1)), motherInLaw.term)
+            // And her brother my brother-in-law.
+            val brotherInLaw = relate("Ankit Srivastava", "Ankit Kumar") as Relation.Found
+            assertEquals(KinshipTerm.OfSpouse(KinshipTerm.Sibling), brotherInLaw.term)
+
+            // My own side still reads correctly, and reaches across the marriage.
+            assertEquals(
+                KinshipTerm.Ancestor(1),
+                (relate("Ankit Srivastava", "Vinod Srivastava") as Relation.Found).term,
+            )
+            assertTrue(relate("Vinod Srivastava", "Sandeep Kumar") is Relation.Found)
+        }
+    }
+
+    @Test
+    fun sharingTheSamePersonTwiceIsRecognisedRatherThanDuplicated() {
+        val seeded = seedSandeepsFamily()
+        val archive = shareBranchOf(seeded.sandeep.id)
+        runBlocking { app.container.database.clearAllTables() }
+
+        importInto(archive)
+        importInto(archive)
+
+        runBlocking {
+            // The same file twice is the same four people, not eight: every record carries where it
+            // came from, so the second import recognises them outright.
+            assertEquals(4, repository.observeAllPeople().first().size)
+        }
+    }
+
+    @Test
+    fun somebodyWithNobodyBelowThemStillHasAFamilyToSend() {
+        val seeded = seedSandeepsFamily()
+        val archive = shareBranchOf(seeded.sarika.id)
+        runBlocking { app.container.database.clearAllTables() }
+        importInto(archive)
+
+        runBlocking {
+            // Sarika alone: no children, and no partner to bring.
+            assertEquals(setOf("Sarika Kumar"), namesInTree())
+            assertNull(repository.observeAllPeople().first().single().birthDate?.let { null })
+        }
+    }
+
+    /**
+     * What actually leaves the app.
+     *
+     * The message is assembled from three pieces of copy and two numbers, and a format argument in
+     * the wrong order is the sort of thing nobody notices until it is in somebody's chat window.
+     */
+    @Test
+    fun theIntentCarriesTheFileAndAMessageThatNamesTheFamily() {
+        val seeded = seedSandeepsFamily()
+        val shared = runBlocking { app.container.branchShare.prepare(seeded.sandeep.id) }!!
+
+        assertEquals("Sandeep Kumar", shared.personName)
+        assertEquals(4, shared.people)
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val message = context.getString(
+            R.string.share_message,
+            shared.personName,
+            context.resources.getQuantityString(R.plurals.person_count, shared.people, shared.people),
+            BuildConfig.SITE_URL,
+        )
+        val intent = sendBranchIntent(shared.uri, message, "Send Sandeep Kumar's family")
+
+        assertEquals(Intent.ACTION_SEND, intent.action)
+        assertEquals(TreeDocument.MIME_TYPE, intent.type)
+        assertEquals(shared.uri, intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+        assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+
+        val text = intent.getStringExtra(Intent.EXTRA_TEXT)!!
+        assertTrue("should name whose family it is: $text", "Sandeep Kumar" in text)
+        assertTrue("should say how many people: $text", "4 people" in text)
+        assertTrue("should say where to get the app: $text", BuildConfig.SITE_URL in text)
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,22 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/update_paths" />
         </provider>
+
+        <!--
+            Hands one person's exported branch to whichever app the user picked to send it with.
+            Separate from the updater's provider so the two never share a directory: one holds an
+            APK about to be installed, the other a piece of somebody's family about to leave the
+            device, and they should not be one setting away from each other.
+        -->
+        <provider
+            android:name=".transfer.ShareFileProvider"
+            android:authorities="${applicationId}.shares"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/share_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
@@ -6,6 +6,7 @@ import com.vibethroughcode.ftree.data.FTreeDatabase
 import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.KinshipPreferences
 import com.vibethroughcode.ftree.data.PhotoStore
+import com.vibethroughcode.ftree.transfer.BranchShare
 import com.vibethroughcode.ftree.transfer.TreeExporter
 import com.vibethroughcode.ftree.transfer.TreeIdentity
 import com.vibethroughcode.ftree.transfer.TreeImporter
@@ -29,6 +30,7 @@ class AppContainer(context: Context) {
     val photoStore: PhotoStore by lazy { PhotoStore(context.applicationContext) }
     val treeIdentity: TreeIdentity by lazy { TreeIdentity(context.applicationContext) }
     val exporter: TreeExporter by lazy { TreeExporter(familyRepository, photoStore, treeIdentity) }
+    val branchShare: BranchShare by lazy { BranchShare(context, familyRepository, exporter) }
     val importer: TreeImporter by lazy {
         TreeImporter(
             database = database,

--- a/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/data/FamilyRepository.kt
@@ -69,6 +69,13 @@ class FamilyRepository(
     suspend fun descendantIdsOf(personId: String): Set<String> =
         FamilyGraph.descendantsOf(personId) { relationships.childIdsOf(it) }
 
+    /** One person's household and the households under it — see [FamilyGraph.branchFrom]. */
+    suspend fun branchIdsOf(personId: String): Set<String> = FamilyGraph.branchFrom(
+        personId = personId,
+        childrenOf = { relationships.childIdsOf(it) },
+        spousesOf = { relationships.spouseIdsOfAll(listOf(it)) },
+    )
+
     suspend fun addPerson(person: Person): Person {
         people.insert(person)
         return person

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/FamilyGraph.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/FamilyGraph.kt
@@ -29,6 +29,29 @@ object FamilyGraph {
     ): Set<String> = reachable(personId, childrenOf)
 
     /**
+     * One person, everyone below them, and whoever each of them married.
+     *
+     * This is what "share Sandeep's family" means: his household and the households under it. It
+     * deliberately goes *down* only. Sending somebody a branch should not quietly hand over the
+     * sharer's parents, siblings, cousins and in-laws, and a recipient starting their own tree from
+     * a relative's file wants the people below that relative, not the whole archive they came from.
+     *
+     * Partners come along at every level, because a couple is how a family is read and a child
+     * arriving without the parent they married is a hole in the story. Their *parents* do not: they
+     * are the doorway back into another whole family, which is exactly what this is not for.
+     */
+    suspend fun branchFrom(
+        personId: String,
+        childrenOf: suspend (String) -> List<String>,
+        spousesOf: suspend (String) -> List<String>,
+    ): Set<String> {
+        val bloodline = descendantsOf(personId, childrenOf) + personId
+        val everyone = LinkedHashSet(bloodline)
+        bloodline.forEach { everyone.addAll(spousesOf(it)) }
+        return everyone
+    }
+
+    /**
      * True when making [parentId] a parent of [childId] would make someone their own ancestor.
      *
      * Genealogically this is nonsense, and structurally it would let a tree walk upwards forever,

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/BranchShare.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/BranchShare.kt
@@ -1,0 +1,96 @@
+package com.vibethroughcode.ftree.transfer
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.FileProvider
+import com.vibethroughcode.ftree.data.FamilyRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * A branch written out and ready to hand to another app.
+ *
+ * [people] is carried so the message can say how many are in the file. Somebody receiving a
+ * document over a chat app has no idea what is in it until they open it, and "4 people" is the
+ * difference between a file worth installing an app for and one worth ignoring.
+ */
+data class SharedBranch(
+    val uri: Uri,
+    val personName: String?,
+    val people: Int,
+)
+
+/**
+ * Writes one person's branch to a file another app can read.
+ *
+ * The whole-tree export asks the user where to put the file, because it is their archive and they
+ * are keeping it. A share is the opposite: the file is a message, nobody wants to name it, and it
+ * should not survive being sent. So it is written to the cache under a name that says what it is,
+ * handed over as a content URI for the length of one intent, and the previous one is deleted each
+ * time rather than accumulating copies of a family in a temporary directory.
+ */
+class BranchShare(
+    private val context: Context,
+    private val repository: FamilyRepository,
+    private val exporter: TreeExporter,
+) {
+
+    suspend fun prepare(personId: String): SharedBranch? = withContext(Dispatchers.IO) {
+        val person = repository.person(personId) ?: return@withContext null
+        val branch = repository.branchIdsOf(personId)
+
+        val directory = File(context.cacheDir, DIRECTORY)
+        directory.deleteRecursively()
+        directory.mkdirs()
+
+        val file = File(directory, fileNameFor(person.name))
+        val summary = file.outputStream().use { exporter.exportTo(it, only = branch) }
+
+        SharedBranch(
+            uri = FileProvider.getUriForFile(context, "${context.packageName}.$AUTHORITY", file),
+            personName = person.name?.takeIf { it.isNotBlank() },
+            people = summary.people,
+        )
+    }
+
+    /**
+     * `Sandeep-Kumar-family.ftree`.
+     *
+     * The name is the only part of a shared file most people will read before deciding whether to
+     * open it, so it carries whose family it is. Anything that is not a letter, a digit or a dash
+     * goes, because this name has to survive every chat app, file manager and filesystem between
+     * here and the person receiving it.
+     */
+    private fun fileNameFor(name: String?): String {
+        val stem = name.orEmpty().trim()
+            .replace(Regex("[^\\p{L}\\p{N}]+"), "-")
+            .trim('-')
+            .take(48)
+            .ifBlank { "shared" }
+        return "$stem-family.${TreeDocument.FILE_EXTENSION}"
+    }
+
+    private companion object {
+        const val DIRECTORY = "shared"
+        const val AUTHORITY = "shares"
+    }
+}
+
+/**
+ * The intent that carries a branch out of the app.
+ *
+ * Built here rather than at the call site so that what travels can be asserted. Whether a given
+ * chat app *shows* the message beside the document is that app's decision and not something this
+ * can guarantee — which is exactly why the file is named after whose family it is. The name is the
+ * part that always arrives.
+ */
+fun sendBranchIntent(uri: Uri, message: String?, subject: String?): Intent =
+    Intent(Intent.ACTION_SEND).apply {
+        type = TreeDocument.MIME_TYPE
+        putExtra(Intent.EXTRA_STREAM, uri)
+        message?.let { putExtra(Intent.EXTRA_TEXT, it) }
+        subject?.let { putExtra(Intent.EXTRA_SUBJECT, it) }
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/ShareFileProvider.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/ShareFileProvider.kt
@@ -1,0 +1,13 @@
+package com.vibethroughcode.ftree.transfer
+
+import androidx.core.content.FileProvider
+
+/**
+ * The provider that hands a shared branch to another app.
+ *
+ * It exists only to have a different class name from the updater's provider. Two `<provider>`
+ * entries naming the same class are one component to Android, so a URI minted for this authority
+ * arrived at the updater's provider and was refused — which the round-trip test caught the first
+ * time it ran. A subclass each keeps the two apart, and keeps their directories apart with them.
+ */
+class ShareFileProvider : FileProvider()

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeExporter.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/TreeExporter.kt
@@ -19,7 +19,7 @@ data class ExportSummary(
 )
 
 /**
- * Writes the whole tree to a `.ftree` archive.
+ * Writes a tree, or one branch of it, to a `.ftree` archive.
  *
  * Streams straight into the destination rather than building the file in memory, so exporting a
  * large family with photographs costs no more memory than exporting a small one.
@@ -31,9 +31,24 @@ class TreeExporter(
     private val json: Json = ExportJson,
 ) {
 
-    suspend fun exportTo(destination: OutputStream): ExportSummary = withContext(Dispatchers.IO) {
-        val people = repository.allPeople()
-        val relationships = repository.allRelationships()
+    /**
+     * [only] narrows the archive to those people. A relationship travels when *both* ends do, so a
+     * shared branch never carries an edge pointing at somebody who is not in the file — the reader
+     * would have no way to resolve it, and it would leak the existence of a person who was
+     * deliberately left behind.
+     */
+    suspend fun exportTo(
+        destination: OutputStream,
+        only: Set<String>? = null,
+    ): ExportSummary = withContext(Dispatchers.IO) {
+        val people = repository.allPeople().let { all ->
+            if (only == null) all else all.filter { it.id in only }
+        }
+        val kept = people.mapTo(mutableSetOf()) { it.id }
+        val relationships = repository.allRelationships().let { all ->
+            if (only == null) all
+            else all.filter { it.fromPersonId in kept && it.toPersonId in kept }
+        }
         val origins = repository.originsOf(people.map { it.id }).groupBy { it.personId }
 
         val referenced = people.mapNotNull { it.photoId }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -1,5 +1,6 @@
 package com.vibethroughcode.ftree.ui
 
+import android.content.Intent
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Row
@@ -22,6 +23,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
@@ -42,9 +44,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
+import com.vibethroughcode.ftree.BuildConfig
 import com.vibethroughcode.ftree.FTreeApplication
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.transfer.TreeDocument
+import com.vibethroughcode.ftree.transfer.sendBranchIntent
 import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.isShortWindow
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
@@ -56,6 +60,7 @@ import com.vibethroughcode.ftree.ui.settings.SettingsScreen
 import com.vibethroughcode.ftree.ui.settings.SettingsViewModel
 import com.vibethroughcode.ftree.ui.transfer.ImportReviewScreen
 import com.vibethroughcode.ftree.ui.transfer.TransferMessages
+import com.vibethroughcode.ftree.ui.common.peopleCount
 import com.vibethroughcode.ftree.ui.transfer.TransferViewModel
 import com.vibethroughcode.ftree.ui.transfer.defaultExportName
 import com.vibethroughcode.ftree.ui.tree.TreeScreen
@@ -94,6 +99,7 @@ private val destinations = listOf(
 @Composable
 fun FTreeApp() {
     val navController = rememberNavController()
+    val context = LocalContext.current
     // Named once here and read by every screen that says a relationship out loud.
     val kinshipLanguage by (LocalContext.current.applicationContext as FTreeApplication)
         .container.kinshipPreferences.language.collectAsStateWithLifecycle()
@@ -112,6 +118,31 @@ fun FTreeApp() {
     val importPicker = rememberLauncherForActivityResult(
         ActivityResultContracts.OpenDocument()
     ) { uri -> uri?.let(transferViewModel::prepareImport) }
+
+    /*
+     * Handing one person's family to another app.
+     *
+     * The chooser cannot open until the file exists, so the view model writes it first and this
+     * watches for it. Everything user-facing is assembled here rather than in the view model: the
+     * message is a string resource that has to follow the reader's configuration, and an Intent is
+     * not something a view model should know how to build.
+     */
+    val shared by transferViewModel.share.collectAsStateWithLifecycle()
+    val siteUrl = BuildConfig.SITE_URL
+    val sharedName = shared?.personName
+    val sharedCount = shared?.people?.let { peopleCount(it) }
+    val shareMessage = when {
+        sharedCount == null -> null
+        sharedName == null -> stringResource(R.string.share_message_unnamed, sharedCount, siteUrl)
+        else -> stringResource(R.string.share_message, sharedName, sharedCount, siteUrl)
+    }
+    val shareTitle = sharedName?.let { stringResource(R.string.share_chooser_title, it) }
+    LaunchedEffect(shared) {
+        val branch = shared ?: return@LaunchedEffect
+        val send = sendBranchIntent(branch.uri, shareMessage, shareTitle)
+        runCatching { context.startActivity(Intent.createChooser(send, shareTitle)) }
+        transferViewModel.clearShare()
+    }
 
     val backStackEntry by navController.currentBackStackEntryAsState()
     val destination = backStackEntry?.destination
@@ -179,6 +210,7 @@ fun FTreeApp() {
                                 navController.navigate(AddRelativeRoute(anchorId, kind))
                             },
                             onRelate = { navController.navigate(RelationRoute(fromId = it)) },
+                            onShare = transferViewModel::shareBranch,
                             // Dropping the trace means going back to the plain chart, which is where
                             // clearing a highlight should leave you — not one screen further back.
                             onClearTrace = {
@@ -234,6 +266,7 @@ fun FTreeApp() {
                             onRelate = { personId ->
                                 navController.navigate(RelationRoute(fromId = personId))
                             },
+                            onShare = transferViewModel::shareBranch,
                         )
                     }
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/ViewModelFactory.kt
@@ -54,6 +54,7 @@ object FTreeViewModels {
             TransferViewModel(
                 exporter = app.container.exporter,
                 importer = app.container.importer,
+                branchShare = app.container.branchShare,
                 contentResolver = app.contentResolver,
                 repository = app.container.familyRepository,
             )

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.CompareArrows
 import androidx.compose.material.icons.filled.DeleteOutline
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material.icons.filled.AccountTree
@@ -69,6 +70,7 @@ const val PersonNameTag = "person-name"
 const val PersonDeleteTag = "person-delete"
 const val PersonMenuTag = "person-menu"
 const val PersonRelateTag = "person-relate"
+const val PersonShareTag = "person-share"
 const val PersonEditTag = "person-edit"
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -80,6 +82,7 @@ fun PersonDetailScreen(
     onAddRelative: (String, RelativeKind) -> Unit,
     onShowOnTree: (String) -> Unit,
     onRelate: (String) -> Unit,
+    onShare: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PersonDetailViewModel = viewModel(factory = FTreeViewModels.Factory),
 ) {
@@ -142,6 +145,20 @@ fun PersonDetailScreen(
                             },
                             onClick = { menuOpen = false; onRelate(viewModel.personId) },
                             modifier = Modifier.testTag(PersonRelateTag),
+                        )
+                        /*
+                         * Sending one person's family, rather than the whole archive.
+                         *
+                         * Above delete because it is the one somebody actually comes here to do,
+                         * and because the two should not be neighbours a mis-tap apart.
+                         */
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.share_branch)) },
+                            leadingIcon = {
+                                Icon(Icons.Default.Share, contentDescription = null)
+                            },
+                            onClick = { menuOpen = false; onShare(viewModel.personId) },
+                            modifier = Modifier.testTag(PersonShareTag),
                         )
                         DropdownMenuItem(
                             text = { Text(stringResource(R.string.delete_person)) },

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferMessages.kt
@@ -82,6 +82,8 @@ fun TransferMessages(
             else base + " " + stringResource(R.string.import_conflicts, result.conflicts.size)
         }
 
+        TransferOutcome.ShareFailed -> stringResource(R.string.share_failed)
+
         is TransferOutcome.ImportFailed -> stringResource(
             when (current.problem) {
                 ImportProblem.NOT_AN_ARCHIVE -> R.string.import_failed_not_archive

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/transfer/TransferViewModel.kt
@@ -4,11 +4,13 @@ import android.content.ContentResolver
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.vibethroughcode.ftree.transfer.BranchShare
 import com.vibethroughcode.ftree.transfer.ExportSummary
 import com.vibethroughcode.ftree.transfer.ImportFailure
 import com.vibethroughcode.ftree.transfer.ImportPlan
 import com.vibethroughcode.ftree.transfer.ImportProblem
 import com.vibethroughcode.ftree.transfer.ImportResult
+import com.vibethroughcode.ftree.transfer.SharedBranch
 import com.vibethroughcode.ftree.transfer.TreeExporter
 import com.vibethroughcode.ftree.transfer.TreeImporter
 import com.vibethroughcode.ftree.data.FamilyRepository
@@ -27,11 +29,13 @@ sealed interface TransferOutcome {
     data object ExportFailed : TransferOutcome
     data class Imported(val result: ImportResult) : TransferOutcome
     data class ImportFailed(val problem: ImportProblem) : TransferOutcome
+    data object ShareFailed : TransferOutcome
 }
 
 class TransferViewModel(
     private val exporter: TreeExporter,
     private val importer: TreeImporter,
+    private val branchShare: BranchShare,
     private val contentResolver: ContentResolver,
     repository: FamilyRepository,
 ) : ViewModel() {
@@ -79,6 +83,27 @@ class TransferViewModel(
             _busy.value = false
         }
     }
+
+    /**
+     * One person's branch, written and waiting to be handed to another app.
+     *
+     * Held here rather than returned, because the file has to exist before the chooser opens and
+     * writing it is not instant on a large family. The screen watches this, sends it once, and
+     * clears it; a share left in this state is a file nobody asked for.
+     */
+    private val _share = MutableStateFlow<SharedBranch?>(null)
+    val share: StateFlow<SharedBranch?> = _share.asStateFlow()
+
+    fun shareBranch(personId: String) {
+        viewModelScope.launch {
+            _busy.value = true
+            _share.value = runCatching { branchShare.prepare(personId) }.getOrNull()
+            if (_share.value == null) _outcome.value = TransferOutcome.ShareFailed
+            _busy.value = false
+        }
+    }
+
+    fun clearShare() { _share.value = null }
 
     fun clearOutcome() { _outcome.value = null }
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.CenterFocusStrong
 import androidx.compose.material.icons.filled.CompareArrows
 import androidx.compose.material.icons.filled.FitScreen
 import androidx.compose.material.icons.filled.PersonAddAlt
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.UnfoldMore
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -77,6 +78,7 @@ const val TreeModeFocusedTag = "tree-mode-focused"
 const val TreeModeWholeTag = "tree-mode-whole"
 const val TreeRelateTag = "tree-relate"
 const val TreeRelateFromTag = "tree-relate-from"
+const val TreeShareTag = "tree-share"
 const val TreeClearTraceTag = "tree-clear-trace"
 const val TreeFrameTag = "tree-frame"
 
@@ -125,6 +127,7 @@ fun TreeScreen(
     onAddPerson: () -> Unit,
     onAddRelative: (String, RelativeKind) -> Unit,
     onRelate: (String?) -> Unit,
+    onShare: (String) -> Unit,
     onClearTrace: () -> Unit,
     modifier: Modifier = Modifier,
     /** The people on a relation to draw: both ends and everyone between. Empty is the usual case. */
@@ -333,6 +336,10 @@ fun TreeScreen(
                     selected = null
                     onRelate(person.id)
                 },
+                onShare = {
+                    selected = null
+                    onShare(person.id)
+                },
                 onAddRelative = { kind ->
                     selected = null
                     onAddRelative(person.id, kind)
@@ -505,6 +512,7 @@ private fun PersonActions(
     onOpen: () -> Unit,
     onFocus: () -> Unit,
     onRelate: () -> Unit,
+    onShare: () -> Unit,
     onAddRelative: (RelativeKind) -> Unit,
 ) {
     Column(
@@ -532,6 +540,12 @@ private fun PersonActions(
             label = stringResource(R.string.relation_open_from_person),
             tag = TreeRelateFromTag,
             onClick = onRelate,
+        )
+        SheetAction(
+            icon = { Icon(Icons.Default.Share, contentDescription = null) },
+            label = stringResource(R.string.share_branch),
+            tag = TreeShareTag,
+            onClick = onShare,
         )
         // Naming the four kinds outright is one tap either way, and avoids the sheet quietly
         // choosing "parent" on the user's behalf.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,18 @@
     <string name="export_done">Exported %1$s and %2$s.</string>
     <string name="export_done_photos">Exported %1$s, %2$s and %3$s.</string>
     <string name="export_failed">Couldn\'t write that file. Try somewhere else.</string>
+
+    <!-- Sharing one person's branch -->
+    <string name="share_branch">Share this family</string>
+    <string name="share_chooser_title">Send %1$s\'s family</string>
+    <string name="share_failed">Couldn\'t prepare that family to send.</string>
+    <!--
+        The message that travels with the file. It has to work for somebody who has never heard of
+        this app and is looking at an attachment in a chat: what it is, how many people are in it,
+        where to get the app, and that importing it will not overwrite anything they already have.
+    -->
+    <string name="share_message">Hey — I\'ve shared %1$s\'s family tree with you: %2$s.\n\nf-tree is a free family tree app that keeps everything on your phone. Get it at %3$s, then open Settings → Import a tree and choose this file. It merges into your own tree; nothing of yours is replaced.</string>
+    <string name="share_message_unnamed">Hey — I\'ve shared part of my family tree with you: %1$s.\n\nf-tree is a free family tree app that keeps everything on your phone. Get it at %2$s, then open Settings → Import a tree and choose this file. It merges into your own tree; nothing of yours is replaced.</string>
     <string name="export_empty">There is nobody in your tree to export yet.</string>
     <string name="import_tree">Import a tree</string>
     <string name="import_title">Import this tree?</string>

--- a/app/src/main/res/xml/share_paths.xml
+++ b/app/src/main/res/xml/share_paths.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    The one directory a shared branch is written to. It lives in the cache because a shared file is
+    a message rather than a document: it is rewritten on every share and the system may reclaim it
+    whenever it likes.
+-->
+<paths>
+    <cache-path name="shared" path="shared/" />
+</paths>

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/BranchTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/BranchTest.kt
@@ -1,0 +1,66 @@
+package com.vibethroughcode.ftree.graph
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/** Who travels when one person's family is shared. */
+class BranchTest {
+
+    /**
+     * Sandeep married Pragya and they have Ankit and Sarika. Ankit married Priya and they have
+     * Aarav. Sandeep also has a brother, a father, and a nephew through the brother — none of whom
+     * are his to give away.
+     */
+    private val children = mapOf(
+        "father" to listOf("sandeep", "brother"),
+        "sandeep" to listOf("ankit", "sarika"),
+        "pragya" to listOf("ankit", "sarika"),
+        "ankit" to listOf("aarav"),
+        "priya" to listOf("aarav"),
+        "brother" to listOf("nephew"),
+    )
+    private val spouses = mapOf(
+        "sandeep" to listOf("pragya"),
+        "pragya" to listOf("sandeep"),
+        "ankit" to listOf("priya"),
+        "priya" to listOf("ankit"),
+        "father" to listOf("mother"),
+        "mother" to listOf("father"),
+    )
+
+    private suspend fun branch(of: String) = FamilyGraph.branchFrom(
+        personId = of,
+        childrenOf = { children[it].orEmpty() },
+        spousesOf = { spouses[it].orEmpty() },
+    )
+
+    @Test
+    fun `a branch is the person, everyone below them, and whoever they married`() = runTest {
+        assertEquals(
+            setOf("sandeep", "pragya", "ankit", "sarika", "priya", "aarav"),
+            branch("sandeep"),
+        )
+    }
+
+    @Test
+    fun `it does not reach upwards or sideways`() = runTest {
+        val shared = branch("sandeep")
+        listOf("father", "mother", "brother", "nephew").forEach {
+            assertEquals("$it should not travel", false, it in shared)
+        }
+    }
+
+    @Test
+    fun `a partner's own parents are not a doorway into their family`() = runTest {
+        // Priya is in Ankit's branch because he married her; her people are not.
+        val shared = branch("ankit")
+        assertEquals(setOf("ankit", "priya", "aarav"), shared)
+    }
+
+    @Test
+    fun `somebody with nobody below them shares themselves and their partner`() = runTest {
+        assertEquals(setOf("sarika"), branch("sarika"))
+        assertEquals(setOf("pragya", "sandeep", "ankit", "sarika", "priya", "aarav"), branch("pragya"))
+    }
+}


### PR DESCRIPTION
Tap somebody, send their family over WhatsApp. The recipient imports it and it merges into their tree.

## What travels

**The person, everyone descended from them, and the partners of all of them.**

For Sandeep Kumar that is Sandeep, his wife, his children and their partners, and so on down. What stays behind is everything *above* and *beside* him — his parents, his siblings, their children.

Verified on the real sample family. Sharing Vinod Kumar produced exactly:

```
Vinod-Kumar-family.ftree
  - Vinod Kumar        the person
  - Anita Kumar        his wife
  - Ankit Kumar        child
  - Neha Kumar         child
  - Priya Sharma       Ankit's wife
  - Aarav Kumar        grandchild
  8 relationships
```

…and **not** his parents (Raj, Sushila), his sister (Meena), his grandfather (Shyam Lal) or his nephew (Rohit).

**Why down and not up:** sending somebody a branch should not quietly hand over the rest of the sharer's family, and a recipient starting their own tree from a relative's file wants the people below that relative, not the archive they came from.

**Why partners but not their parents:** a couple is how a family is read, and a child arriving without the parent they married is a hole in the story. A partner's *parents* are the doorway back into another whole family, which is exactly what this is not.

A relationship travels only when **both** ends do, so a shared branch never carries an edge pointing at somebody who is not in the file.

## Where it is

Both places you would look: the person screen's overflow menu, and the sheet that opens when you tap somebody on the tree. (The relation finder already lives in both, so this follows a path that exists.)

## The message

The file is named after whose family it is — `Sandeep-Kumar-family.ftree` — because that is the part that always arrives. The message alongside it says whose family, how many people, where to get the app, and that importing will not overwrite anything:

> Hey — I've shared Sandeep Kumar's family tree with you: 4 people.
>
> f-tree is a free family tree app that keeps everything on your phone. Get it at https://ftree.vibethroughcode.com, then open Settings → Import a tree and choose this file. It merges into your own tree; nothing of yours is replaced.

**One caveat I could not verify here:** whether a given chat app shows that message *beside* a document is that app's decision, and there is no WhatsApp on the emulator. The intent carries it correctly — there is a test asserting exactly that — but it is worth one look on your phone.

## Grafting a branch onto your own tree

The other half of why this exists, and it is a test:

1. Share Sandeep's branch (4 people)
2. Wipe the tree, build a different one — Ankit Srivastava and his father
3. Import the file — 6 people, still two separate families
4. Marry Ankit Srivastava to Sarika, one relationship

Then every question across the join answers:

| | |
|---|---|
| Sarika | wife |
| Sandeep | father-in-law |
| Pragya | mother-in-law |
| Ankit Kumar | brother-in-law |
| Vinod Srivastava | still his father |

No "merge two trees" mode, because there does not need to be: a tree is a graph and a marriage is an edge.

Re-importing the same file is a no-op — every record carries where it came from.

## A bug the tests caught

Two `<provider>` entries naming `androidx.core.content.FileProvider` are **one component** to Android, so URIs minted for `.shares` arrived at the updater's provider and were refused with a `SecurityException`. Sharing needs its own subclass. Caught on the round-trip test's first run.

## Verification

180 unit tests (4 new for the selection rule), **135 instrumented** (6 new for the round trip), lint clean. Exercised on device: the sheet opens with the right file, and the archive contents were unzipped and checked person by person.

🤖 Generated with [Claude Code](https://claude.com/claude-code)