### PR TITLE
Send a relationship as a picture

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,29 @@ importing will not overwrite anything they already have. Whether a given chat ap
 message beside the document is that app's decision — which is why the file is named after whose
 family it is. The name is the part that always arrives.
 
+### Sharing a relationship as a picture
+
+Sending a `.ftree` taught us something: **a chat app handed a document quietly drops the message
+that came with it.** The file arrives, the sentence explaining it does not. Handed an `image/png`,
+the same app shows the text beside the picture — Android's own share sheet does it too, which is how
+this was confirmed rather than assumed.
+
+So a relationship can also be sent as a card. Not a screenshot: a screenshot carries a status bar, a
+navigation bar and whatever font size the sender happens to use, none of which is the answer. The
+card is the app's own sentence and its own notation, laid out for the purpose, in two drawings of
+the same line — **Tree**, cards down a spine with each step named on the rule that makes it, and
+**List**, a register with a rail through the faces. The reader sees it before sending and picks.
+
+The preview *is* the card. The same composable is drawn on screen and recorded into the file through
+a `GraphicsLayer`, so there is no second rendering that could disagree with what was shown. Its
+density is pinned at three pixels to the point rather than read from the device, which is what makes
+the picture 1080 x 1350 from every phone; the preview scales that to fit after layout, so nothing is
+re-measured. The ground is painted opaque, because a PNG with transparent corners is at the mercy of
+whatever it lands on.
+
+A line of any length fits, because both ends are always shown and a middle that will not fit is
+counted rather than cut — "+4 more" is true where a silently shortened chain is not.
+
 ### Joining a shared branch to your own tree
 
 This is the other half of why it exists. Import the branch, then create one relationship between

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/transfer/CardShareTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/transfer/CardShareTest.kt
@@ -1,0 +1,70 @@
+package com.vibethroughcode.ftree.transfer
+
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * What leaves the app when a relationship is shared as a picture.
+ *
+ * The type is the point. A chat app handed `image/png` shows the message beside it; handed a
+ * document it drops the message, which is what sending a `.ftree` turned out to do.
+ */
+@RunWith(AndroidJUnit4::class)
+class CardShareTest {
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    private fun card(): Bitmap = Bitmap.createBitmap(1080, 1350, Bitmap.Config.ARGB_8888)
+
+    @Test
+    fun thePictureIsWrittenWhereAnotherAppCanReadIt() = runBlocking {
+        val uri = app.container.cardShare.write(card(), "Meena")
+
+        val bytes = app.contentResolver.openInputStream(uri)!!.use { it.readBytes() }
+        val decoded = BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        assertEquals(1080, decoded.width)
+        assertEquals(1350, decoded.height)
+        assertTrue("named after who it is about: $uri", uri.toString().endsWith("Meena.png"))
+    }
+
+    @Test
+    fun theLastPictureGoesWhenTheNextIsMade() = runBlocking {
+        app.container.cardShare.write(card(), "Meena")
+        app.container.cardShare.write(card(), "Vinod Kumar")
+
+        val directory = java.io.File(app.cacheDir, "shared")
+        assertEquals(listOf("Vinod-Kumar.png"), directory.list()!!.toList())
+    }
+
+    @Test
+    fun theIntentIsAPictureWithSomethingSaidBesideIt() {
+        val uri = Uri.parse("content://example/card.png")
+        val caption = "Meena is Ankit Kumar's aunt."
+        val intent = sendCardIntent(uri, caption)
+
+        assertEquals(Intent.ACTION_SEND, intent.action)
+        // Not the document type the branch share uses: that is the whole difference.
+        assertEquals("image/png", intent.type)
+        assertEquals(uri, intent.getParcelableExtra(Intent.EXTRA_STREAM, Uri::class.java))
+        assertEquals(caption, intent.getStringExtra(Intent.EXTRA_TEXT))
+        assertTrue(intent.flags and Intent.FLAG_GRANT_READ_URI_PERMISSION != 0)
+    }
+
+    @Test
+    fun aNameWithNothingUsableInItStillMakesAFile() = runBlocking {
+        val uri = app.container.cardShare.write(card(), "   ")
+        assertTrue(uri.toString().endsWith("relationship.png"))
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt
@@ -7,6 +7,7 @@ import com.vibethroughcode.ftree.data.FamilyRepository
 import com.vibethroughcode.ftree.data.KinshipPreferences
 import com.vibethroughcode.ftree.data.PhotoStore
 import com.vibethroughcode.ftree.transfer.BranchShare
+import com.vibethroughcode.ftree.transfer.CardShare
 import com.vibethroughcode.ftree.transfer.TreeExporter
 import com.vibethroughcode.ftree.transfer.TreeIdentity
 import com.vibethroughcode.ftree.transfer.TreeImporter
@@ -31,6 +32,7 @@ class AppContainer(context: Context) {
     val treeIdentity: TreeIdentity by lazy { TreeIdentity(context.applicationContext) }
     val exporter: TreeExporter by lazy { TreeExporter(familyRepository, photoStore, treeIdentity) }
     val branchShare: BranchShare by lazy { BranchShare(context, familyRepository, exporter) }
+    val cardShare: CardShare by lazy { CardShare(context) }
     val importer: TreeImporter by lazy {
         TreeImporter(
             database = database,

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/CardShare.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/CardShare.kt
@@ -1,0 +1,59 @@
+package com.vibethroughcode.ftree.transfer
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * Writes a picture of a relationship somewhere another app can read it.
+ *
+ * The same cache directory and the same provider the branch share uses, for the same reasons: it is
+ * a message rather than a document, nobody wants to name it, and the last one goes when the next is
+ * made. PNG rather than JPEG because the card is flat colour, a hairline rule and small type — all
+ * three of which JPEG blurs at exactly the sizes that matter.
+ */
+class CardShare(private val context: Context) {
+
+    suspend fun write(bitmap: Bitmap, name: String): Uri = withContext(Dispatchers.IO) {
+        val directory = File(context.cacheDir, DIRECTORY)
+        directory.deleteRecursively()
+        directory.mkdirs()
+
+        val file = File(directory, fileNameFor(name))
+        file.outputStream().use { bitmap.compress(Bitmap.CompressFormat.PNG, 100, it) }
+        FileProvider.getUriForFile(context, "${context.packageName}.shares", file)
+    }
+
+    private fun fileNameFor(name: String): String {
+        val stem = name.trim()
+            .replace(Regex("[^\\p{L}\\p{N}]+"), "-")
+            .trim('-')
+            .take(48)
+            .ifBlank { "relationship" }
+        return "$stem.png"
+    }
+
+    private companion object {
+        const val DIRECTORY = "shared"
+    }
+}
+
+/**
+ * The intent that carries a picture out of the app.
+ *
+ * `image/png` rather than a document type, which is the whole reason this exists: a chat app treats
+ * a picture as something to say a sentence about and shows the text beside it, where the same app
+ * handed a file quietly drops the message.
+ */
+fun sendCardIntent(uri: Uri, caption: String?): Intent =
+    Intent(Intent.ACTION_SEND).apply {
+        type = "image/png"
+        putExtra(Intent.EXTRA_STREAM, uri)
+        caption?.let { putExtra(Intent.EXTRA_TEXT, it) }
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+    }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationCard.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationCard.kt
@@ -1,0 +1,373 @@
+package com.vibethroughcode.ftree.ui.relation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.graph.Relation
+import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
+import com.vibethroughcode.ftree.ui.common.PersonAvatar
+import com.vibethroughcode.ftree.ui.common.asRelativeKind
+import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
+import com.vibethroughcode.ftree.ui.theme.FTreeText
+import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+
+/** Which drawing of the line between two people the card carries. */
+enum class CardStyle { TREE, LIST }
+
+/**
+ * The card's size in its own units. Rendered at three pixels to the point, so the image is always
+ * 1080 x 1350 whatever the phone it was made on — the shape a chat app expects, and the same file
+ * from every device.
+ */
+val CARD_WIDTH = 360.dp
+val CARD_HEIGHT = 450.dp
+
+/** How many people the body can show before it starts summarising. */
+private const val TREE_SEATS = 4
+private const val LIST_SEATS = 5
+
+/**
+ * Every card on the tree is the same width.
+ *
+ * Boxes sized to their names would step in and out down the page and the connectors would meet them
+ * off-centre; one width gives the drawing a spine, which is what makes it read as descent rather
+ * than as a list that has been boxed.
+ */
+private val TREE_CARD_WIDTH = 208.dp
+
+/**
+ * A relationship, as something you can send.
+ *
+ * The app answers "how are we related" in two registers — the sentence and the line it was worked
+ * out along — and the card keeps both, because the sentence alone is a claim and the line is what
+ * makes it checkable by somebody who knows the family. What it does not do is screenshot the app:
+ * a screenshot carries a status bar, a navigation bar and whatever the reader's font size happens
+ * to be, and none of that is the answer.
+ *
+ * Nothing is invented for the picture. It is the same sentence [answerSentence] writes on the
+ * screen, in the same vocabulary the reader has chosen, using the app's own notation for a card and
+ * a connector — so what arrives in somebody's chat is recognisably the thing they were shown.
+ */
+@Composable
+fun RelationCard(
+    state: RelationUiState,
+    relation: Relation.Found,
+    style: CardStyle,
+    modifier: Modifier = Modifier,
+) {
+    val accents = FTreeTheme.accents
+    val answer = answerSentence(state, relation)
+    val from = state.from ?: return
+
+    /*
+     * An opaque ground under a rounded card, rather than a rounded card on nothing.
+     *
+     * A PNG with transparent corners is at the mercy of whatever it lands on: some chat apps
+     * composite it onto black and the card grows four dark ears. Painting the whole frame means the
+     * picture is the same everywhere, and gives the card an edge to sit on.
+     */
+    Box(
+        modifier = modifier
+            .size(CARD_WIDTH, CARD_HEIGHT)
+            .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+            .padding(14.dp),
+    ) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(18.dp))
+            .background(MaterialTheme.colorScheme.background)
+            .border(1.dp, accents.rule, RoundedCornerShape(18.dp))
+            .padding(horizontal = 24.dp, vertical = 22.dp),
+    ) {
+        Text(
+            text = stringResource(R.string.app_name).uppercase(),
+            style = FTreeText.sectionLabel,
+            color = accents.unknown,
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Text(
+            text = answer?.sentence
+                ?: stringResource(
+                    R.string.card_connected,
+                    from.displayName(),
+                    state.to?.displayName().orEmpty(),
+                ),
+            style = MaterialTheme.typography.headlineSmall.copy(fontSize = 22.sp, lineHeight = 29.sp),
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 4,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Spacer(Modifier.height(10.dp))
+
+        Text(
+            text = stringResource(R.string.card_steps, relation.steps),
+            style = FTreeText.recordSmall,
+            color = accents.unknown,
+        )
+
+        Spacer(Modifier.height(16.dp))
+        HorizontalDivider(color = accents.rule)
+
+        Box(
+            modifier = Modifier.fillMaxWidth().weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            val people = listOf(from) + state.chain.map { it.person }
+            val roles = listOf<String?>(null) + state.chain.map { link ->
+                stringResource(
+                    relativeRoleLabel(
+                        link.kind.asRelativeKind(),
+                        link.person.gender,
+                        LocalKinshipLanguage.current,
+                    )
+                )
+            }
+            when (style) {
+                CardStyle.TREE -> TreeBody(people, roles)
+                CardStyle.LIST -> ListBody(people, roles)
+            }
+        }
+
+        HorizontalDivider(color = accents.rule)
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = stringResource(R.string.card_footer),
+            style = FTreeText.recordSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    }
+}
+
+/**
+ * The line drawn as a descent: cards down the middle, joined by the app's own connector, with each
+ * step named on the rule that makes it.
+ *
+ * This is the shape somebody recognises as a family tree, which is why it is the one the card
+ * offers first.
+ */
+@Composable
+private fun TreeBody(people: List<Person>, roles: List<String?>) {
+    val accents = FTreeTheme.accents
+    val shown = seat(people, roles, TREE_SEATS)
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        shown.forEachIndexed { index, seat ->
+            if (index > 0) {
+                Connector(label = seat.role, hidden = seat.person == null)
+            }
+            when (val person = seat.person) {
+                null -> Text(
+                    text = stringResource(R.string.card_more, seat.skipped),
+                    style = FTreeText.recordSmall,
+                    color = accents.unknown,
+                )
+
+                else -> Row(
+                    modifier = Modifier
+                        .width(TREE_CARD_WIDTH)
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.surfaceContainerLow)
+                        .border(1.dp, accents.rule, RoundedCornerShape(12.dp))
+                        .padding(horizontal = 12.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                ) {
+                    PersonAvatar(person, diameter = 26.dp, decorative = true)
+                    Name(person, style = MaterialTheme.typography.titleSmall)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The rule between two cards, with the step written beside it.
+ *
+ * The line is centred on the card above and below it and the label hangs off it, rather than the
+ * two sharing a row — otherwise the width of the word decides where the spine goes, and a long one
+ * bends the whole drawing.
+ */
+@Composable
+private fun Connector(label: String?, hidden: Boolean) {
+    val accents = FTreeTheme.accents
+    Box(
+        modifier = Modifier.width(TREE_CARD_WIDTH).height(26.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Box(
+            Modifier
+                .width(1.dp)
+                .height(26.dp)
+                .background(if (hidden) Color.Transparent else accents.rule)
+        )
+        label?.let {
+            Text(
+                text = it,
+                style = FTreeText.recordSmall,
+                color = accents.unknown,
+                modifier = Modifier.align(Alignment.Center).padding(start = 96.dp),
+            )
+        }
+    }
+}
+
+/**
+ * The same line as a register: one person to a row, each saying what they are to the one above.
+ *
+ * Plainer than the tree and better for a longer line, where boxes and connectors become a ladder
+ * nobody reads.
+ */
+@Composable
+private fun ListBody(people: List<Person>, roles: List<String?>) {
+    val accents = FTreeTheme.accents
+    val shown = seat(people, roles, LIST_SEATS)
+
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(2.dp),
+    ) {
+        shown.forEachIndexed { index, seat ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                /*
+                 * A rail through the faces, joining one row to the next.
+                 *
+                 * Without it this is a list of people who happen to be near each other. The line is
+                 * what says they are a route, which is the whole difference between this card and a
+                 * screenshot of a contacts app.
+                 */
+                Box(
+                    modifier = Modifier.size(32.dp, 46.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (index > 0) {
+                        Box(
+                            Modifier
+                                .width(1.dp)
+                                .height(23.dp)
+                                .align(Alignment.TopCenter)
+                                .background(accents.rule)
+                        )
+                    }
+                    if (index < shown.lastIndex) {
+                        Box(
+                            Modifier
+                                .width(1.dp)
+                                .height(23.dp)
+                                .align(Alignment.BottomCenter)
+                                .background(accents.rule)
+                        )
+                    }
+                    when (val person = seat.person) {
+                        null -> Box(
+                            Modifier
+                                .size(7.dp)
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(accents.unknown)
+                        )
+
+                        else -> PersonAvatar(person, diameter = 32.dp, decorative = true)
+                    }
+                }
+
+                Column(Modifier.weight(1f)) {
+                    when (val person = seat.person) {
+                        null -> Text(
+                            text = stringResource(R.string.card_more, seat.skipped),
+                            style = FTreeText.recordSmall,
+                            color = accents.unknown,
+                        )
+
+                        else -> {
+                            Name(person, style = MaterialTheme.typography.titleSmall)
+                            seat.role?.let {
+                                Text(
+                                    text = it,
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Name(person: Person, style: androidx.compose.ui.text.TextStyle) {
+    val accents = FTreeTheme.accents
+    Text(
+        text = person.displayName(),
+        style = style,
+        fontStyle = if (person.isUnnamed) FontStyle.Italic else FontStyle.Normal,
+        color = if (person.isUnnamed) accents.unknown else MaterialTheme.colorScheme.onSurface,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        textAlign = TextAlign.Start,
+    )
+}
+
+/** A place on the card: somebody, or the note standing in for the people who did not fit. */
+private data class Seat(val person: Person?, val role: String?, val skipped: Int = 0)
+
+/**
+ * Fits a line of any length into a fixed card.
+ *
+ * A card that grew with the family would be a different picture every time and a poor one for a
+ * long line. So both ends are always shown — they are the two people the question was about — and
+ * where the middle does not fit it is counted rather than cut, because "and four more" is true and
+ * a silently shortened chain is not.
+ */
+private fun seat(people: List<Person>, roles: List<String?>, seats: Int): List<Seat> {
+    if (people.size <= seats) {
+        return people.mapIndexed { index, person -> Seat(person, roles.getOrNull(index)) }
+    }
+    val head = seats / 2
+    val tail = seats - head - 1
+    return buildList {
+        repeat(head) { add(Seat(people[it], roles.getOrNull(it))) }
+        add(Seat(null, null, skipped = people.size - head - tail))
+        for (i in people.size - tail until people.size) add(Seat(people[i], roles.getOrNull(i)))
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationScreen.kt
@@ -1,5 +1,7 @@
 package com.vibethroughcode.ftree.ui.relation
 
+import android.content.Intent
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,6 +21,7 @@ import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.PersonSearch
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.SwapVert
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -28,6 +31,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -36,12 +40,15 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -50,10 +57,12 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.vibethroughcode.ftree.FTreeApplication
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.graph.KinshipTerm
 import com.vibethroughcode.ftree.graph.Relation
+import com.vibethroughcode.ftree.transfer.sendCardIntent
 import com.vibethroughcode.ftree.ui.FTreeViewModels
 import com.vibethroughcode.ftree.ui.common.PersonAvatar
 import com.vibethroughcode.ftree.ui.common.PersonRow
@@ -66,6 +75,7 @@ import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.common.asRelativeKind
 import com.vibethroughcode.ftree.ui.theme.FTreeText
+import kotlinx.coroutines.launch
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 
 const val RelationSlotFromTag = "relation-slot-from"
@@ -76,6 +86,7 @@ const val RelationChainTag = "relation-chain"
 const val RelationPickListTag = "relation-pick-list"
 const val RelationPickSearchTag = "relation-pick-search"
 const val RelationShowOnChartTag = "relation-show-on-chart"
+const val RelationShareCardTag = "relation-share-card"
 
 /**
  * How two people are related.
@@ -99,6 +110,7 @@ fun RelationScreen(
     val state by viewModel.uiState.collectAsStateWithLifecycle()
     val query by viewModel.currentQuery.collectAsStateWithLifecycle()
     var picking by rememberSaveable { mutableStateOf<RelationSlot?>(null) }
+    var sharing by rememberSaveable { mutableStateOf(false) }
 
     Scaffold(
         modifier = modifier,
@@ -149,10 +161,54 @@ fun RelationScreen(
                     onSwap = viewModel::swap,
                     onOpenPerson = onOpenPerson,
                     onShowOnChart = { onShowOnChart(state.trace) },
+                    onShare = { sharing = true },
                 )
             }
         }
     }
+
+    val found = state.relation as? Relation.Found
+    if (sharing && found != null) {
+        ShareCard(state = state, relation = found, onDismiss = { sharing = false })
+    }
+}
+
+/**
+ * Making the picture and handing it over.
+ *
+ * Kept here rather than in a view model because it is one screen's business and the whole of it is
+ * Android: a bitmap, a file, an intent. The chooser opens on the file being written, so nothing is
+ * left in the cache that was never sent anywhere.
+ */
+@Composable
+private fun ShareCard(
+    state: RelationUiState,
+    relation: Relation.Found,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val app = context.applicationContext as FTreeApplication
+    val failed = stringResource(R.string.card_failed)
+
+    ShareRelationDialog(
+        state = state,
+        relation = relation,
+        onDismiss = onDismiss,
+        onSend = { picture ->
+            scope.launch {
+                runCatching {
+                    val uri = app.container.cardShare.write(picture.image.asAndroidBitmap(), picture.name)
+                    context.startActivity(
+                        Intent.createChooser(sendCardIntent(uri, picture.caption), null)
+                    )
+                }.onFailure {
+                    Toast.makeText(context, failed, Toast.LENGTH_LONG).show()
+                }
+                onDismiss()
+            }
+        },
+    )
 }
 
 @Composable
@@ -162,6 +218,7 @@ private fun Answer(
     onSwap: () -> Unit,
     onOpenPerson: (String) -> Unit,
     onShowOnChart: () -> Unit,
+    onShare: () -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxHeight().readableMeasure(),
@@ -235,18 +292,34 @@ private fun Answer(
                 )
             }
             item {
-                Button(
-                    onClick = onShowOnChart,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 20.dp, vertical = 16.dp)
-                        .testTag(RelationShowOnChartTag),
+                Column(
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
-                    Icon(Icons.Default.AccountTree, contentDescription = null)
-                    Text(
-                        text = stringResource(R.string.relation_show_on_chart),
-                        modifier = Modifier.padding(start = 12.dp),
-                    )
+                    Button(
+                        onClick = onShowOnChart,
+                        modifier = Modifier.fillMaxWidth().testTag(RelationShowOnChartTag),
+                    ) {
+                        Icon(Icons.Default.AccountTree, contentDescription = null)
+                        Text(
+                            text = stringResource(R.string.relation_show_on_chart),
+                            modifier = Modifier.padding(start = 12.dp),
+                        )
+                    }
+                    // Only offered where there is an answer to send. A picture of two people the
+                    // record does not join is not a thing anybody wants in a family group.
+                    if (state.relation is Relation.Found) {
+                        OutlinedButton(
+                            onClick = onShare,
+                            modifier = Modifier.fillMaxWidth().testTag(RelationShareCardTag),
+                        ) {
+                            Icon(Icons.Default.Share, contentDescription = null)
+                            Text(
+                                text = stringResource(R.string.card_share),
+                                modifier = Modifier.padding(start = 12.dp),
+                            )
+                        }
+                    }
                 }
             }
         }
@@ -483,7 +556,7 @@ private fun PersonPicker(
 }
 
 /** The answer, and whether a birth year would sharpen it. */
-private data class Answer(val sentence: String, val needsBirthYears: Boolean = false)
+internal data class Answer(val sentence: String, val needsBirthYears: Boolean = false)
 
 /**
  * How the relationship reads as a sentence, or nothing when the record cannot say.
@@ -494,7 +567,7 @@ private data class Answer(val sentence: String, val needsBirthYears: Boolean = f
  * Ankit's first cousin once removed" — same fact, said the way a person would say it.
  */
 @Composable
-private fun answerSentence(state: RelationUiState, relation: Relation.Found): Answer? {
+internal fun answerSentence(state: RelationUiState, relation: Relation.Found): Answer? {
     val to = state.to ?: return null
     val from = state.from ?: return null
     val term = relation.term ?: return null

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/ShareRelationDialog.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/ShareRelationDialog.kt
@@ -1,0 +1,260 @@
+package com.vibethroughcode.ftree.ui.relation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.layer.drawLayer
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.graph.Relation
+import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.theme.FTreeText
+import kotlinx.coroutines.launch
+
+const val ShareCardTreeTag = "share-card-tree"
+const val ShareCardListTag = "share-card-list"
+const val ShareCardSendTag = "share-card-send"
+const val ShareCardPreviewTag = "share-card-preview"
+
+/** The picture that will be sent, and what will be said beside it. */
+data class RelationPicture(val image: ImageBitmap, val name: String, val caption: String)
+
+/**
+ * Seeing the card before sending it.
+ *
+ * The preview *is* the card: the same composable is drawn on screen and recorded into the file, so
+ * there is no second rendering that could disagree with what was shown. It is scaled to fit rather
+ * than re-laid out, which is why the picture is the same 1080 x 1350 whatever phone made it.
+ *
+ * A picture rather than a screenshot, and rather than a document. A chat app treats a picture as
+ * something to say a sentence about and shows the message beside it; handed a file, the same app
+ * quietly drops it.
+ */
+@Composable
+fun ShareRelationDialog(
+    state: RelationUiState,
+    relation: Relation.Found,
+    onDismiss: () -> Unit,
+    onSend: (RelationPicture) -> Unit,
+) {
+    var style by rememberSaveable { mutableStateOf(CardStyle.TREE) }
+    var working by remember { mutableStateOf(false) }
+    val layer = rememberGraphicsLayer()
+    val scope = rememberCoroutineScope()
+
+    val answer = answerSentence(state, relation)
+    val fromName = state.from?.displayName().orEmpty()
+    val toName = state.to?.displayName().orEmpty()
+    val headline = answer?.sentence
+        ?: stringResource(R.string.card_connected, fromName, toName)
+    val caption = stringResource(R.string.card_caption, headline, stringResource(R.string.card_footer))
+    val fileName = state.to?.name.orEmpty().ifBlank { "relationship" }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Surface(Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.surfaceContainerLowest) {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .statusBarsPadding()
+                    .navigationBarsPadding(),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(start = 4.dp, end = 12.dp, top = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = stringResource(R.string.edit_back))
+                    }
+                    Text(
+                        text = stringResource(R.string.card_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+
+                Box(
+                    modifier = Modifier.fillMaxWidth().weight(1f).padding(horizontal = 20.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CardPreview(state, relation, style, layer)
+                }
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .widthIn(max = 480.dp)
+                        .padding(horizontal = 20.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+                        SegmentedButton(
+                            selected = style == CardStyle.TREE,
+                            onClick = { style = CardStyle.TREE },
+                            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                            modifier = Modifier.testTag(ShareCardTreeTag),
+                        ) { Text(stringResource(R.string.card_style_tree)) }
+                        SegmentedButton(
+                            selected = style == CardStyle.LIST,
+                            onClick = { style = CardStyle.LIST },
+                            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                            modifier = Modifier.testTag(ShareCardListTag),
+                        ) { Text(stringResource(R.string.card_style_list)) }
+                    }
+
+                    // Shown rather than hidden: somebody about to post this in a family group should
+                    // know what is going with it before the chat app opens, not after.
+                    Column {
+                        Text(
+                            text = stringResource(R.string.card_caption_label),
+                            style = FTreeText.sectionLabel,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                        Text(
+                            text = caption,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(top = 6.dp),
+                        )
+                    }
+
+                    Button(
+                        onClick = {
+                            if (working) return@Button
+                            working = true
+                            scope.launch {
+                                val image = layer.toImageBitmap()
+                                onSend(RelationPicture(image, fileName, caption))
+                                working = false
+                            }
+                        },
+                        modifier = Modifier.fillMaxWidth().testTag(ShareCardSendTag),
+                    ) {
+                        if (working) {
+                            CircularProgressIndicator(
+                                Modifier.size(18.dp),
+                                strokeWidth = 2.dp,
+                                color = MaterialTheme.colorScheme.onPrimary,
+                            )
+                        } else {
+                            Icon(Icons.Default.Share, contentDescription = null, modifier = Modifier.size(18.dp))
+                        }
+                        Spacer(Modifier.size(10.dp))
+                        Text(stringResource(R.string.card_send))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The card at its true size, shown at whatever size the screen has.
+ *
+ * The density inside is pinned rather than taken from the device, which is what makes the picture
+ * identical from every phone: three pixels to the point means the 360 by 450 card is always
+ * 1080 by 1350. The preview then scales that down to fit, after layout, so nothing is re-measured
+ * and the thing recorded is exactly the thing on screen.
+ */
+@Composable
+private fun CardPreview(
+    state: RelationUiState,
+    relation: Relation.Found,
+    style: CardStyle,
+    layer: androidx.compose.ui.graphics.layer.GraphicsLayer,
+) {
+    val outer = LocalDensity.current
+    BoxWithConstraints(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        val widthPx = CARD_PIXEL_WIDTH
+        val heightPx = CARD_PIXEL_HEIGHT
+        val scale = minOf(
+            constraints.maxWidth / widthPx.toFloat(),
+            constraints.maxHeight / heightPx.toFloat(),
+        ).coerceAtMost(1f)
+
+        Box(
+            modifier = Modifier
+                .size(with(outer) { (widthPx * scale).toDp() }, with(outer) { (heightPx * scale).toDp() })
+                .testTag(ShareCardPreviewTag),
+        ) {
+            CompositionLocalProvider(LocalDensity provides Density(CARD_DENSITY, 1f)) {
+                Box(
+                    Modifier
+                        .requiredSize(CARD_WIDTH, CARD_HEIGHT)
+                        .graphicsLayer {
+                            scaleX = scale
+                            scaleY = scale
+                            transformOrigin = TransformOrigin(0f, 0f)
+                        }
+                        .drawWithContent {
+                            layer.record { this@drawWithContent.drawContent() }
+                            drawLayer(layer)
+                        },
+                ) {
+                    RelationCard(state = state, relation = relation, style = style)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Three pixels to the point, and the size that falls out of it.
+ *
+ * Pinned rather than read from the device so that the same relationship makes the same picture on
+ * every phone — and so the file is the shape a chat app expects rather than whatever aspect the
+ * sender's screen happened to be.
+ */
+const val CARD_DENSITY = 3f
+const val CARD_PIXEL_WIDTH = 1080
+const val CARD_PIXEL_HEIGHT = 1350

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,19 @@
     <string name="export_failed">Couldn\'t write that file. Try somewhere else.</string>
 
     <!-- Sharing one person's branch -->
+    <!-- The shareable relationship card -->
+    <string name="card_steps">%1$d steps apart</string>
+    <string name="card_connected">%1$s and %2$s are related.</string>
+    <string name="card_more">+%1$d more</string>
+    <string name="card_footer">ftree.vibethroughcode.com</string>
+    <string name="card_share">Share this relationship</string>
+    <string name="card_title">Share</string>
+    <string name="card_style_tree">Tree</string>
+    <string name="card_style_list">List</string>
+    <string name="card_caption_label">Sent with the picture</string>
+    <string name="card_send">Send</string>
+    <string name="card_failed">Couldn\'t make that picture.</string>
+    <string name="card_caption">%1$s\n\nWorked out in f-tree, a family tree that stays on your phone: %2$s</string>
     <string name="share_branch">Share this family</string>
     <string name="share_chooser_title">Send %1$s\'s family</string>
     <string name="share_failed">Couldn\'t prepare that family to send.</string>


### PR DESCRIPTION
You found that a `.ftree` arrives without its message. This adds the other kind of share — and confirms why.

## The diagnostic, first

Android's own share sheet tells the story:

| shared as | sheet says | caption |
|---|---|---|
| `.ftree` document | *"Sharing 1 file"* + a file card | **nothing** |
| `image/png` card | *"Sharing image"* + the text | **shown** |

So it is the *type*, not the code. A chat app treats a picture as something to say a sentence about; handed a document it drops the message. Your WhatsApp result and the system sheet agree.

## The card

**Not a screenshot.** A screenshot carries a status bar, a navigation bar and whatever font size the sender happens to use, none of which is the answer. This is the app's own sentence and its own notation, laid out for the purpose.

Two drawings of the same line, chosen before sending:

- **Tree** — cards down a spine, each step named on the rule that makes it. One card width throughout, so the connectors meet them centred and it reads as descent rather than a boxed list.
- **List** — a register, with a rail through the faces. Without the rail it is a list of people who happen to be near each other; the line is what says they are a route.

## How it is rendered

**The preview *is* the card.** The same composable is drawn on screen and recorded into the file through a `GraphicsLayer`, so there is no second rendering that could disagree with what was shown.

Its density is pinned at **3 px to the point** rather than read from the device — that is what makes the picture **1080 × 1350 from every phone**, the shape a chat app expects, rather than whatever aspect the sender's screen happened to be. The preview scales that down to fit *after* layout, so nothing is re-measured.

The ground is painted **opaque**: a PNG with transparent corners is at the mercy of whatever it lands on, and some apps composite it onto black.

A line of any length fits — both ends are always shown, and a middle that will not fit is **counted rather than cut** (`+4 more`), because that is true and a silently shortened chain is not.

## Where it is

On the relation answer, under "Show on the chart", and only when there *is* an answer — a picture of two people the record does not join is not something anybody wants in a family group.

The caption is shown on the preview screen before you send, so you know what is going with it.

## Verification

188 unit tests, **142 instrumented** (4 new), lint clean. Exercised on device end to end: both styles previewed, sent, and the exported PNG pulled off the device and checked — 1080×1350, fully opaque, correct content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)