### PR TITLE
Version 0.5.2 — the missing rung

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,11 +86,21 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           apk="f-tree-${{ env.version }}.apk"
+
+          # A version with a suffix — 0.6.0-beta.1 — is a beta, and GitHub has to be told so. It is
+          # what keeps `releases/latest` answering with the last stable release, which is the whole
+          # mechanism separating the two channels in the app: the ordinary updater reads that
+          # endpoint and can therefore never be handed an unfinished build by accident.
+          case "${{ env.version }}" in
+            *-*) prerelease="--prerelease" ;;
+            *)   prerelease="" ;;
+          esac
+
           # Attach to a release written by hand if there is one; otherwise create it.
           if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             gh release upload "$GITHUB_REF_NAME" "$apk" --clobber
           else
-            gh release create "$GITHUB_REF_NAME" "$apk" \
+            gh release create "$GITHUB_REF_NAME" "$apk" $prerelease \
               --title "f-tree ${{ env.version }}" \
               --generate-notes
           fi

--- a/README.md
+++ b/README.md
@@ -478,6 +478,25 @@ attaches to an existing release rather than replacing it.
 Note that the secrets are a *deployment* mechanism, not a backup — a secret can never be read back
 out. Keep the keystore file itself somewhere safe: losing it means no in-place updates, ever.
 
+### Beta releases
+
+A tag with a suffix — `v0.6.0-beta.1`, matching a `versionName` of `0.6.0-beta.1` — is published as
+a GitHub **pre-release**. That single flag is the whole mechanism separating the two channels:
+GitHub's `releases/latest` endpoint skips pre-releases, and the ordinary updater reads that endpoint,
+so somebody who has not asked for betas cannot be handed one by accident.
+
+The beta channel reads the full `releases` list instead, and takes the newest thing on it — which
+means a beta reader is moved on to the stable release as soon as it supersedes the beta they are on,
+without having to change any setting.
+
+**Promoting a beta to stable** is a fresh tag without the suffix: bump `versionName` to `0.6.0`,
+tag `v0.6.0`. Everybody gets it, including the beta readers, because `0.6.0 > 0.6.0-beta.1`.
+
+Opting in lives at the very bottom of Settings, under the licence notice, behind copy that
+discourages it and a dialog that has to be agreed to. It says the thing somebody would otherwise only
+find out afterwards: Android will not install an older version over a newer one, so switching the
+setting back does not move you off a beta — the next stable release does.
+
 Release builds are minified. **Always install and exercise a release build before publishing it** —
 R8 has broken this app once already, by renaming an enum that navigation resolves by name and that
 the database persists by name. `app/proguard-rules.pro` explains what must be kept and why.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,6 +33,13 @@ android {
             "UPDATE_RELEASE_URL",
             "\"https://api.github.com/repos/thisisankit27/f-tree/releases/latest\"",
         )
+        // Every release, newest first. `releases/latest` deliberately skips pre-releases, so the
+        // beta channel has to read the list instead.
+        buildConfigField(
+            "String",
+            "UPDATE_RELEASES_URL",
+            "\"https://api.github.com/repos/thisisankit27/f-tree/releases?per_page=20\"",
+        )
         buildConfigField(
             "String",
             "RELEASES_PAGE_URL",

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 9
-        versionName = "0.5.1"
+        versionCode = 11
+        versionName = "0.5.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/BetaChannelFlowTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/BetaChannelFlowTest.kt
@@ -1,0 +1,101 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.ui.settings.SettingsBetaConfirmTag
+import com.vibethroughcode.ftree.ui.settings.SettingsBetaToggleTag
+import com.vibethroughcode.ftree.ui.settings.SettingsUpdatesToggleTag
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Opting in to unfinished builds.
+ *
+ * The point of the tests is that it is hard to do by accident: it does nothing until ordinary update
+ * checking is on, and it does not happen at all until somebody has read a dialog and agreed to it.
+ */
+@RunWith(AndroidJUnit4::class)
+class BetaChannelFlowTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    private val preferences get() = app.container.updatePreferences
+
+    @Before
+    fun start() {
+        preferences.setBetaChannel(false)
+        preferences.setEnabled(false)
+        rule.onNodeWithTag(NavSettingsTag).performClick()
+    }
+
+    @After
+    fun leaveItOff() {
+        preferences.setBetaChannel(false)
+        preferences.setEnabled(false)
+    }
+
+    @Test
+    fun itDoesNothingUntilUpdateCheckingIsOn() {
+        rule.onNodeWithTag(SettingsBetaToggleTag).performScrollTo().assertIsDisplayed()
+        rule.onNodeWithText("Turn on", substring = true).assertIsDisplayed()
+
+        // The row is inert, so tapping it cannot turn anything on.
+        rule.onNodeWithTag(SettingsBetaToggleTag).performClick()
+        rule.onAllNodesWithText("Take unfinished builds?").assertCountEquals(0)
+        assertFalse(preferences.betaChannel.value)
+    }
+
+    @Test
+    fun turningItOnTakesReadingSomethingFirst() {
+        rule.onNodeWithTag(SettingsUpdatesToggleTag).performScrollTo().performClick()
+
+        rule.onNodeWithTag(SettingsBetaToggleTag).performScrollTo().performClick()
+        rule.onNodeWithText("Take unfinished builds?").assertIsDisplayed()
+        // The consequence somebody would otherwise only discover afterwards.
+        rule.onNodeWithText("will not move you back", substring = true).assertIsDisplayed()
+        rule.onNodeWithText("Export your tree before you install one.").assertIsDisplayed()
+
+        // Backing out changes nothing.
+        rule.onNodeWithText("Not now").performClick()
+        assertFalse(preferences.betaChannel.value)
+        rule.onNodeWithTag(SettingsBetaToggleTag).performScrollTo().assertIsOff()
+
+        rule.onNodeWithTag(SettingsBetaToggleTag).performClick()
+        rule.onNodeWithTag(SettingsBetaConfirmTag).performClick()
+        assertTrue(preferences.betaChannel.value)
+        rule.onNodeWithTag(SettingsBetaToggleTag).performScrollTo().assertIsOn()
+    }
+
+    @Test
+    fun turningItOffIsNotAnInterruption() {
+        preferences.setEnabled(true)
+        preferences.setBetaChannel(true)
+
+        rule.onNodeWithTag(SettingsBetaToggleTag).performScrollTo().performClick()
+
+        rule.onAllNodesWithText("Take unfinished builds?").assertCountEquals(0)
+        assertFalse(preferences.betaChannel.value)
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
@@ -21,6 +21,8 @@ import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.OpenInNew
 import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material.icons.filled.WarningAmber
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -68,6 +70,8 @@ const val SettingsWordsEnglishTag = "settings-words-english"
 const val SettingsWordsHindiTag = "settings-words-hindi"
 const val SettingsExportTag = "settings-export"
 const val SettingsImportTag = "settings-import"
+const val SettingsBetaToggleTag = "settings-beta-toggle"
+const val SettingsBetaConfirmTag = "settings-beta-confirm"
 
 /**
  * Settings, and the only place in the app that can reach the network.
@@ -90,6 +94,8 @@ fun SettingsScreen(
     val state by viewModel.updateState.collectAsStateWithLifecycle()
     val photosInChart by viewModel.photosInChart.collectAsStateWithLifecycle()
     val kinshipLanguage by viewModel.kinshipLanguage.collectAsStateWithLifecycle()
+    val betaChannel by viewModel.betaChannel.collectAsStateWithLifecycle()
+    var confirmingBeta by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier,
@@ -227,10 +233,86 @@ fun SettingsScreen(
             stringResource(R.string.about_fonts),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 16.dp, bottom = 40.dp),
+            modifier = Modifier.padding(top = 16.dp),
+        )
+
+        /*
+         * Last on the page, and meant to be.
+         *
+         * A beta is an unfinished build of an app somebody keeps their family in. Putting it under
+         * the licence notice rather than beside "Check for updates" is the honest placement: it is
+         * for people who came looking for it, and nobody should meet it while turning ordinary
+         * updates on.
+         */
+        SectionRule(stringResource(R.string.settings_section_beta))
+        SettingsSwitch(
+            title = stringResource(R.string.settings_beta_toggle),
+            body = stringResource(
+                if (enabled) R.string.settings_beta_explainer
+                else R.string.settings_beta_explainer_updates_off
+            ),
+            checked = betaChannel,
+            enabled = enabled,
+            onCheckedChange = { wanted ->
+                // Turning it off is not a decision worth interrupting; turning it on is.
+                if (wanted) confirmingBeta = true else viewModel.setBetaChannel(false)
+            },
+            tag = SettingsBetaToggleTag,
+        )
+
+        Spacer(Modifier.height(40.dp))
+    }
+    }
+
+    if (confirmingBeta) {
+        BetaOptInDialog(
+            onDismiss = { confirmingBeta = false },
+            onConfirm = {
+                confirmingBeta = false
+                viewModel.setBetaChannel(true)
+            },
         )
     }
-    }
+}
+
+/**
+ * What somebody is agreeing to before the updater will offer them an unfinished build.
+ *
+ * It states the one consequence that is not obvious and cannot be undone by flicking the switch
+ * back: Android will not install an older version over a newer one, so a beta keeps you on betas
+ * until the stable release passes it. Everything else here is a risk somebody can weigh; that is a
+ * fact they would otherwise discover afterwards.
+ */
+@Composable
+private fun BetaOptInDialog(onDismiss: () -> Unit, onConfirm: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Default.WarningAmber, contentDescription = null) },
+        title = { Text(stringResource(R.string.settings_beta_dialog_title)) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                Text(
+                    stringResource(R.string.settings_beta_dialog_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Text(
+                    stringResource(R.string.settings_beta_dialog_export),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm, modifier = Modifier.testTag(SettingsBetaConfirmTag)) {
+                Text(stringResource(R.string.settings_beta_dialog_confirm))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_beta_dialog_cancel))
+            }
+        },
+    )
 }
 
 /**
@@ -247,12 +329,14 @@ private fun SettingsSwitch(
     checked: Boolean,
     onCheckedChange: (Boolean) -> Unit,
     tag: String,
+    enabled: Boolean = true,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .toggleable(
                 value = checked,
+                enabled = enabled,
                 onValueChange = onCheckedChange,
                 role = Role.Switch,
             )

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsViewModel.kt
@@ -24,6 +24,11 @@ class SettingsViewModel(
     val updatesEnabled: StateFlow<Boolean> = preferences.enabled
     val updateState: StateFlow<UpdateState> = updates.state
 
+    /** Whether the updater may offer an unfinished release. See [UpdatePreferences.betaChannel]. */
+    val betaChannel: StateFlow<Boolean> = preferences.betaChannel
+
+    fun setBetaChannel(value: Boolean) = preferences.setBetaChannel(value)
+
     val photosInChart: StateFlow<Boolean> = chart.photosInChart
 
     fun setPhotosInChart(enabled: Boolean) = chart.setPhotosInChart(enabled)

--- a/app/src/main/java/com/vibethroughcode/ftree/update/Release.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/update/Release.kt
@@ -111,11 +111,50 @@ fun readRelease(
 ): ReleaseLookup {
     val payload = runCatching { json.decodeFromString<ReleasePayload>(body) }.getOrNull()
         ?: return ReleaseLookup.NoUsableRelease
+    return chooseFrom(listOf(payload), current, allowPreRelease)
+}
 
-    if (payload.draft) return ReleaseLookup.NoUsableRelease
-    if (payload.prerelease && !allowPreRelease) return ReleaseLookup.NoUsableRelease
+/**
+ * The same question asked of a *list* of releases.
+ *
+ * GitHub's `releases/latest` deliberately skips pre-releases, which is exactly right for the
+ * ordinary channel and useless for the other one. So the beta channel reads the full list and picks
+ * from it, which also means a beta reader is offered the newest thing on offer whether that happens
+ * to be a beta or the stable release that supersedes it.
+ */
+fun readReleases(
+    body: String,
+    current: AppVersion,
+    allowPreRelease: Boolean = false,
+): ReleaseLookup {
+    val payloads = runCatching { json.decodeFromString<List<ReleasePayload>>(body) }.getOrNull()
+        ?: return ReleaseLookup.NoUsableRelease
+    return chooseFrom(payloads, current, allowPreRelease)
+}
 
-    val version = AppVersion.parse(payload.tag) ?: return ReleaseLookup.NoUsableRelease
+/**
+ * Picks the newest release worth offering, and says why when there is none.
+ *
+ * Drafts never count: they are visible only to whoever is signed in as the author, and a draft is
+ * by definition not published. A pre-release counts only when the reader has asked for them.
+ *
+ * "Up to date" and "nothing usable" are told apart deliberately. The first is an answer; the second
+ * means the newest release has no APK attached to it, which is a state of the *repository* and not
+ * of the reader, and alarming somebody about it would be pointing at the wrong thing.
+ */
+private fun chooseFrom(
+    payloads: List<ReleasePayload>,
+    current: AppVersion,
+    allowPreRelease: Boolean,
+): ReleaseLookup {
+    val candidates = payloads
+        .filterNot { it.draft }
+        .filter { allowPreRelease || !it.prerelease }
+        .mapNotNull { payload -> AppVersion.parse(payload.tag)?.let { it to payload } }
+
+    if (candidates.isEmpty()) return ReleaseLookup.NoUsableRelease
+
+    val (version, payload) = candidates.maxByOrNull { it.first } ?: return ReleaseLookup.NoUsableRelease
     if (version <= current) return ReleaseLookup.UpToDate
 
     val apk = payload.assets.firstOrNull {

--- a/app/src/main/java/com/vibethroughcode/ftree/update/UpdateClient.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/update/UpdateClient.kt
@@ -20,11 +20,19 @@ import kotlin.coroutines.coroutineContext
  */
 class UpdateClient(
     private val releaseUrl: String = BuildConfig.UPDATE_RELEASE_URL,
+    private val releaseListUrl: String = BuildConfig.UPDATE_RELEASES_URL,
 ) {
 
-    /** Fetches the latest release as raw JSON. Parsing is [readRelease]'s job, and is pure. */
-    suspend fun fetchLatestRelease(): String = withContext(Dispatchers.IO) {
-        val connection = open(releaseUrl)
+    /**
+     * Fetches the release to consider, as raw JSON. Parsing is [readRelease]'s job, and is pure.
+     *
+     * [includePreReleases] chooses the endpoint rather than filtering afterwards, because GitHub's
+     * `releases/latest` does not merely hide pre-releases from the response — it answers a
+     * different question, and asking it would leave a beta reader looking at the stable release
+     * forever.
+     */
+    suspend fun fetchLatestRelease(includePreReleases: Boolean = false): String = withContext(Dispatchers.IO) {
+        val connection = open(if (includePreReleases) releaseListUrl else releaseUrl)
         connection.setRequestProperty("Accept", "application/vnd.github+json")
         try {
             val code = connection.responseCode

--- a/app/src/main/java/com/vibethroughcode/ftree/update/UpdatePreferences.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/update/UpdatePreferences.kt
@@ -31,6 +31,26 @@ class UpdatePreferences(context: Context) {
         }
     }
 
+    private val _betaChannel = MutableStateFlow(prefs.getBoolean(KEY_BETA, false))
+
+    /**
+     * Whether the updater is willing to offer an unfinished release.
+     *
+     * Separate from [enabled] rather than a third state of it, because they answer different
+     * questions: whether the app may ask GitHub anything at all, and which answer it will accept.
+     * Turning this on while update checking is off does nothing, which is the honest arrangement —
+     * no setting here can start a request on its own.
+     */
+    val betaChannel: StateFlow<Boolean> = _betaChannel.asStateFlow()
+
+    fun setBetaChannel(value: Boolean) {
+        prefs.edit().putBoolean(KEY_BETA, value).apply()
+        _betaChannel.value = value
+        // A version skipped on one channel means nothing on the other: leaving it behind would
+        // silently hide the first release the reader has just asked to be offered.
+        prefs.edit().remove(KEY_SKIPPED).apply()
+    }
+
     var lastCheckedAt: Long
         get() = prefs.getLong(KEY_LAST_CHECKED, 0L)
         set(value) = prefs.edit().putLong(KEY_LAST_CHECKED, value).apply()
@@ -44,5 +64,6 @@ class UpdatePreferences(context: Context) {
         const val KEY_ENABLED = "enabled"
         const val KEY_LAST_CHECKED = "last-checked"
         const val KEY_SKIPPED = "skipped-version"
+        const val KEY_BETA = "beta-channel"
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/update/UpdateRepository.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/update/UpdateRepository.kt
@@ -56,9 +56,13 @@ class UpdateRepository(
 
         _state.value = UpdateState.Checking
         try {
-            val body = client.fetchLatestRelease()
+            val beta = preferences.betaChannel.value
+            val body = client.fetchLatestRelease(includePreReleases = beta)
             val current = currentVersion ?: AppVersion(listOf(0))
-            _state.value = when (val lookup = readRelease(body, current)) {
+            val lookup =
+                if (beta) readReleases(body, current, allowPreRelease = true)
+                else readRelease(body, current)
+            _state.value = when (lookup) {
                 is ReleaseLookup.Newer -> {
                     val skipped = preferences.skippedVersion
                     if (!manual && skipped == lookup.update.version.toString()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -318,6 +318,20 @@
     <string name="settings_import_body">Merges another .ftree into yours. Nothing of yours is replaced, and a backup is written first.</string>
     <string name="settings_version">Version %1$s</string>
     <string name="settings_source">Source and releases</string>
+
+    <!--
+        The beta channel. Written to be read twice: once by somebody deciding, and once by somebody
+        who has already decided and wants to know what they agreed to.
+    -->
+    <string name="settings_section_beta">Beta releases</string>
+    <string name="settings_beta_toggle">Offer me beta releases</string>
+    <string name="settings_beta_explainer">Most people should leave this off. Betas are unfinished builds put out to be tested — they can be slow, wrong, or lose work, and a fix may take days. You will be offered them ahead of everyone else, which is the point and also the risk.</string>
+    <string name="settings_beta_explainer_updates_off">Turn on “Check for updates” above first. This only changes which release the updater offers you; on its own it does nothing.</string>
+    <string name="settings_beta_dialog_title">Take unfinished builds?</string>
+    <string name="settings_beta_dialog_body">A beta is a version that has not been through a full release. It may misbehave in ways the stable app does not, and turning this off afterwards will not move you back — Android will not install an older version over a newer one, so you will stay on betas until the next stable release passes the one you are on.</string>
+    <string name="settings_beta_dialog_export">Export your tree before you install one.</string>
+    <string name="settings_beta_dialog_confirm">Offer me betas</string>
+    <string name="settings_beta_dialog_cancel">Not now</string>
     <string name="settings_permissions_title">Permissions</string>
     <string name="settings_permissions_body">Two, both only for the updater above: internet access to ask GitHub about releases, and permission to install an update. Nothing else in the app touches the network.</string>
 

--- a/app/src/test/java/com/vibethroughcode/ftree/update/BetaChannelTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/update/BetaChannelTest.kt
@@ -1,0 +1,109 @@
+package com.vibethroughcode.ftree.update
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Which release each channel is willing to be offered.
+ *
+ * The separation is the whole feature: somebody on the ordinary channel must never be handed an
+ * unfinished build, and somebody on the beta channel must be offered whichever is newest — beta or
+ * the stable release that supersedes it.
+ */
+class BetaChannelTest {
+
+    private fun release(
+        tag: String,
+        prerelease: Boolean = false,
+        draft: Boolean = false,
+        apk: Boolean = true,
+    ) = """
+        {
+          "tag_name": "$tag",
+          "draft": $draft,
+          "prerelease": $prerelease,
+          "published_at": "2026-09-07T00:00:00Z",
+          "body": "notes",
+          "assets": ${if (apk) """[{"name":"f-tree-x.apk","browser_download_url":"https://example.com/x.apk","size":1}]""" else "[]"}
+        }
+    """.trimIndent()
+
+    private fun list(vararg releases: String) = releases.joinToString(",", "[", "]")
+
+    private val current = AppVersion.parse("0.5.1")!!
+
+    @Test
+    fun `the ordinary channel refuses a pre-release outright`() {
+        val lookup = readRelease(release("v0.6.0-beta.1", prerelease = true), current)
+        assertEquals(ReleaseLookup.NoUsableRelease, lookup)
+    }
+
+    @Test
+    fun `the beta channel is offered the newest beta`() {
+        val lookup = readReleases(
+            list(release("v0.6.0-beta.1", prerelease = true), release("v0.5.1")),
+            current,
+            allowPreRelease = true,
+        )
+        assertEquals("0.6.0-beta.1", (lookup as ReleaseLookup.Newer).update.version.toString())
+    }
+
+    @Test
+    fun `a beta reader is moved on to the stable release that supersedes it`() {
+        val onBeta = AppVersion.parse("0.6.0-beta.1")!!
+        val lookup = readReleases(
+            list(release("v0.6.0"), release("v0.6.0-beta.1", prerelease = true)),
+            onBeta,
+            allowPreRelease = true,
+        )
+        assertEquals("0.6.0", (lookup as ReleaseLookup.Newer).update.version.toString())
+    }
+
+    @Test
+    fun `a beta reader already on the newest beta is up to date`() {
+        val onBeta = AppVersion.parse("0.6.0-beta.1")!!
+        val lookup = readReleases(
+            list(release("v0.6.0-beta.1", prerelease = true), release("v0.5.1")),
+            onBeta,
+            allowPreRelease = true,
+        )
+        assertEquals(ReleaseLookup.UpToDate, lookup)
+    }
+
+    @Test
+    fun `reading the list on the ordinary channel still skips every pre-release`() {
+        val lookup = readReleases(
+            list(release("v0.6.0-beta.2", prerelease = true), release("v0.5.1")),
+            current,
+            allowPreRelease = false,
+        )
+        assertEquals(ReleaseLookup.UpToDate, lookup)
+    }
+
+    @Test
+    fun `drafts never count on either channel`() {
+        val lookup = readReleases(
+            list(release("v9.9.9", draft = true), release("v0.5.1")),
+            current,
+            allowPreRelease = true,
+        )
+        assertEquals(ReleaseLookup.UpToDate, lookup)
+    }
+
+    @Test
+    fun `a release with no apk attached is nothing to offer rather than an error`() {
+        val lookup = readReleases(
+            list(release("v0.6.0-beta.1", prerelease = true, apk = false)),
+            current,
+            allowPreRelease = true,
+        )
+        assertEquals(ReleaseLookup.NoUsableRelease, lookup)
+    }
+
+    @Test
+    fun `a beta loses to the same version without the suffix`() {
+        assertTrue(AppVersion.parse("0.6.0-beta.1")!! < AppVersion.parse("0.6.0")!!)
+        assertTrue(AppVersion.parse("0.5.1")!! < AppVersion.parse("0.6.0-beta.1")!!)
+    }
+}


### PR DESCRIPTION
**Not for merging into `main`** — this is a maintenance branch cut from the `v0.5.1` tag, opened so the release is reviewable. `main` already contains everything in it except the version number.

## Why it exists

0.5.1 has no way to ask for betas, so 0.6.0-beta.1 was published to an audience that could not reach it. This is the missing rung: install 0.5.2 through the ordinary updater, opt in, and the beta becomes reachable.

## What is in it

The beta channel commit, cherry-picked onto `v0.5.1`. **Deliberately not the sharing feature** — that is the thing the beta exists to test, and putting it in a stable release would defeat the point of having one.

Verified by inspection: no `BranchShare`, no share strings, no share entry points.

## versionCode 11, not 10

10 is already published as `0.6.0-beta.1`, and Android will not install a lower versionCode over a higher one. So the beta is re-cut above this as **0.6.0-beta.2** (code 12); otherwise opting in from 0.5.2 would offer a build that then refused to install.

0.6.0-beta.1 stays on the releases page as history. The beta channel always offers the newest by version name, so nobody is sent to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)