### PR TITLE
Version 0.6.0-beta.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 13
-        versionName = "0.6.0-beta.3"
+        versionCode = 14
+        versionName = "0.6.0-beta.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 14, `versionName` 0.6.0-beta.4 — carrying #59.

One card instead of two, the list sized to the room the sentence leaves it, and a preview whose frame comes from its own scale. Export unchanged at 1080 × 1350.

Pre-release, so `releases/latest` stays on v0.5.2 and only the beta channel is offered this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)