### PR TITLE
Version 0.6.0-beta.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 9
-        versionName = "0.5.1"
+        versionCode = 10
+        versionName = "0.6.0-beta.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps `versionName` to **0.6.0-beta.1** and `versionCode` to 10, so the first beta tag can be cut.

It carries the two things that want trying on a real phone before everybody gets them:

- **Sharing one person's family** (#52) — in particular whether WhatsApp shows the message beside the document, which cannot be checked on an emulator
- **The beta channel itself** (#53)

The suffix is what makes it a beta: the workflow publishes a suffixed tag as a GitHub pre-release, and `releases/latest` skips those, so nobody on the ordinary channel is offered it.

Promoting it later is a fresh tag without the suffix — `0.6.0` — which everybody gets, beta readers included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)