### PR TITLE
One card, sized to the room it has

### DIFF
--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationCardTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/RelationCardTest.kt
@@ -1,0 +1,242 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asAndroidBitmap
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.isDialog
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.Density
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.data.Gender
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.graph.Relation
+import com.vibethroughcode.ftree.graph.RelationStep
+import com.vibethroughcode.ftree.graph.StepKind
+import com.vibethroughcode.ftree.ui.relation.CARD_DENSITY
+import com.vibethroughcode.ftree.ui.relation.CARD_HEIGHT
+import com.vibethroughcode.ftree.ui.relation.CARD_WIDTH
+import com.vibethroughcode.ftree.ui.relation.ChainLink
+import com.vibethroughcode.ftree.ui.relation.RelationCard
+import com.vibethroughcode.ftree.ui.relation.RelationPicture
+import com.vibethroughcode.ftree.ui.relation.RelationUiState
+import com.vibethroughcode.ftree.ui.relation.ShareCardPreviewTag
+import com.vibethroughcode.ftree.ui.relation.ShareCardSendTag
+import com.vibethroughcode.ftree.ui.relation.ShareRelationDialog
+import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import java.io.File
+import java.io.FileOutputStream
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * The picture that gets sent, measured rather than looked at.
+ *
+ * The card is a fixed 360 by 450 and the sentence above the people is not, so the only question
+ * that matters here is whether what is drawn stays inside its own frame. "Nearly overflowing" and
+ * "overflowing" look identical in a screenshot, so every claim below is a comparison of bounds.
+ */
+@RunWith(AndroidJUnit4::class)
+class RelationCardTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val footer = "ftree.vibethroughcode.com"
+
+    private fun chain(vararg names: String): RelationUiState {
+        val people = names.map { Person(name = it, gender = Gender.MALE) }
+        return RelationUiState(
+            loading = false,
+            from = people.first(),
+            to = people.last(),
+            chain = people.drop(1).map { ChainLink(it, StepKind.PARENT) },
+        )
+    }
+
+    private fun found(state: RelationUiState) = Relation.Found(
+        chain = state.chain.map { RelationStep(it.person.id, it.kind) },
+        term = null,
+        sharedAncestorId = null,
+    )
+
+    /** Composes the card at the size it is exported at, and keeps the image for a human to see. */
+    private fun show(state: RelationUiState, name: String) {
+        rule.setContent {
+            FTreeTheme(darkTheme = true) {
+                CompositionLocalProvider(LocalDensity provides Density(CARD_DENSITY, 1f)) {
+                    Box(Modifier.requiredSize(CARD_WIDTH, CARD_HEIGHT).testTag("card")) {
+                        RelationCard(state = state, relation = found(state))
+                    }
+                }
+            }
+        }
+        val image = rule.onNodeWithTag("card").captureToImage().asAndroidBitmap()
+        val directory = InstrumentationRegistry.getInstrumentation()
+            .targetContext.getExternalFilesDir(null)!!
+        FileOutputStream(File(directory, "$name.png")).use {
+            image.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+
+    /** Nobody drawn on the card may run into the rule above the footer. */
+    private fun assertFitsAboveTheFooter(last: String) {
+        val bottom = rule.onNodeWithText(last).getUnclippedBoundsInRoot().bottom
+        val footerTop = rule.onNodeWithText(footer).getUnclippedBoundsInRoot().top
+        assertTrue("$last ends at $bottom, past the footer at $footerTop", bottom <= footerTop)
+    }
+
+    @Test
+    fun fourPeopleFitWithoutBeingSquashedIntoTheFooter() {
+        val state = chain("Ankit Srivastava", "Pragya Srivastava", "Kinshuk Srivastava", "Akshit Srivastava")
+        show(state, "card-four")
+
+        // All four, because four is what there was room for — the count is what the card avoids
+        // when it can, not something it reaches for.
+        rule.onNodeWithText("Ankit Srivastava").assertIsDisplayed()
+        rule.onNodeWithText("Pragya Srivastava").assertIsDisplayed()
+        rule.onNodeWithText("Kinshuk Srivastava").assertIsDisplayed()
+        rule.onNodeWithText("Akshit Srivastava").assertIsDisplayed()
+        assertFitsAboveTheFooter("Akshit Srivastava")
+    }
+
+    @Test
+    fun twoPeopleSitTogetherRatherThanDriftingApart() {
+        val state = chain("Ankit Srivastava", "Sarika Srivastava")
+        show(state, "card-two")
+
+        rule.onNodeWithText("Sarika Srivastava").assertIsDisplayed()
+        assertFitsAboveTheFooter("Sarika Srivastava")
+    }
+
+    /**
+     * The case that was wrong: a Hindi term with its English gloss runs to four lines, and the
+     * fourth person was left overlapping the footer.
+     */
+    @Test
+    fun fourPeopleStillFitUnderALongSentence() {
+        val state = chain(
+            "Akshit Kumar Srivastava", "Pragya Kumari Srivastava",
+            "Kinshuk Kumar Srivastava", "Sarika Kumari Srivastava",
+        )
+        show(state, "card-four-long")
+
+        rule.onNodeWithText("Akshit Kumar Srivastava").assertIsDisplayed()
+        rule.onNodeWithText("Sarika Kumari Srivastava").assertIsDisplayed()
+        assertFitsAboveTheFooter("Sarika Kumari Srivastava")
+    }
+
+    /**
+     * The preview has to sit inside the screen it is shown on.
+     *
+     * The card has a size of its own and the phone does not, so the preview scales it — and the
+     * only thing that can go wrong is the scaled drawing being centred on a size it is not, which
+     * puts it half off the top-left corner. What is asserted is the frame, not the appearance.
+     */
+    @Test
+    fun theSheetShowsTheWholeCardInsideTheScreen() {
+        val state = chain("Ankit Srivastava", "Pragya Srivastava", "Kinshuk Srivastava", "Akshit Srivastava")
+        rule.setContent {
+            FTreeTheme(darkTheme = true) {
+                ShareRelationDialog(
+                    state = state,
+                    relation = found(state),
+                    onDismiss = {},
+                    onSend = {},
+                )
+            }
+        }
+
+        /*
+         * Compared in pixels, deliberately. The card carries a density of its own — that is what
+         * fixes the export at 1080 by 1350 — so its bounds in dp are in different units from the
+         * sheet's around it, and comparing those two numbers proves nothing.
+         */
+        val sheet = rule.onNode(isDialog()).fetchSemanticsNode()
+        val preview = rule.onNodeWithTag(ShareCardPreviewTag).fetchSemanticsNode()
+        val left = preview.positionInRoot.x
+        val top = preview.positionInRoot.y
+        val frame = "preview ${preview.size} at ($left, $top) in a sheet of ${sheet.size}"
+        assertTrue("$frame starts off the left", left >= 0f)
+        assertTrue("$frame starts off the top", top >= 0f)
+        assertTrue("$frame runs past the right", left + preview.size.width <= sheet.size.width)
+        assertTrue("$frame runs past the bottom", top + preview.size.height <= sheet.size.height)
+        // And centred across the sheet, rather than merely inside it.
+        val slack = sheet.size.width - preview.size.width
+        assertTrue("$frame is not centred", kotlin.math.abs(left - slack / 2f) <= 1f)
+
+        val image = rule.onNode(isDialog()).captureToImage().asAndroidBitmap()
+        val directory = InstrumentationRegistry.getInstrumentation()
+            .targetContext.getExternalFilesDir(null)!!
+        FileOutputStream(File(directory, "sheet.png")).use {
+            image.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+
+    /**
+     * What Send hands over is the picture at its own size, not the preview at the screen's.
+     *
+     * The preview is scaled to whatever room the phone has, so this is the assertion that keeps
+     * the file the same on every device: a big screen shows a bigger card and sends the same one.
+     */
+    @Test
+    fun theSentPictureIsTheSameSizeWhateverTheScreen() {
+        val state = chain("Ankit Srivastava", "Pragya Srivastava", "Kinshuk Srivastava", "Akshit Srivastava")
+        var sent: RelationPicture? = null
+        rule.setContent {
+            FTreeTheme(darkTheme = true) {
+                ShareRelationDialog(
+                    state = state,
+                    relation = found(state),
+                    onDismiss = {},
+                    onSend = { sent = it },
+                )
+            }
+        }
+
+        rule.onNodeWithTag(ShareCardSendTag).performClick()
+        rule.waitUntil(5_000) { sent != null }
+
+        val picture = sent!!
+        assertEquals(1080, picture.image.width)
+        assertEquals(1350, picture.image.height)
+        // The caption travels with it, which is the whole reason this is a picture and not a file.
+        assertTrue("caption was ${picture.caption}", picture.caption.contains(footer))
+
+        val directory = InstrumentationRegistry.getInstrumentation()
+            .targetContext.getExternalFilesDir(null)!!
+        FileOutputStream(File(directory, "sent.png")).use {
+            picture.image.asAndroidBitmap()
+                .compress(android.graphics.Bitmap.CompressFormat.PNG, 100, it)
+        }
+    }
+
+    @Test
+    fun aLongLineIsCountedRatherThanCut() {
+        val state = chain(
+            "Ankit Srivastava", "Pragya Srivastava", "Kinshuk Srivastava", "Akshit Srivastava",
+            "Meena Srivastava", "Vinod Srivastava", "Sunita Srivastava", "Aarav Srivastava",
+        )
+        show(state, "card-eight")
+
+        // Both ends, because they are the two people the question was about.
+        rule.onNodeWithText("Ankit Srivastava").assertIsDisplayed()
+        rule.onNodeWithText("Aarav Srivastava").assertIsDisplayed()
+        // And the middle counted rather than silently dropped.
+        rule.onNodeWithText("more", substring = true).assertIsDisplayed()
+        assertFitsAboveTheFooter("Aarav Srivastava")
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationCard.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -21,7 +22,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
@@ -39,9 +39,6 @@ import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 
-/** Which drawing of the line between two people the card carries. */
-enum class CardStyle { TREE, LIST }
-
 /**
  * The card's size in its own units. Rendered at three pixels to the point, so the image is always
  * 1080 x 1350 whatever the phone it was made on — the shape a chat app expects, and the same file
@@ -50,18 +47,19 @@ enum class CardStyle { TREE, LIST }
 val CARD_WIDTH = 360.dp
 val CARD_HEIGHT = 450.dp
 
-/** How many people the body can show before it starts summarising. */
-private const val TREE_SEATS = 4
-private const val LIST_SEATS = 5
+/** The smallest a row can be and still carry a name over the step that makes it. */
+private val MIN_ROW = 40.dp
 
-/**
- * Every card on the tree is the same width.
- *
- * Boxes sized to their names would step in and out down the page and the connectors would meet them
- * off-centre; one width gives the drawing a spine, which is what makes it read as descent rather
- * than as a list that has been boxed.
- */
-private val TREE_CARD_WIDTH = 208.dp
+/** And the largest, so a two-person answer sits together rather than drifting apart. */
+private val MAX_ROW = 64.dp
+
+private val ROW_GAP = 2.dp
+
+/** The fewest rows that can still tell the truth: both ends, and the note between them. */
+private const val MIN_SEATS = 3
+
+/** Past this many characters the sentence is set smaller, so it cannot eat the drawing. */
+private const val LONG_SENTENCE = 58
 
 /**
  * A relationship, as something you can send.
@@ -73,14 +71,13 @@ private val TREE_CARD_WIDTH = 208.dp
  * to be, and none of that is the answer.
  *
  * Nothing is invented for the picture. It is the same sentence [answerSentence] writes on the
- * screen, in the same vocabulary the reader has chosen, using the app's own notation for a card and
- * a connector — so what arrives in somebody's chat is recognisably the thing they were shown.
+ * screen, in the same vocabulary the reader has chosen, using the app's own notation for a face and
+ * a connecting line — so what arrives in somebody's chat is recognisably the thing they were shown.
  */
 @Composable
 fun RelationCard(
     state: RelationUiState,
     relation: Relation.Found,
-    style: CardStyle,
     modifier: Modifier = Modifier,
 ) {
     val accents = FTreeTheme.accents
@@ -100,231 +97,169 @@ fun RelationCard(
             .background(MaterialTheme.colorScheme.surfaceContainerHigh)
             .padding(14.dp),
     ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .clip(RoundedCornerShape(18.dp))
-            .background(MaterialTheme.colorScheme.background)
-            .border(1.dp, accents.rule, RoundedCornerShape(18.dp))
-            .padding(horizontal = 24.dp, vertical = 22.dp),
-    ) {
-        Text(
-            text = stringResource(R.string.app_name).uppercase(),
-            style = FTreeText.sectionLabel,
-            color = accents.unknown,
-        )
-
-        Spacer(Modifier.height(16.dp))
-
-        Text(
-            text = answer?.sentence
-                ?: stringResource(
-                    R.string.card_connected,
-                    from.displayName(),
-                    state.to?.displayName().orEmpty(),
-                ),
-            style = MaterialTheme.typography.headlineSmall.copy(fontSize = 22.sp, lineHeight = 29.sp),
-            color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 4,
-            overflow = TextOverflow.Ellipsis,
-        )
-
-        Spacer(Modifier.height(10.dp))
-
-        Text(
-            text = stringResource(R.string.card_steps, relation.steps),
-            style = FTreeText.recordSmall,
-            color = accents.unknown,
-        )
-
-        Spacer(Modifier.height(16.dp))
-        HorizontalDivider(color = accents.rule)
-
-        Box(
-            modifier = Modifier.fillMaxWidth().weight(1f),
-            contentAlignment = Alignment.Center,
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .clip(RoundedCornerShape(18.dp))
+                .background(MaterialTheme.colorScheme.background)
+                .border(1.dp, accents.rule, RoundedCornerShape(18.dp))
+                .padding(horizontal = 24.dp, vertical = 20.dp),
         ) {
-            val people = listOf(from) + state.chain.map { it.person }
-            val roles = listOf<String?>(null) + state.chain.map { link ->
-                stringResource(
-                    relativeRoleLabel(
-                        link.kind.asRelativeKind(),
-                        link.person.gender,
-                        LocalKinshipLanguage.current,
-                    )
-                )
-            }
-            when (style) {
-                CardStyle.TREE -> TreeBody(people, roles)
-                CardStyle.LIST -> ListBody(people, roles)
-            }
-        }
-
-        HorizontalDivider(color = accents.rule)
-        Spacer(Modifier.height(10.dp))
-        Text(
-            text = stringResource(R.string.card_footer),
-            style = FTreeText.recordSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-    }
-}
-
-/**
- * The line drawn as a descent: cards down the middle, joined by the app's own connector, with each
- * step named on the rule that makes it.
- *
- * This is the shape somebody recognises as a family tree, which is why it is the one the card
- * offers first.
- */
-@Composable
-private fun TreeBody(people: List<Person>, roles: List<String?>) {
-    val accents = FTreeTheme.accents
-    val shown = seat(people, roles, TREE_SEATS)
-
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        shown.forEachIndexed { index, seat ->
-            if (index > 0) {
-                Connector(label = seat.role, hidden = seat.person == null)
-            }
-            when (val person = seat.person) {
-                null -> Text(
-                    text = stringResource(R.string.card_more, seat.skipped),
-                    style = FTreeText.recordSmall,
-                    color = accents.unknown,
-                )
-
-                else -> Row(
-                    modifier = Modifier
-                        .width(TREE_CARD_WIDTH)
-                        .clip(RoundedCornerShape(12.dp))
-                        .background(MaterialTheme.colorScheme.surfaceContainerLow)
-                        .border(1.dp, accents.rule, RoundedCornerShape(12.dp))
-                        .padding(horizontal = 12.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                ) {
-                    PersonAvatar(person, diameter = 26.dp, decorative = true)
-                    Name(person, style = MaterialTheme.typography.titleSmall)
-                }
-            }
-        }
-    }
-}
-
-/**
- * The rule between two cards, with the step written beside it.
- *
- * The line is centred on the card above and below it and the label hangs off it, rather than the
- * two sharing a row — otherwise the width of the word decides where the spine goes, and a long one
- * bends the whole drawing.
- */
-@Composable
-private fun Connector(label: String?, hidden: Boolean) {
-    val accents = FTreeTheme.accents
-    Box(
-        modifier = Modifier.width(TREE_CARD_WIDTH).height(26.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        Box(
-            Modifier
-                .width(1.dp)
-                .height(26.dp)
-                .background(if (hidden) Color.Transparent else accents.rule)
-        )
-        label?.let {
             Text(
-                text = it,
+                text = stringResource(R.string.app_name).uppercase(),
+                style = FTreeText.sectionLabel,
+                color = accents.unknown,
+            )
+
+            Spacer(Modifier.height(14.dp))
+
+            /*
+             * The sentence is the headline, but it is not allowed to be the whole card. A short
+             * answer is set large because it can be; a long one — a Hindi term with its gloss, two
+             * long names — steps down a size rather than pushing the people it is about off the
+             * bottom.
+             */
+            val sentence = answer?.sentence ?: stringResource(
+                R.string.card_connected,
+                from.displayName(),
+                state.to?.displayName().orEmpty(),
+            )
+            val long = sentence.length > LONG_SENTENCE
+            Text(
+                text = sentence,
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    fontSize = if (long) 19.sp else 23.sp,
+                    lineHeight = if (long) 25.sp else 30.sp,
+                ),
+                color = MaterialTheme.colorScheme.onSurface,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.card_steps, relation.steps),
                 style = FTreeText.recordSmall,
                 color = accents.unknown,
-                modifier = Modifier.align(Alignment.Center).padding(start = 96.dp),
+            )
+
+            Spacer(Modifier.height(14.dp))
+            HorizontalDivider(color = accents.rule)
+
+            Box(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                val people = listOf(from) + state.chain.map { it.person }
+                val roles = listOf<String?>(null) + state.chain.map { link ->
+                    stringResource(
+                        relativeRoleLabel(
+                            link.kind.asRelativeKind(),
+                            link.person.gender,
+                            LocalKinshipLanguage.current,
+                        )
+                    )
+                }
+                ListBody(people, roles)
+            }
+
+            HorizontalDivider(color = accents.rule)
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.card_footer),
+                style = FTreeText.recordSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
 }
 
 /**
- * The same line as a register: one person to a row, each saying what they are to the one above.
+ * The line as a register: one person to a row, each saying what they are to the one above.
  *
- * Plainer than the tree and better for a longer line, where boxes and connectors become a ladder
- * nobody reads.
+ * How many rows there are is decided by the room left over, not by a constant. The card is a fixed
+ * size and the sentence above it is not, so the space available here is only known once that
+ * sentence has been set; assuming a number of rows is how the last person ends up squeezed into the
+ * footer. Instead: as many people as fit at a height a name can be read at, and the rest counted.
  */
 @Composable
 private fun ListBody(people: List<Person>, roles: List<String?>) {
     val accents = FTreeTheme.accents
-    val shown = seat(people, roles, LIST_SEATS)
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val seats = ((maxHeight + ROW_GAP) / (MIN_ROW + ROW_GAP)).toInt().coerceAtLeast(MIN_SEATS)
+        val shown = seat(people, roles, seats)
+        val row = ((maxHeight - ROW_GAP * (shown.size - 1)) / shown.size).coerceIn(MIN_ROW, MAX_ROW)
+        val face = (row - 14.dp).coerceIn(24.dp, 32.dp)
 
-    Column(
-        modifier = Modifier.fillMaxWidth(),
-        verticalArrangement = Arrangement.spacedBy(2.dp),
-    ) {
-        shown.forEachIndexed { index, seat ->
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-            ) {
-                /*
-                 * A rail through the faces, joining one row to the next.
-                 *
-                 * Without it this is a list of people who happen to be near each other. The line is
-                 * what says they are a route, which is the whole difference between this card and a
-                 * screenshot of a contacts app.
-                 */
-                Box(
-                    modifier = Modifier.size(32.dp, 46.dp),
-                    contentAlignment = Alignment.Center,
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(ROW_GAP, Alignment.CenterVertically),
+        ) {
+            shown.forEachIndexed { index, seat ->
+                Row(
+                    modifier = Modifier.fillMaxWidth().height(row),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
-                    if (index > 0) {
-                        Box(
-                            Modifier
-                                .width(1.dp)
-                                .height(23.dp)
-                                .align(Alignment.TopCenter)
-                                .background(accents.rule)
-                        )
-                    }
-                    if (index < shown.lastIndex) {
-                        Box(
-                            Modifier
-                                .width(1.dp)
-                                .height(23.dp)
-                                .align(Alignment.BottomCenter)
-                                .background(accents.rule)
-                        )
-                    }
-                    when (val person = seat.person) {
-                        null -> Box(
-                            Modifier
-                                .size(7.dp)
-                                .clip(RoundedCornerShape(4.dp))
-                                .background(accents.unknown)
-                        )
+                    /*
+                     * A rail through the faces, joining one row to the next.
+                     *
+                     * Without it this is a list of people who happen to be near each other. The line
+                     * is what says they are a route, which is the whole difference between this card
+                     * and a screenshot of a contacts app. The gutter keeps one width whatever size
+                     * the faces take, so the names stay in a column.
+                     */
+                    Box(
+                        modifier = Modifier.size(32.dp, row),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (index > 0) {
+                            Box(
+                                Modifier
+                                    .width(1.dp)
+                                    .height(row / 2)
+                                    .align(Alignment.TopCenter)
+                                    .background(accents.rule)
+                            )
+                        }
+                        if (index < shown.lastIndex) {
+                            Box(
+                                Modifier
+                                    .width(1.dp)
+                                    .height(row / 2)
+                                    .align(Alignment.BottomCenter)
+                                    .background(accents.rule)
+                            )
+                        }
+                        when (val person = seat.person) {
+                            null -> Box(
+                                Modifier
+                                    .size(7.dp)
+                                    .clip(RoundedCornerShape(4.dp))
+                                    .background(accents.unknown)
+                            )
 
-                        else -> PersonAvatar(person, diameter = 32.dp, decorative = true)
+                            else -> PersonAvatar(person, diameter = face, decorative = true)
+                        }
                     }
-                }
 
-                Column(Modifier.weight(1f)) {
-                    when (val person = seat.person) {
-                        null -> Text(
-                            text = stringResource(R.string.card_more, seat.skipped),
-                            style = FTreeText.recordSmall,
-                            color = accents.unknown,
-                        )
+                    Column(Modifier.weight(1f)) {
+                        when (val person = seat.person) {
+                            null -> Text(
+                                text = stringResource(R.string.card_more, seat.skipped),
+                                style = FTreeText.recordSmall,
+                                color = accents.unknown,
+                            )
 
-                        else -> {
-                            Name(person, style = MaterialTheme.typography.titleSmall)
-                            seat.role?.let {
-                                Text(
-                                    text = it,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                )
+                            else -> {
+                                Name(person, style = MaterialTheme.typography.titleSmall)
+                                seat.role?.let {
+                                    Text(
+                                        text = it,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                    )
+                                }
                             }
                         }
                     }
@@ -352,7 +287,7 @@ private fun Name(person: Person, style: androidx.compose.ui.text.TextStyle) {
 private data class Seat(val person: Person?, val role: String?, val skipped: Int = 0)
 
 /**
- * Fits a line of any length into a fixed card.
+ * Fits a line of any length into the rows there is room for.
  *
  * A card that grew with the family would be a different picture every time and a poor one for a
  * long line. So both ends are always shown — they are the two people the question was about — and

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/ShareRelationDialog.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/ShareRelationDialog.kt
@@ -1,21 +1,17 @@
 package com.vibethroughcode.ftree.ui.relation
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Share
@@ -24,31 +20,29 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.SegmentedButton
-import androidx.compose.material3.SegmentedButtonDefaults
-import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.layer.GraphicsLayer
 import androidx.compose.ui.graphics.layer.drawLayer
 import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.layout.layout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -58,9 +52,8 @@ import com.vibethroughcode.ftree.graph.Relation
 import com.vibethroughcode.ftree.ui.common.displayName
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
-const val ShareCardTreeTag = "share-card-tree"
-const val ShareCardListTag = "share-card-list"
 const val ShareCardSendTag = "share-card-send"
 const val ShareCardPreviewTag = "share-card-preview"
 
@@ -85,7 +78,6 @@ fun ShareRelationDialog(
     onDismiss: () -> Unit,
     onSend: (RelationPicture) -> Unit,
 ) {
-    var style by rememberSaveable { mutableStateOf(CardStyle.TREE) }
     var working by remember { mutableStateOf(false) }
     val layer = rememberGraphicsLayer()
     val scope = rememberCoroutineScope()
@@ -123,35 +115,19 @@ fun ShareRelationDialog(
                     )
                 }
 
-                Box(
-                    modifier = Modifier.fillMaxWidth().weight(1f).padding(horizontal = 20.dp),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    CardPreview(state, relation, style, layer)
-                }
+                CardPreview(
+                    state = state,
+                    relation = relation,
+                    layer = layer,
+                    modifier = Modifier.fillMaxWidth().weight(1f).padding(horizontal = 20.dp, vertical = 8.dp),
+                )
 
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .widthIn(max = 480.dp)
                         .padding(horizontal = 20.dp, vertical = 12.dp),
                     verticalArrangement = Arrangement.spacedBy(14.dp),
                 ) {
-                    SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-                        SegmentedButton(
-                            selected = style == CardStyle.TREE,
-                            onClick = { style = CardStyle.TREE },
-                            shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                            modifier = Modifier.testTag(ShareCardTreeTag),
-                        ) { Text(stringResource(R.string.card_style_tree)) }
-                        SegmentedButton(
-                            selected = style == CardStyle.LIST,
-                            onClick = { style = CardStyle.LIST },
-                            shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                            modifier = Modifier.testTag(ShareCardListTag),
-                        ) { Text(stringResource(R.string.card_style_list)) }
-                    }
-
                     // Shown rather than hidden: somebody about to post this in a family group should
                     // know what is going with it before the chat app opens, not after.
                     Column {
@@ -210,40 +186,49 @@ fun ShareRelationDialog(
 private fun CardPreview(
     state: RelationUiState,
     relation: Relation.Found,
-    style: CardStyle,
-    layer: androidx.compose.ui.graphics.layer.GraphicsLayer,
+    layer: GraphicsLayer,
+    modifier: Modifier = Modifier,
 ) {
-    val outer = LocalDensity.current
-    BoxWithConstraints(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        val widthPx = CARD_PIXEL_WIDTH
-        val heightPx = CARD_PIXEL_HEIGHT
-        val scale = minOf(
-            constraints.maxWidth / widthPx.toFloat(),
-            constraints.maxHeight / heightPx.toFloat(),
-        ).coerceAtMost(1f)
-
-        Box(
-            modifier = Modifier
-                .size(with(outer) { (widthPx * scale).toDp() }, with(outer) { (heightPx * scale).toDp() })
-                .testTag(ShareCardPreviewTag),
-        ) {
-            CompositionLocalProvider(LocalDensity provides Density(CARD_DENSITY, 1f)) {
-                Box(
-                    Modifier
-                        .requiredSize(CARD_WIDTH, CARD_HEIGHT)
-                        .graphicsLayer {
-                            scaleX = scale
-                            scaleY = scale
-                            transformOrigin = TransformOrigin(0f, 0f)
-                        }
-                        .drawWithContent {
-                            layer.record { this@drawWithContent.drawContent() }
-                            drawLayer(layer)
-                        },
-                ) {
-                    RelationCard(state = state, relation = relation, style = style)
-                }
+    Box(modifier.clipToBounds(), contentAlignment = Alignment.Center) {
+        CompositionLocalProvider(LocalDensity provides Density(CARD_DENSITY, 1f)) {
+            Box(
+                Modifier
+                    .testTag(ShareCardPreviewTag)
+                    .scaledToFit()
+                    .requiredSize(CARD_WIDTH, CARD_HEIGHT)
+                    .drawWithContent {
+                        layer.record { this@drawWithContent.drawContent() }
+                        drawLayer(layer)
+                    },
+            ) {
+                RelationCard(state = state, relation = relation)
             }
+        }
+    }
+}
+
+/**
+ * Fits whatever it wraps to the room it is given, and then takes up exactly that much room.
+ *
+ * The scale is worked out and applied in one measurement, so what the parent is told about this
+ * element is by construction the size it draws at. Kept as one function because the alternative —
+ * measuring in one place and scaling in another — is how a preview ends up centred on a size it
+ * isn't, hanging off the top-left corner of its own frame.
+ */
+private fun Modifier.scaledToFit(): Modifier = layout { measurable, constraints ->
+    // Measured free of the incoming constraints: the card has a size of its own and it is that size
+    // being fitted, not a squashed version of it. What is scaled is a recorded display list, so a
+    // roomy screen gets a larger card drawn again rather than a small one stretched.
+    val placeable = measurable.measure(Constraints())
+    val scale = minOf(
+        constraints.maxWidth / placeable.width.toFloat(),
+        constraints.maxHeight / placeable.height.toFloat(),
+    )
+    layout((placeable.width * scale).roundToInt(), (placeable.height * scale).roundToInt()) {
+        placeable.placeWithLayer(0, 0) {
+            scaleX = scale
+            scaleY = scale
+            transformOrigin = TransformOrigin(0f, 0f)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,8 +167,6 @@
     <string name="card_footer">ftree.vibethroughcode.com</string>
     <string name="card_share">Share this relationship</string>
     <string name="card_title">Share</string>
-    <string name="card_style_tree">Tree</string>
-    <string name="card_style_list">List</string>
     <string name="card_caption_label">Sent with the picture</string>
     <string name="card_send">Send</string>
     <string name="card_failed">Couldn\'t make that picture.</string>


### PR DESCRIPTION
The relationship picture, after using it: the tree option goes, the list fits itself to the space, and the preview stops hanging off its own frame.

### The tree drawing goes
Two drawings of one line meant two layouts to keep honest and a choice to make before sending. The register reads better at every length, so it is now the card — no segmented row, no `CardStyle`.

### The list decides its own rows
The card is a fixed 360 × 450 and the sentence above the people is not. A constant five seats meant **four people at a fixed 46dp needed 190dp when a four-line answer had left 166** — so the fourth was drawn over the footer rule:

Now the space decides. As many people as fit at a height a name can be read at, the rest counted as before, and a long sentence steps down a size rather than pushing the people it is about off the bottom.

### The preview takes its frame from its own scale
It measured in one place (`Box(Modifier.size(scaled))`) and scaled in another (`graphicsLayer` inside `requiredSize`), and nothing clipped the difference. One `layout` pass now works out the scale and reports the size that falls out of it, so the two cannot disagree, and the frame clips.

Given the room, it now fills it — what is scaled is a recorded display list, so a bigger screen **redraws** the card rather than stretching it. The export is untouched: still 1080 × 1350 from every phone.

### Verification
New `RelationCardTest` (6), asserting bounds rather than appearance:

- the last person's row ends above the footer rule — with a short sentence and with a long one
- both ends shown and the middle counted for a chain of eight
- the preview sits inside the sheet **and centred on it**, compared in pixels (the card carries a density of its own, so its dp are not the sheet's dp)
- Send hands over a 1080 × 1350 picture with the caption, whatever the screen

Run at 720×1600, 1080×1920, 1080×2400 and 1440×3200. 188 unit, 148 instrumented, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)