### PR TITLE
Version 0.6.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 15
-        versionName = "0.6.0-beta.5"
+        versionCode = 16
+        versionName = "0.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 16, `versionName` 0.6.0 — the betas promoted, unchanged.

`git diff v0.6.0-beta.5..HEAD` is these two lines and nothing else, so what goes to everyone is exactly what has been running in the beta channel.

### What lands for stable readers, coming from 0.5.2

- **Share one person's family** rather than the whole archive — descendants and partners, never anyone above or beside
- **Send a relationship as a picture**, which is how the message survives: a chat app keeps the caption on an image and drops it on a document
- **The beta channel** itself, off by default and behind a warning
- **Open a `.ftree` somebody sent you** — tapped in a file manager, or from a chat app's share sheet

### Checked before tagging

- every earlier tag's content is contained in `main`; nothing released was left on a branch
- `v0.5.2` is not an *ancestor* commit (it was tagged off its own line), so its content was diffed against `main` file by file: no file, no string and no line of the update code exists there and not here
- the upgrade itself rehearsed on a device — 0.5.2 installed, a person recorded through its own database, then 0.6.0 installed **over** it: versionCode 11 → 16, same signature, no reinstall, and the person still there when the app opened

188 unit, 153 instrumented, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)