### PR TITLE
Version 0.6.0-beta.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 10
-        versionName = "0.6.0-beta.1"
+        versionCode = 12
+        versionName = "0.6.0-beta.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Same contents as `0.6.0-beta.1`, re-cut above `0.5.2`.

## Why

`beta.1` went out at versionCode **10**. `0.5.2` — the stable release that carries the opt-in, and therefore has to be installable by everyone on 0.5.1 — had to take **11**.

Android will not install a lower versionCode over a higher one, so `beta.1` could not have been installed from `0.5.2`, which is the only path it exists to be reached by. Code **12** fixes the ordering:

```
0.5.1            9
0.6.0-beta.1    10   ← unreachable from 0.5.2
0.5.2           11   ← carries the opt-in
0.6.0-beta.2    12   ← what opting in now offers
```

`beta.1` stays on the releases page as history. The channel always offers the newest by version *name*, so nobody is sent back to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)