### PR TITLE
Open a family tree somebody sent you

### DIFF
--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/OpenTreeFileTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/OpenTreeFileTest.kt
@@ -1,0 +1,199 @@
+package com.vibethroughcode.ftree.ui
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.core.content.FileProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.transfer.openedTree
+import com.vibethroughcode.ftree.ui.transfer.ImportConfirmTag
+import java.io.File
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * A family tree arriving from somewhere else.
+ *
+ * The share was only half a feature while the file it produced could not be opened: a relative
+ * receives a `.ftree` in a chat app and there is nothing on their phone that will take it. These
+ * are the two gestures they will actually make — tapping the file, and choosing this app from a
+ * share sheet — and in both the file is shown as a proposal, never applied on arrival.
+ */
+@RunWith(AndroidJUnit4::class)
+class OpenTreeFileTest {
+
+    @get:Rule
+    val rule = createEmptyComposeRule()
+
+    private val context
+        get() = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private val app: FTreeApplication
+        get() = context.applicationContext as FTreeApplication
+
+    private lateinit var sandeep: Person
+
+    @Before
+    fun seedAFamily() {
+        app.container.database.clearAllTables()
+        val repository = app.container.familyRepository
+        sandeep = Person(name = "Sandeep Kumar", birthDate = "1958")
+        val pragya = Person(name = "Pragya Kumari", birthDate = "1962")
+        val ankit = Person(name = "Ankit Kumar", birthDate = "1990")
+        runBlocking {
+            listOf(sandeep, pragya, ankit).forEach { repository.addPerson(it) }
+            repository.addRelative(sandeep.id, pragya.id, RelativeKind.SPOUSE)
+            repository.addRelative(sandeep.id, ankit.id, RelativeKind.CHILD)
+        }
+    }
+
+    @After
+    fun closeWhateverIsOpen() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            listOf(Stage.RESUMED, Stage.STARTED, Stage.PAUSED).forEach { stage ->
+                ActivityLifecycleMonitorRegistry.getInstance()
+                    .getActivitiesInStage(stage)
+                    .forEach { it.finish() }
+            }
+        }
+    }
+
+    /** The app's own share, which is where a file people actually receive comes from. */
+    private fun sharedBranch(): Uri = runBlocking {
+        app.container.branchShare.prepare(sandeep.id)!!.uri
+    }
+
+    /** Something with the right name and nothing else right about it. */
+    private fun notATree(): Uri {
+        val directory = File(context.cacheDir, "shared").apply { mkdirs() }
+        val file = File(directory, "holiday-photos.ftree")
+        file.writeText("this is not a family tree")
+        return FileProvider.getUriForFile(context, "${context.packageName}.shares", file)
+    }
+
+    private fun open(intent: Intent) {
+        context.startActivity(intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+    }
+
+    private fun awaitReview() = rule.waitUntil(15_000) {
+        rule.onAllNodesWithTag(ImportConfirmTag).fetchSemanticsNodes().isNotEmpty()
+    }
+
+    @Test
+    fun aTreeTappedInAFileManagerIsOfferedForReview() {
+        open(Intent(context, MainActivity::class.java).setAction(Intent.ACTION_VIEW).setData(sharedBranch()))
+
+        awaitReview()
+        // Sandeep, his wife and his son: the branch that was shared, counted back on arrival.
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("3 people", substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun aTreeSentFromAChatAppIsOfferedForReview() {
+        open(
+            Intent(context, MainActivity::class.java)
+                .setAction(Intent.ACTION_SEND)
+                .setType("application/octet-stream")
+                .putExtra(Intent.EXTRA_STREAM, sharedBranch())
+        )
+
+        awaitReview()
+    }
+
+    /**
+     * The price of being offered for files of no particular type is being handed some of them.
+     *
+     * It is paid here: read, refused in a sentence, and the tree left exactly as it was — rather
+     * than the app declining to appear in the list when somebody needs it.
+     */
+    @Test
+    fun somethingThatIsNotATreeIsRefusedRatherThanImported() {
+        open(Intent(context, MainActivity::class.java).setAction(Intent.ACTION_VIEW).setData(notATree()))
+
+        rule.waitUntil(15_000) {
+            rule.onAllNodesWithText("That file isn't a family tree export.").fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.onAllNodesWithTag(ImportConfirmTag).fetchSemanticsNodes().let {
+            assertEquals("nothing was proposed", 0, it.size)
+        }
+    }
+
+    /** Whether the app is in the list at all, which is decided by the manifest and nothing else. */
+    private fun offeredFor(intent: Intent): Boolean = context.packageManager
+        .queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+        .any { it.activityInfo.name == MainActivity::class.java.name }
+
+    /**
+     * The part the app cannot test by starting itself.
+     *
+     * Every other test here launches MainActivity by name, which skips the manifest entirely. This
+     * is the question somebody actually has — "does f-tree come up when I tap the file my cousin
+     * sent me" — and it is answered by asking the system, with the intents chat apps really send.
+     */
+    @Test
+    fun theAppComesUpForAFileSomebodyWasSent() {
+        // What a chat app hands over: its own provider, and a type it invented for an extension
+        // nothing has heard of.
+        val tapped = Intent(Intent.ACTION_VIEW).setDataAndType(
+            Uri.parse("content://com.whatsapp.provider.media/item/42"),
+            "application/octet-stream",
+        )
+        assertTrue("not offered when a received file is tapped", offeredFor(tapped))
+
+        val shared = Intent(Intent.ACTION_SEND)
+            .setType("application/octet-stream")
+            .putExtra(Intent.EXTRA_STREAM, Uri.parse("content://com.whatsapp.provider.media/item/42"))
+        assertTrue("not offered on a share sheet", offeredFor(shared))
+
+        /*
+         * And not claimed, on purpose: a `file:` path with the right name on it. The app cannot
+         * read one without a storage permission it has no other reason to hold, so being in the
+         * list for it would mean appearing and then failing.
+         */
+        val path = Intent(Intent.ACTION_VIEW).setDataAndType(
+            Uri.parse("file:///storage/emulated/0/Download/Sandeep-Kumar-family.ftree"),
+            "application/octet-stream",
+        )
+        assertFalse("offered for a file it could not read", offeredFor(path))
+
+        // And the boundary of the bargain: this app has no business in the list for a photograph.
+        val photograph = Intent(Intent.ACTION_VIEW).setDataAndType(
+            Uri.parse("content://media/external/images/media/12"),
+            "image/jpeg",
+        )
+        assertFalse("offered for a photograph", offeredFor(photograph))
+    }
+
+    /** Starting the app from its own icon opens nothing: only a file handed over is a file opened. */
+    @Test
+    fun anOrdinaryLaunchOpensNothing() {
+        assertNull(openedTree(Intent(Intent.ACTION_MAIN)))
+        assertNull(openedTree(null))
+        val uri = Uri.parse("content://example/tree.ftree")
+        assertEquals(uri, openedTree(Intent(Intent.ACTION_VIEW).setData(uri)))
+        assertEquals(
+            uri,
+            openedTree(Intent(Intent.ACTION_SEND).putExtra(Intent.EXTRA_STREAM, uri))
+        )
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,14 +22,65 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.FTree">
+        <!--
+            One task, whichever way the app is entered.
+
+            singleTask because opening a shared `.ftree` from a chat app should bring the reader to
+            their own family tree with everything where they left it, not open a second copy of the
+            app nested inside the chat app's task with a back button that leads somewhere strange.
+            The file arrives at onNewIntent when the app is already running.
+        -->
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:launchMode="singleTask"
             android:theme="@style/Theme.FTree">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!--
+                Opening a family tree somebody sent.
+
+                Matched on type rather than on the `.ftree` name, because a content URI usually has
+                no name in its path to match: a chat app stores what it received under a number and
+                reports whatever type it recorded, which for an extension nothing has heard of means
+                octet-stream. Matching those types is the only thing that puts this app in the list
+                somebody is looking at when they tap a file a relative sent them.
+
+                The cost is being offered for other files of no particular type, and it is paid
+                openly: the file is read and refused with a sentence if it is not a family tree,
+                rather than the app quietly not appearing when it should.
+            -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="content" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/zip" />
+                <data android:mimeType="application/x-zip-compressed" />
+                <data android:mimeType="application/ftree" />
+            </intent-filter>
+
+            <!--
+                Deliberately no `file:` filter, tempting though the `.ftree` name is to match on.
+                A path in somebody's Downloads is not readable by this app on any current Android
+                without a storage permission it has no other reason to hold, so claiming those files
+                would mean appearing in the list and then failing — which is worse than not being
+                there. Every file manager and chat app that matters hands over a content URI.
+            -->
+
+            <!-- Sending a file to this app from a chat app's share sheet. -->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/octet-stream" />
+                <data android:mimeType="application/zip" />
+                <data android:mimeType="application/x-zip-compressed" />
+                <data android:mimeType="application/ftree" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/vibethroughcode/ftree/MainActivity.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/MainActivity.kt
@@ -1,20 +1,49 @@
 package com.vibethroughcode.ftree
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import com.vibethroughcode.ftree.transfer.openedTree
 import com.vibethroughcode.ftree.ui.FTreeApp
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 class MainActivity : ComponentActivity() {
+
+    /**
+     * A file handed to the app from outside, waiting to be looked at.
+     *
+     * Held here rather than read from the intent where it is needed, because an intent is delivered
+     * once but a composition happens many times: reading it directly would re-open the same file on
+     * every rotation, throwing away whatever the reader had decided about the import so far.
+     */
+    private val opened = MutableStateFlow<Uri?>(null)
+
+    /** Read-only, and made once: a flow built inside the composition would be a new one each time. */
+    private val openedFile: StateFlow<Uri?> = opened.asStateFlow()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        // Only on a fresh start. A recreated activity is handed the same intent again, and that is
+        // the app being rebuilt, not somebody opening a file a second time.
+        if (savedInstanceState == null) opened.value = openedTree(intent)
         setContent {
             FTreeTheme {
-                FTreeApp()
+                FTreeApp(opened = openedFile, onOpened = { opened.value = null })
             }
         }
+    }
+
+    /** The app was already running when the file was opened. */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        opened.value = openedTree(intent)
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/transfer/OpenedTree.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/transfer/OpenedTree.kt
@@ -1,0 +1,26 @@
+package com.vibethroughcode.ftree.transfer
+
+import android.content.Intent
+import android.net.Uri
+import androidx.core.content.IntentCompat
+
+/**
+ * The file another app has just handed to this one, if it handed one over at all.
+ *
+ * Two ways in, because they are two different gestures and both are things people do: tapping a
+ * `.ftree` in a file manager or a chat app's downloads, which arrives as a VIEW, and choosing this
+ * app from a share sheet, which arrives as a SEND with the file in an extra.
+ *
+ * What is deliberately *not* checked here is whether the file looks like a family tree. Providers
+ * disagree about what a `.ftree` is — octet-stream, zip, or whatever a chat app stored it as — and
+ * a name is not evidence in any case. The file is opened and read before anything is claimed about
+ * it, and a file that turns out not to be one is refused with a sentence rather than filtered out
+ * of the chooser on a guess.
+ */
+fun openedTree(intent: Intent?): Uri? = when (intent?.action) {
+    Intent.ACTION_VIEW -> intent.data
+    // Through IntentCompat rather than the typed overload, which is API 33 and this app runs from
+    // 26. The old phone in a family is exactly the one somebody is trying to get a tree onto.
+    Intent.ACTION_SEND -> IntentCompat.getParcelableExtra(intent, Intent.EXTRA_STREAM, Uri::class.java)
+    else -> null
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -1,6 +1,7 @@
 package com.vibethroughcode.ftree.ui
 
 import android.content.Intent
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Row
@@ -64,7 +65,14 @@ import com.vibethroughcode.ftree.ui.common.peopleCount
 import com.vibethroughcode.ftree.ui.transfer.TransferViewModel
 import com.vibethroughcode.ftree.ui.transfer.defaultExportName
 import com.vibethroughcode.ftree.ui.tree.TreeScreen
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlin.reflect.KClass
+
+/** Nothing was handed to the app: the ordinary case, and a single instance rather than a new one
+ * per composition, which would restart the collection on every recomposition. */
+private val nothingOpened: StateFlow<Uri?> = MutableStateFlow<Uri?>(null).asStateFlow()
 
 const val NavTreeTag = "nav-tree"
 const val NavPeopleTag = "nav-people"
@@ -95,9 +103,17 @@ private val destinations = listOf(
  * Import and export live here rather than on any one screen: a transfer is an operation on the
  * whole tree, its result belongs in an app-level snackbar, and the import review has to survive
  * whichever screen started it.
+ *
+ * [opened] is a file another app handed over — someone tapping a `.ftree` in their downloads, or
+ * choosing this app from a chat app's share sheet. It goes through exactly the same review as a
+ * file picked from inside the app, because arriving from outside says nothing about whether it
+ * should be trusted, and the reader still has to see what it would do before it does it.
  */
 @Composable
-fun FTreeApp() {
+fun FTreeApp(
+    opened: StateFlow<Uri?> = nothingOpened,
+    onOpened: () -> Unit = {},
+) {
     val navController = rememberNavController()
     val context = LocalContext.current
     // Named once here and read by every screen that says a relationship out loud.
@@ -142,6 +158,19 @@ fun FTreeApp() {
         val send = sendBranchIntent(branch.uri, shareMessage, shareTitle)
         runCatching { context.startActivity(Intent.createChooser(send, shareTitle)) }
         transferViewModel.clearShare()
+    }
+
+    /*
+     * A file opened from outside, shown as a proposal rather than applied.
+     *
+     * Cleared as soon as it is handed over, so that a rotation — or coming back to the app later —
+     * does not read the same file again over the top of whatever is happening now.
+     */
+    val openedFile by opened.collectAsStateWithLifecycle()
+    LaunchedEffect(openedFile) {
+        val file = openedFile ?: return@LaunchedEffect
+        transferViewModel.prepareImport(file)
+        onOpened()
     }
 
     val backStackEntry by navController.currentBackStackEntryAsState()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -179,8 +179,8 @@
         this app and is looking at an attachment in a chat: what it is, how many people are in it,
         where to get the app, and that importing it will not overwrite anything they already have.
     -->
-    <string name="share_message">Hey — I\'ve shared %1$s\'s family tree with you: %2$s.\n\nf-tree is a free family tree app that keeps everything on your phone. Get it at %3$s, then open Settings → Import a tree and choose this file. It merges into your own tree; nothing of yours is replaced.</string>
-    <string name="share_message_unnamed">Hey — I\'ve shared part of my family tree with you: %1$s.\n\nf-tree is a free family tree app that keeps everything on your phone. Get it at %2$s, then open Settings → Import a tree and choose this file. It merges into your own tree; nothing of yours is replaced.</string>
+    <string name="share_message">Hey — I\'ve shared %1$s\'s family tree with you: %2$s.\n\nf-tree is a free family tree app that keeps everything on your phone. Get it at %3$s, then tap the file and choose f-tree to open it. It merges into your own tree; nothing of yours is replaced.</string>
+    <string name="share_message_unnamed">Hey — I\'ve shared part of my family tree with you: %1$s.\n\nf-tree is a free family tree app that keeps everything on your phone. Get it at %2$s, then tap the file and choose f-tree to open it. It merges into your own tree; nothing of yours is replaced.</string>
     <string name="export_empty">There is nobody in your tree to export yet.</string>
     <string name="import_tree">Import a tree</string>
     <string name="import_title">Import this tree?</string>


### PR DESCRIPTION
The share was half a feature: a relative receives a `.ftree`, taps it, and nothing on their phone will take it. Now the app appears when the file is tapped, and on the share sheet when it is sent on.

### Matched on type, not on the name
A content URI usually has no name in its path to match — a chat app stores what it received under a number and reports whatever type it recorded, which for an extension nothing has heard of means `application/octet-stream`. Matching those types is the only thing that puts the app in the list somebody is looking at.

The cost is being offered for other files of no particular type, and it's paid openly: the file is read and **refused in a sentence** if it isn't a family tree.

**No `file:` filter**, tempting though the `.ftree` name is to match on — a path in Downloads isn't readable on any current Android without a storage permission this app has no other reason to hold. Claiming those files would mean appearing in the list and then failing.

### Same review as any import
Arriving from outside says nothing about whether a file should be trusted, so it goes through the existing proposal screen. Nothing is written until the reader confirms.

`singleTask`, so opening a tree brings them to their own app with everything where they left it rather than a second copy nested in the chat app's task. The intent is read once on a fresh start and again only at `onNewIntent` — read from the composition it would re-open the same file on every rotation, discarding whatever had been decided about the import.

### Verification
`OpenTreeFileTest` (5), including the part the app cannot test by starting itself — every other test launches `MainActivity` by name and skips the manifest entirely, so this one asks **the system's own resolver**:

- offered for a chat app's content URI, on both VIEW and SEND
- **not** offered for a photograph, or for a `file:` path it could not read
- a branch this app shared, handed back to it, counted on arrival (3 people)
- something that is not a tree refused, with nothing proposed

Also fixed on the way: `getParcelableExtra(name, Class)` is API 33 and `minSdk` is 26 — an outright crash on an older phone, which is exactly the phone someone is trying to get a tree onto. Now via `IntentCompat`.

188 unit, **153 instrumented**, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)