### PR TITLE
Version 0.7.0-beta.2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 17
-        versionName = "0.7.0-beta.1"
+        versionCode = 18
+        versionName = "0.7.0-beta.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 18, `versionName` 0.7.0-beta.2 — a pre-release, so `releases/latest` keeps answering v0.6.0 and stable users are untouched.

Ships [#67](https://github.com/thisisankit27/f-tree/pull/67):

- **Every descent bar reaches its parents.** The bar was drawn between the first and last child and never extended to the stem, so a couple sitting outside the run of their own children left a connector hanging in mid-air — 2 of 19 bars on the focused chart and 18 of 45 on the whole one, measured on a real 148-person record.
- **The lines take part in a selection.** Connectors now carry the people they join, so the ones running to the selected person draw heavier and in the selection's colour while the rest fade with the cards.
- **A tap selects before it offers to do anything.** It used to select *and* open a sheet over the top of the selection.
- **Landscape anchors the reading column to the rail**, so the top bar, the list and the floating button share one pair of edges instead of scattering across the width.

206 unit, 155 instrumented, lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)