### PR TITLE
Version 0.6.0-beta.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 12
-        versionName = "0.6.0-beta.2"
+        versionCode = 13
+        versionName = "0.6.0-beta.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Bumps to **0.6.0-beta.3** (versionCode 13) so the relationship card (#57) goes out on the beta channel.

It is also the experiment: Android's share sheet shows a caption beside an `image/png` and drops it beside a document, which matches what you saw in WhatsApp. Installing this beta and sharing a relationship is the confirmation on a real chat app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)