### PR TITLE
Connect every descent bar, and let the lines take part in a selection

### DIFF
--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/WholeTreeAndUpdatesTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/WholeTreeAndUpdatesTest.kt
@@ -10,6 +10,8 @@ import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
@@ -25,6 +27,7 @@ import com.vibethroughcode.ftree.ui.tree.TreeModeFocusedTag
 import com.vibethroughcode.ftree.ui.tree.TreeModeWholeTag
 import com.vibethroughcode.ftree.ui.tree.WholeFamilyChartTag
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
 import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Rule
@@ -86,6 +89,39 @@ class WholeTreeAndUpdatesTest {
         // The summary is the plainest statement of it, and it is ordinary text rather than canvas.
         rule.onNodeWithText("3 people", substring = true).assertIsDisplayed()
         rule.onNodeWithText("with no relatives recorded", substring = true).assertIsDisplayed()
+    }
+
+    /**
+     * The complaint this answers: a tap both lit up somebody's relatives *and* opened a sheet over
+     * the top of them, so the highlight had to be dismissed before it could be looked at.
+     *
+     * The taps are at the centre of the canvas with a single person seeded, which is where the
+     * chart frames them — so if a tap ever stops landing on the card, the second one cannot open
+     * anything either and the test fails rather than passing vacuously.
+     */
+    @Test
+    fun aTapOnTheWholeChartSelectsBeforeItOffersToDoAnything() {
+        val repository = app.container.familyRepository
+        runBlocking { repository.addPerson(Person(name = "Ankit Kumar", birthDate = "1990")) }
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        rule.onNodeWithTag(TreeModeWholeTag).performClick()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithTag(WholeFamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        rule.onNodeWithTag(WholeFamilyChartTag).performTouchInput { click(center) }
+        rule.waitForIdle()
+        assertTrue(
+            "the first tap must leave the chart uncovered",
+            rule.onAllNodesWithText("Open Ankit Kumar").fetchSemanticsNodes().isEmpty(),
+        )
+
+        rule.onNodeWithTag(WholeFamilyChartTag).performTouchInput { click(center) }
+        rule.waitForIdle()
+        rule.onNodeWithText("Open Ankit Kumar").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
@@ -31,6 +31,12 @@ data class SpouseLink(val fromX: Float, val toX: Float, val y: Float)
  * Grouped by *parent set* rather than by individual parent, so a couple's children hang from one
  * connector while a half-sibling hangs from their own — which is what makes a second marriage
  * legible instead of a tangle of crossing lines.
+ *
+ * It carries the people it joins as well as the coordinates, because a connector that cannot say
+ * whose it is cannot take part in anything the chart does with a selection. Without them the only
+ * honest thing a highlight could do was fade the cards and leave every line at full strength —
+ * which is to dim the hundred and forty people you can already tell apart and keep the lattice you
+ * cannot.
  */
 data class DescentLink(
     val originX: Float,
@@ -38,7 +44,24 @@ data class DescentLink(
     val busY: Float,
     val childXs: List<Float>,
     val childTopY: Float,
-)
+    val parentIds: List<String> = emptyList(),
+    /** In the same order as [childXs], so a drop and a child can be matched up. */
+    val childIds: List<String> = emptyList(),
+) {
+    /** Whether this connector runs to or from [personId] — a parent on it, or one of the children. */
+    fun touches(personId: String): Boolean = personId in parentIds || personId in childIds
+
+    /**
+     * The horizontal bar's extent: from the parents' stem across to the far side of the children.
+     *
+     * Expressed here rather than worked out at drawing time so that "the bar reaches everything it
+     * has to join" is a property of the connector that a test can hold it to, instead of a detail
+     * of one canvas that happened to be right. Drawing the bar between the children alone is what
+     * left a stem hanging in mid-air whenever the parents sat outside their own children's span.
+     */
+    val barStart: Float get() = minOf(originX, childXs.minOrNull() ?: originX)
+    val barEnd: Float get() = maxOf(originX, childXs.maxOrNull() ?: originX)
+}
 
 data class TreeLayout(
     val nodes: List<TreeNode> = emptyList(),

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
@@ -373,10 +373,11 @@ object TreeLayoutEngine {
         if (parentXs.isEmpty()) return@mapNotNull null
         val originX = parentXs.map { it + nodeWidth / 2f }.average().toFloat()
 
-        val childXs = children
-            .mapNotNull { id -> unitOf[id]?.xOf(id)?.plus(nodeWidth / 2f) }
-            .sorted()
-        if (childXs.isEmpty()) return@mapNotNull null
+        // Kept together as pairs through the sort, so a drop and the child under it stay matched.
+        val placed = children
+            .mapNotNull { id -> unitOf[id]?.xOf(id)?.plus(nodeWidth / 2f)?.let { id to it } }
+            .sortedBy { it.second }
+        if (placed.isEmpty()) return@mapNotNull null
 
         val parentBottom = yOf(parentLevel) + nodeHeight
         val childTop = yOf(childLevel)
@@ -384,8 +385,10 @@ object TreeLayoutEngine {
             originX = originX,
             originY = parentBottom,
             busY = parentBottom + (childTop - parentBottom) / 2f,
-            childXs = childXs,
+            childXs = placed.map { it.second },
             childTopY = childTop,
+            parentIds = parents.toList(),
+            childIds = placed.map { it.first },
         )
     }
 }

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayout.kt
@@ -23,7 +23,16 @@ data class WholeTreeNode(
 }
 
 /** The doubled rule between partners, as [SpouseLink] but carrying which pair it joins. */
-data class WholeSpouseLink(val fromX: Float, val toX: Float, val y: Float, val ended: Boolean)
+data class WholeSpouseLink(
+    val fromX: Float,
+    val toX: Float,
+    val y: Float,
+    val ended: Boolean,
+    val aId: String = "",
+    val bId: String = "",
+) {
+    fun touches(personId: String): Boolean = personId == aId || personId == bId
+}
 
 /**
  * A bracket over siblings whose shared parents are unknown.
@@ -31,7 +40,15 @@ data class WholeSpouseLink(val fromX: Float, val toX: Float, val y: Float, val e
  * Derived siblings hang from their family's descent bar; these have no bar to hang from, so they
  * get a notation of their own. Dashed, because what joins them is the part nobody wrote down.
  */
-data class SiblingBracket(val fromX: Float, val toX: Float, val y: Float)
+data class SiblingBracket(
+    val fromX: Float,
+    val toX: Float,
+    val y: Float,
+    val aId: String = "",
+    val bId: String = "",
+) {
+    fun touches(personId: String): Boolean = personId == aId || personId == bId
+}
 
 /** One connected family, framed and counted. */
 data class TreeGroup(

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
@@ -620,6 +620,8 @@ object WholeTreeLayoutEngine {
                 toX = right.x,
                 y = left.centerY,
                 ended = false,
+                aId = a,
+                bId = b,
             )
         }
 
@@ -647,6 +649,8 @@ object WholeTreeLayoutEngine {
                     busY = max(childTopY - TreeMetrics.LEVEL_GAP * 0.42f, originY + 10f),
                     childXs = childNodes.map { it.centerX },
                     childTopY = childTopY,
+                    parentIds = parentNodes.map { it.person.id },
+                    childIds = childNodes.map { it.person.id },
                 )
             }
 
@@ -657,7 +661,7 @@ object WholeTreeLayoutEngine {
             if (na.y != nb.y) return@forEach
             val left = if (na.x < nb.x) na else nb
             val right = if (na.x < nb.x) nb else na
-            brackets += SiblingBracket(left.centerX, right.centerX, left.y)
+            brackets += SiblingBracket(left.centerX, right.centerX, left.y, aId = a, bId = b)
         }
 
         return Links(spouses, descents, brackets)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -50,6 +50,7 @@ import com.vibethroughcode.ftree.FTreeApplication
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.transfer.TreeDocument
 import com.vibethroughcode.ftree.transfer.sendBranchIntent
+import com.vibethroughcode.ftree.ui.common.LocalHasNavigationRail
 import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.isShortWindow
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
@@ -186,7 +187,17 @@ fun FTreeApp(
      */
     val useRail = onTopLevel && isShortWindow()
 
-    CompositionLocalProvider(LocalKinshipLanguage provides kinshipLanguage) {
+    /*
+     * The rail is announced rather than re-derived.
+     *
+     * Every screen beside it lays its own reading column against it, and a screen working that out
+     * from the window size would be guessing at a decision made here — and would guess wrongly the
+     * moment the rail appears or disappears for a reason other than the height.
+     */
+    CompositionLocalProvider(
+        LocalKinshipLanguage provides kinshipLanguage,
+        LocalHasNavigationRail provides useRail,
+    ) {
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
             bottomBar = {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/Windowing.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/Windowing.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
@@ -30,14 +31,40 @@ fun isShortWindow(): Boolean {
 private val SHORT_WINDOW = 500.dp
 
 /**
- * Holds a column of reading matter to a sensible measure, centred in whatever is left.
+ * Whether a navigation rail stands along the start edge of whatever is being laid out.
+ *
+ * Provided once by the app shell, which is the only thing that knows. A screen has no business
+ * asking about the orientation to work this out — the rail appears for reasons of its own — and
+ * it needs the answer because a column of reading matter is positioned relative to the edge it
+ * sits beside, not relative to the glass.
+ */
+val LocalHasNavigationRail = staticCompositionLocalOf { false }
+
+/**
+ * Holds a column of reading matter to a sensible measure, against whatever edge it belongs to.
  *
  * A list of names stretched across a landscape phone puts the name at one edge of the screen and
  * the date at the other, with a hand's width of nothing between them — the eye loses the row on the
  * way across. Typographers have known the answer for five hundred years and it is not "wider": a
  * line has a comfortable length, and past it you add margins rather than words.
  *
+ * Where the column *sits* is the other half of it, and the answer is not "the middle" whatever the
+ * screen. Centred beside a navigation rail, a column leaves a band of nothing between the rail and
+ * the first word, bounded by furniture on both sides — a gap that reads as a mistake rather than as
+ * a margin, and one the eye keeps trying to fill. So the column anchors to the rail when there is
+ * one and centres when there is not, which in both cases puts its start edge against the nearest
+ * real edge.
+ *
+ * Applied to a whole screen rather than to its body: a top bar and a floating button laid out to
+ * the full width, above a column that is not, leave a search icon and an "add" button stranded out
+ * in the margin with nothing to line up against. One measure for the screen means everything on it
+ * shares the same two edges.
+ *
  * The charts are exempt, deliberately. They are pictures, not prose, and they want every pixel.
  */
-fun Modifier.readableMeasure(max: Dp = 560.dp): Modifier =
-    fillMaxWidth().wrapContentWidth(Alignment.CenterHorizontally).widthIn(max = max)
+@Composable
+fun Modifier.readableMeasure(max: Dp = 560.dp): Modifier {
+    val alignment =
+        if (LocalHasNavigationRail.current) Alignment.Start else Alignment.CenterHorizontally
+    return fillMaxWidth().wrapContentWidth(alignment).widthIn(max = max)
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
@@ -78,8 +78,16 @@ fun PeopleScreen(
         if (searching) focusRequester.requestFocus()
     }
 
+    /*
+     * The measure is put on the whole screen rather than on the list inside it.
+     *
+     * The top bar, the search icon and the "add a person" button are laid out by the scaffold, so
+     * insetting only the body left them out in the margin: a search icon against the far bezel
+     * above a list that stopped a hundred points short of it, and nothing on the screen sharing an
+     * edge with anything else.
+     */
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.readableMeasure(),
         topBar = {
             if (searching) {
                 OutlinedTextField(
@@ -135,7 +143,7 @@ fun PeopleScreen(
             }
         },
     ) { padding ->
-        Column(Modifier.fillMaxHeight().padding(padding).readableMeasure()) {
+        Column(Modifier.fillMaxHeight().padding(padding)) {
             if (!state.isEmptyTree) {
                 PeopleFilterRow(
                     filter = state.filter,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
@@ -97,8 +97,10 @@ fun SettingsScreen(
     val betaChannel by viewModel.betaChannel.collectAsStateWithLifecycle()
     var confirmingBeta by remember { mutableStateOf(false) }
 
+    // One measure for the screen, so the title above the settings sits over the settings rather
+    // than over the middle of the glass. See `readableMeasure`.
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.readableMeasure(),
         topBar = {
             CenterAlignedTopAppBar(title = { Text(stringResource(R.string.settings_title)) })
         },
@@ -107,7 +109,6 @@ fun SettingsScreen(
         modifier = Modifier
             .fillMaxHeight()
             .padding(padding)
-            .readableMeasure()
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp),
     ) {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.sp
 import com.vibethroughcode.ftree.data.PartialDate
 import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.graph.DescentLink
 import com.vibethroughcode.ftree.graph.TreeMetrics
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import kotlin.math.max
@@ -56,6 +57,57 @@ internal fun visibleRegion(pan: Offset, zoom: Float, unitPx: Float, viewport: In
 
 internal fun visibleRegion(pan: Offset, zoom: Float, unitPx: Float, viewport: Size): Rect =
     visibleRegion(pan, zoom, unitPx, viewport.width, viewport.height)
+
+/**
+ * One family's descent: a drop from the parents, a bar across the children, and a drop to each.
+ *
+ * The bar runs from the parents' stem to the far side of the children, rather than only between the
+ * first child and the last. That is not a flourish: the parents' midpoint is regularly *outside* the
+ * span of their own children — a couple whose eldest child has a wide subtree of their own gets
+ * pushed clear of the whole run — and a bar drawn only between the children then leaves the stem
+ * ending in mid-air. The chart silently stops claiming the parentage it was drawn to state, and a
+ * reader quite reasonably concludes those children have no recorded parents. It is one line of
+ * arithmetic to draw the connector that was always meant to be there.
+ *
+ * Written once because both charts draw it, and a connector that means one thing on the focused
+ * chart and another on the whole one is not notation.
+ */
+fun DrawScope.drawDescent(
+    link: DescentLink,
+    unitPx: Float,
+    color: Color,
+    strokeWidth: Float,
+    alpha: Float = 1f,
+) {
+    val originX = link.originX * unitPx
+    val busY = link.busY * unitPx
+    val xs = link.childXs.map { it * unitPx }
+    if (xs.isEmpty()) return
+
+    drawLine(
+        color = color,
+        start = Offset(originX, link.originY * unitPx),
+        end = Offset(originX, busY),
+        strokeWidth = strokeWidth,
+        alpha = alpha,
+    )
+    drawLine(
+        color = color,
+        start = Offset(link.barStart * unitPx, busY),
+        end = Offset(link.barEnd * unitPx, busY),
+        strokeWidth = strokeWidth,
+        alpha = alpha,
+    )
+    xs.forEach { x ->
+        drawLine(
+            color = color,
+            start = Offset(x, busY),
+            end = Offset(x, link.childTopY * unitPx),
+            strokeWidth = strokeWidth,
+            alpha = alpha,
+        )
+    }
+}
 
 /** How much of a card is drawn, which depends on how far out the chart is zoomed. */
 enum class CardDetail {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -185,24 +185,7 @@ fun FamilyChart(
         translate(currentPan.x, currentPan.y) {
             scale(currentZoom, currentZoom, Offset.Zero) {
                 layout.descentLinks.forEach { link ->
-                    val originX = link.originX * unitPx
-                    val busY = link.busY * unitPx
-                    val xs = link.childXs.map { it * unitPx }
-
-                    drawLine(
-                        accents.rule,
-                        Offset(originX, link.originY * unitPx),
-                        Offset(originX, busY),
-                        rulePx,
-                    )
-                    if (xs.size > 1) {
-                        drawLine(accents.rule, Offset(xs.first(), busY), Offset(xs.last(), busY), rulePx)
-                    } else {
-                        drawLine(accents.rule, Offset(originX, busY), Offset(xs.first(), busY), rulePx)
-                    }
-                    xs.forEach { x ->
-                        drawLine(accents.rule, Offset(x, busY), Offset(x, link.childTopY * unitPx), rulePx)
-                    }
+                    drawDescent(link, unitPx, accents.rule, rulePx)
                 }
 
                 // Marriage is the doubled rule, as on a drawn pedigree.

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/TreeScreen.kt
@@ -423,14 +423,25 @@ fun TreeScreen(
                          * empty side of it. This is why the sheet is not a modal one: the thing
                          * you choose from has to stay live underneath.
                          */
+                        /*
+                         * One tap, one result.
+                         *
+                         * A tap used to select somebody *and* open a sheet over the top of the
+                         * selection, so the highlight it had just produced was behind a scrim and
+                         * had to be dismissed to be looked at — the chart answering a question by
+                         * covering the answer. Now the first tap only selects: the neighbours and
+                         * the lines joining them light up, the rest recede, and nothing is drawn
+                         * over the chart. Tapping the same person again asks for the actions,
+                         * which by then is a deliberate second thing to want.
+                         */
                         onSelect = {
-                            if (relating) {
-                                relationViewModel.name(it.id)
-                            } else {
-                                wholeTreeViewModel.select(it)
-                                selected = it
+                            when {
+                                relating -> relationViewModel.name(it.id)
+                                wholeSelection?.id == it.id -> selected = it
+                                else -> wholeTreeViewModel.select(it)
                             }
                         },
+                        onDeselect = { if (!relating) wholeTreeViewModel.select(null) },
                     )
                 }
             }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -65,6 +65,8 @@ fun WholeFamilyChart(
     layout: WholeTreeLayout,
     onSelect: (Person) -> Unit,
     modifier: Modifier = Modifier,
+    /** A tap on the paper between the cards, which is how a selection is put down again. */
+    onDeselect: () -> Unit = {},
     selectedId: String? = null,
     highlighted: Set<String> = emptySet(),
     /** True when [layout] holds one traced relation rather than the whole record. */
@@ -194,6 +196,7 @@ fun WholeFamilyChart(
     }
 
     val tapped by rememberUpdatedState(onSelect)
+    val tappedNobody by rememberUpdatedState(onDeselect)
 
     Canvas(
         modifier = modifier
@@ -222,7 +225,9 @@ fun WholeFamilyChart(
                     // It is only restarted when the layout changes, so a tap handler that closes
                     // over screen state — what a tap should do while a relation is being asked —
                     // would otherwise go on doing what it meant several states ago.
-                    layout.nodeAt(x, y)?.let { tapped(it.person) }
+                    // Tapping the paper puts the selection down. Without it the only way out of a
+                    // dimmed chart is to select somebody else, which is not putting it down.
+                    layout.nodeAt(x, y)?.let { tapped(it.person) } ?: tappedNobody()
                 }
             },
     ) {
@@ -240,6 +245,14 @@ fun WholeFamilyChart(
          */
         val showLabels = currentZoom >= SHOW_LABELS && !tracing
         val dimming = highlighted.isNotEmpty()
+        /*
+         * Whose lines to light: the selected person's own, not the whole highlighted set.
+         *
+         * The set is the selection *and* everybody a step from it, which is the right answer for
+         * cards and the wrong one for lines — lighting every connector belonging to every neighbour
+         * would re-draw most of the lattice that dimming just took away.
+         */
+        val lit = selectedId?.takeIf { dimming }
 
         val visible = visibleRegion(currentPan, currentZoom, unitPx, size)
 
@@ -317,21 +330,26 @@ fun WholeFamilyChart(
                     }
                 }
 
+                /*
+                 * The connectors take part in the selection, rather than watching it happen.
+                 *
+                 * Fading the cards alone was the worst of both: a hundred and forty people dimmed
+                 * and the entire lattice joining them left at full strength, so the one thing still
+                 * competing for the eye was the thing the reader was trying to see past. The lines
+                 * that run to the selected person are what *explain* the highlight — these are her
+                 * parents, this is the marriage, those are the children — so they are drawn heavier
+                 * and in the selection's own colour, and every other line recedes with the cards.
+                 */
                 layout.descentLinks.forEach { link ->
                     if (link.busY < visible.top || link.originY > visible.bottom) return@forEach
-                    val originX = link.originX * unitPx
-                    val busY = link.busY * unitPx
-                    val xs = link.childXs.map { it * unitPx }
-
-                    drawLine(accents.rule, Offset(originX, link.originY * unitPx), Offset(originX, busY), rulePx)
-                    if (xs.size > 1) {
-                        drawLine(accents.rule, Offset(xs.first(), busY), Offset(xs.last(), busY), rulePx)
-                    } else {
-                        drawLine(accents.rule, Offset(originX, busY), Offset(xs.first(), busY), rulePx)
-                    }
-                    xs.forEach { x ->
-                        drawLine(accents.rule, Offset(x, busY), Offset(x, link.childTopY * unitPx), rulePx)
-                    }
+                    val on = lit != null && link.touches(lit)
+                    drawDescent(
+                        link = link,
+                        unitPx = unitPx,
+                        color = if (on) colors.primary else accents.rule,
+                        strokeWidth = if (on) rulePx * 2f else rulePx,
+                        alpha = if (!dimming || on) 1f else FADED,
+                    )
                 }
 
                 // Siblings whose shared parents are unknown: bracketed above, dashed, because what
@@ -339,6 +357,7 @@ fun WholeFamilyChart(
                 layout.siblingBrackets.forEach { bracket ->
                     val lift = TreeMetrics.LEVEL_GAP * 0.22f
                     val top = (bracket.y - lift) * unitPx
+                    val on = lit != null && bracket.touches(lit)
                     val path = Path().apply {
                         moveTo(bracket.fromX * unitPx, bracket.y * unitPx)
                         lineTo(bracket.fromX * unitPx, top)
@@ -347,9 +366,10 @@ fun WholeFamilyChart(
                     }
                     drawPath(
                         path = path,
-                        color = accents.rule,
+                        color = if (on) colors.primary else accents.rule,
+                        alpha = if (!dimming || on) 1f else FADED,
                         style = Stroke(
-                            width = rulePx,
+                            width = if (on) rulePx * 2f else rulePx,
                             pathEffect = PathEffect.dashPathEffect(floatArrayOf(rulePx * 4, rulePx * 3)),
                         ),
                     )
@@ -358,12 +378,17 @@ fun WholeFamilyChart(
                 layout.spouseLinks.forEach { link ->
                     if (link.y < visible.top || link.y > visible.bottom) return@forEach
                     val y = link.y * unitPx
+                    val on = lit != null && link.touches(lit)
                     listOf(-spouseGapPx, spouseGapPx).forEach { dy ->
                         drawLine(
+                            // The doubled rule keeps its own colour when lit: widened and at full
+                            // strength it is already the loudest thing on the row, and a marriage
+                            // recoloured to match a selection stops reading as a marriage.
                             color = accents.spouseLink,
                             start = Offset(link.fromX * unitPx, y + dy),
                             end = Offset(link.toX * unitPx, y + dy),
-                            strokeWidth = rulePx,
+                            strokeWidth = if (on) rulePx * 1.6f else rulePx,
+                            alpha = if (!dimming || on) 1f else FADED,
                         )
                     }
                 }
@@ -402,7 +427,7 @@ fun WholeFamilyChart(
                         cornerPx = cornerPx,
                         rulePx = rulePx,
                         emphasised = isSelected,
-                        alpha = if (near) 1f else 0.3f,
+                        alpha = if (near) 1f else FADED,
                         photo = if (detail == CardDetail.SHAPE) null
                         else photos?.image(node.person.photoId),
                     )
@@ -417,6 +442,9 @@ private const val SHOW_NAMES = 0.4f
 private const val SHOW_YEARS = 0.66f
 private const val SHOW_LABELS = 0.34f
 /** The scale at which a card is still readable, used to decide whether fitting is worth it. */
+/** What a card or a connector fades to when it is not part of the selection. */
+private const val FADED = 0.28f
+
 /** Air left around a traced line, in layout units, so the cards do not touch the edges. */
 private const val TRACE_MARGIN = 12f
 

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
@@ -296,6 +296,85 @@ class TreeLayoutEngineTest {
         }
     }
 
+    /**
+     * A man who married twice, with three children by each and grandchildren under all of them —
+     * the shape that put a stem in mid-air on a real family record.
+     */
+    private fun twoMarriages(): FamilySnapshot {
+        val builder = Builder()
+            .person("father", "1900").person("first", "1902").person("second", "1906")
+            .married("father", "first").married("father", "second")
+        var grandchild = 0
+        listOf(
+            "first" to listOf("a1" to "1925", "a2" to "1927", "a3" to "1929"),
+            "second" to listOf("b1" to "1931", "b2" to "1933", "b3" to "1935"),
+        ).forEach { (wife, children) ->
+            children.forEach { (id, born) ->
+                builder.person(id, born).parentOf("father", id).parentOf(wife, id)
+                repeat(4) {
+                    val child = "g${grandchild++}"
+                    builder.person(child, "1955").parentOf(id, child)
+                }
+            }
+        }
+        return builder.build()
+    }
+
+    @Test
+    fun `a descent bar reaches the parents it descends from`() {
+        val layout = TreeLayoutEngine.layout(twoMarriages(), "father", generationsDown = 2)
+
+        val marriages = layout.descentLinks.filter { "father" in it.parentIds }
+        assertEquals("one connector per marriage", 2, marriages.size)
+
+        marriages.forEach { link ->
+            // The case that matters: the couple's midpoint is outside the run of their own
+            // children, because a child's subtree pushed the run clear of them.
+            assertTrue(
+                "fixture no longer reproduces the stranded stem",
+                link.originX < link.childXs.min() || link.originX > link.childXs.max(),
+            )
+            assertTrue("bar does not reach the stem", link.originX in link.barStart..link.barEnd)
+            link.childXs.forEach {
+                assertTrue("bar does not reach a child", it in link.barStart..link.barEnd)
+            }
+        }
+    }
+
+    @Test
+    fun `every descent bar spans its stem and all of its children`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+        assertTrue(layout.descentLinks.isNotEmpty())
+        layout.descentLinks.forEach { link ->
+            assertTrue(link.originX in link.barStart..link.barEnd)
+            link.childXs.forEach { assertTrue(it in link.barStart..link.barEnd) }
+        }
+    }
+
+    @Test
+    fun `a connector names the people at both of its ends`() {
+        val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
+        val mine = layout.descentLinks.single { "child" in it.childIds }
+
+        assertEquals(setOf("me", "wife"), mine.parentIds.toSet())
+        assertTrue(mine.touches("me"))
+        assertTrue(mine.touches("child"))
+        assertFalse("a connector must not claim somebody it does not join", mine.touches("sister"))
+    }
+
+    @Test
+    fun `a drop matches the child underneath it`() {
+        val layout = TreeLayoutEngine.layout(twoMarriages(), "father", generationsDown = 2)
+        layout.descentLinks.forEach { link ->
+            assertEquals(link.childXs.size, link.childIds.size)
+            link.childIds.forEachIndexed { index, id ->
+                // The ids are carried in the same order as the drops, so a drop and the card
+                // beneath it can be matched up rather than assumed to correspond.
+                assertEquals(layout.xOf(id), link.childXs[index], 0.01f)
+            }
+        }
+    }
+
     @Test
     fun `a wide family stays laid out in reasonable time`() {
         val builder = Builder()

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngineTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngineTest.kt
@@ -2,6 +2,7 @@ package com.vibethroughcode.ftree.graph
 
 import com.vibethroughcode.ftree.data.Person
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
@@ -372,6 +373,52 @@ class WholeTreeLayoutEngineTest {
                 "$child is not below $parent",
                 layout.node(child)!!.level > layout.node(parent)!!.level,
             )
+        }
+    }
+
+    @Test
+    fun `every descent bar spans its stem and all of its children`() {
+        val layout = WholeTreeLayoutEngine.layout(archive())
+        assertTrue(layout.descentLinks.isNotEmpty())
+        layout.descentLinks.forEach { link ->
+            assertTrue(
+                "the bar must reach the parents it descends from",
+                link.originX in link.barStart..link.barEnd,
+            )
+            link.childXs.forEach {
+                assertTrue("the bar must reach every child", it in link.barStart..link.barEnd)
+            }
+        }
+    }
+
+    @Test
+    fun `connectors name the people they join`() {
+        val layout = WholeTreeLayoutEngine.layout(archive())
+
+        val descent = layout.descentLinks.single { "kid" in it.childIds }
+        assertEquals(setOf("me", "spouse"), descent.parentIds.toSet())
+        assertTrue(descent.touches("me"))
+        assertTrue(descent.touches("kid"))
+        assertFalse(descent.touches("aunt"))
+
+        val marriage = layout.spouseLinks.single { it.touches("kid".let { _ -> "spouse" }) }
+        assertTrue(marriage.touches("me"))
+        assertFalse(marriage.touches("dad"))
+
+        // Every connector can say whose it is: a line that cannot is a line that has to stay lit
+        // when a selection fades everything around it.
+        assertTrue(layout.descentLinks.all { it.parentIds.isNotEmpty() && it.childIds.isNotEmpty() })
+        assertTrue(layout.spouseLinks.all { it.aId.isNotEmpty() && it.bId.isNotEmpty() })
+    }
+
+    @Test
+    fun `a drop matches the child underneath it`() {
+        val layout = WholeTreeLayoutEngine.layout(archive())
+        layout.descentLinks.forEach { link ->
+            assertEquals(link.childXs.size, link.childIds.size)
+            link.childIds.forEachIndexed { index, id ->
+                assertEquals(layout.node(id)!!.centerX, link.childXs[index], 0.01f)
+            }
         }
     }
 }


### PR DESCRIPTION
Four things Ankit reported from his own 148-person record, plus the measurements that found them.

## The descent bar never reached the parents

The bar was drawn between the first child and the last, and never extended to meet the stem coming down from the parents:

```kotlin
drawLine(originX, originY → originX, busY)                       // stem
if (xs.size > 1) drawLine(xs.first(), busY → xs.last(), busY)    // children ONLY
```

Where a couple's midpoint falls outside the run of their own children — which happens whenever one child's subtree pushes the run clear of them — the stem ends in mid-air, and the chart silently stops claiming the parentage it was drawn to state.

Measured by running the engines over the real record:

| | bars | stem outside the children's span | worst gap |
|---|---|---|---|
| Focused chart | 19 | **2** | 6.4 card widths |
| Whole chart | 45 | **18** | 15 card widths |

Both of one man's marriages were broken, in opposite directions — which is why one wife's children looked connected and the other's did not, depending on where you had panned.

`DescentLink` now exposes `barStart`/`barEnd`, so "the bar reaches everything it joins" is a property a JVM test holds it to rather than a detail of one canvas. `drawDescent` is written once and shared, since a connector that means one thing on each chart is not notation.

## The connectors did not take part in a selection

`highlighted` was used for exactly one thing: card alpha. Every line stayed at full strength, so selecting somebody faded 140 cards and left the lattice the reader was trying to see past untouched.

Connectors could not have done better — they were pure coordinates with no way to answer "do you touch this person?". They now carry the ids they join. Lines running to the selected person are drawn at 2× weight in the selection's colour; the rest fade with the cards. Selecting one person on the real record lights **3 of 88** connectors.

Deliberately *not* done: a separate line from each parent to each child, which was the other option on the table. A child descends from a couple, and one bar per parent set is what makes a second marriage legible. Doubling the lines would treat the symptom by adding more of the cause — the bar was never the confusion, its uniformity was.

## One tap did two things

A tap selected somebody **and** opened a `ModalBottomSheet` — scrim included — over the top of the selection, so the highlight had to be dismissed before it could be looked at. First tap now selects only; second tap on the same person asks for the actions; a tap on the paper puts the selection down.

## Landscape

`readableMeasure` centred a 560dp column while the top bar and FAB were laid out to the full width, so a search icon sat against the far bezel above a list that stopped 100dp short of it. The measure moves to the whole screen and anchors to the rail when there is one — announced by `LocalHasNavigationRail`, since a screen re-deriving it from the window size would be guessing at a decision the shell makes.

Measured on device via `uiautomator dump`:

| | bounds (px) |
|---|---|
| Navigation rail | `136 → 430` (112dp) |
| **Scaffold column** | **`430 → 1900` (exactly 560dp, flush to the rail)** |
| Top bar | `430 → 1900` |
| List rows | `566 → 1900` |
| FAB right edge | `1858` (16dp inside) |

## Known, not fixed here

`placeDescendants` reserves each child a slot as wide as that child's whole subtree, which puts one couple's three children **14.8 card widths apart** and makes the focused chart **45 card widths wide**. That is likely the real cause of "navigation is tedious" — but it is a layout-engine change with its own blast radius and belongs in its own PR.

## Verification

- **206 unit tests** — 7 new, covering the bar's reach in both directions, the ids at both ends, and drops matching their children
- **155 instrumented tests** — 1 new, asserting the first tap leaves the chart uncovered and the second opens the actions
- **lint unchanged** at 82 findings, none in the changed files
- Confirmed on the real 148-person record on device, portrait and landscape

🤖 Generated with [Claude Code](https://claude.com/claude-code)