### PR TITLE
Version 0.7.0-beta.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 16
-        versionName = "0.6.0"
+        versionCode = 17
+        versionName = "0.7.0-beta.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 17, `versionName` 0.7.0-beta.1 — carrying #65.

The relation finder is now one surface over the chart rather than two screens holding half an answer each. A minor bump rather than a patch: a whole destination is gone and the flow is reshaped.

Pre-release, so `releases/latest` stays on v0.6.0 and only the beta channel is offered this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)