### PR TITLE
Version 0.6.0-beta.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 14
-        versionName = "0.6.0-beta.4"
+        versionCode = 15
+        versionName = "0.6.0-beta.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 15, `versionName` 0.6.0-beta.5 — carrying #61.

A `.ftree` somebody sent now opens in the app: tapped in a file manager, or handed over from a chat app's share sheet. Refused with a sentence if it isn't a family tree.

Pre-release, so `releases/latest` stays on v0.5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)