### PR TITLE
Turn the whole-tree chart on its side

### DIFF
--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
@@ -112,6 +112,18 @@ object TreeMetrics {
     /** Between generations, leaving room for the descent connectors. */
     const val LEVEL_GAP = 76f
 
+    /**
+     * The whole-tree chart runs sideways, so it needs the same three gaps measured the other way.
+     *
+     * Between people in a generation the gap is smaller than [SIBLING_GAP]: that gap separates
+     * cards along their long edge, where 36 is what it takes to read as a break, and these are
+     * stacked along their short one. Between generations it is larger than [LEVEL_GAP], because a
+     * descent now leaves sideways and needs room for a stem, a bar and a stub in the space a
+     * vertical chart only has to fit a drop into.
+     */
+    const val STACK_GAP = 22f
+    const val GENERATION_GAP = 104f
+
     const val MARGIN = 24f
 
     /**

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayout.kt
@@ -3,15 +3,31 @@ package com.vibethroughcode.ftree.graph
 import com.vibethroughcode.ftree.data.Person
 
 /**
- * A chart of the entire tree rather than one person's neighbourhood.
+ * A chart of the entire tree rather than one person's neighbourhood — drawn sideways.
  *
  * [TreeLayout] is ego-centric because that is the right answer on a phone showing one person's
  * family. This is the other view: everybody at once, including the people no relationship reaches,
- * whom an ego-centric chart has nowhere to put at all. It is the same picture the web viewer draws.
+ * whom an ego-centric chart has nowhere to put at all.
+ *
+ * It runs **left to right**: a generation is a column, ancestors at the left, descendants to the
+ * right, and the people of one generation stacked down the screen. Drawn the ordinary way round —
+ * a generation to a row — a real family record is a ribbon. Ankit's is 78 cards wide and 5 tall, an
+ * aspect of fifteen, against a phone's of about a half, and it sits at ninety-nine per cent of the
+ * least width it could possibly occupy: the widest generation genuinely holds sixty-four people, so
+ * there is no packing to be won and nothing to fix in the arithmetic. The chart was simply the
+ * wrong way round for the shape of the thing it is read on. Turned on its side the same record is
+ * about five columns by sixty-four people: you scroll down through a generation, which is what a
+ * phone is for, and step sideways only a handful of times to cross the whole family.
+ *
+ * The cost is that every connector is rotated too, so this file carries its own — a marriage is a
+ * doubled rule down the side of a couple rather than across it, and a descent runs out to the right
+ * before it spreads. They are separate types rather than the ego chart's reused with the axes
+ * quietly swapped, because a coordinate whose meaning depends on which chart is reading it is a bug
+ * that compiles.
  */
 data class WholeTreeNode(
     val person: Person,
-    /** Row within the person's own shelf; -1 for somebody no relationship reaches. */
+    /** Column within the person's own shelf; -1 for somebody no relationship reaches. */
     val level: Int,
     val x: Float,
     val y: Float,
@@ -19,14 +35,19 @@ data class WholeTreeNode(
 ) {
     val centerX: Float get() = x + TreeMetrics.NODE_WIDTH / 2f
     val centerY: Float get() = y + TreeMetrics.NODE_HEIGHT / 2f
+    val right: Float get() = x + TreeMetrics.NODE_WIDTH
     val bottom: Float get() = y + TreeMetrics.NODE_HEIGHT
 }
 
-/** The doubled rule between partners, as [SpouseLink] but carrying which pair it joins. */
+/**
+ * The doubled rule between partners, drawn down the side of the couple.
+ *
+ * Vertical, because the couple is stacked: one above the other in their generation's column.
+ */
 data class WholeSpouseLink(
-    val fromX: Float,
-    val toX: Float,
-    val y: Float,
+    val x: Float,
+    val fromY: Float,
+    val toY: Float,
     val ended: Boolean,
     val aId: String = "",
     val bId: String = "",
@@ -35,15 +56,42 @@ data class WholeSpouseLink(
 }
 
 /**
- * A bracket over siblings whose shared parents are unknown.
+ * One family's descent, running sideways: out to the right of the parents, a bar down the children,
+ * and a stub into each.
+ *
+ * [DescentLink] turned through a right angle, and the same rule holds — the bar spans the parents'
+ * stem as well as every child, so a couple sitting outside the run of their own children still has
+ * a connector that reaches them rather than one ending in mid-air.
+ */
+data class WholeDescentLink(
+    /** Where the stem leaves the parents: their right edge, at their middle. */
+    val originX: Float,
+    val originY: Float,
+    /** The column the bar stands in, between the parents and the children. */
+    val busX: Float,
+    val childYs: List<Float>,
+    /** The left edge of the children's column, where each stub arrives. */
+    val childLeftX: Float,
+    val parentIds: List<String> = emptyList(),
+    /** In the same order as [childYs], so a stub and a child can be matched up. */
+    val childIds: List<String> = emptyList(),
+) {
+    fun touches(personId: String): Boolean = personId in parentIds || personId in childIds
+
+    val barStart: Float get() = minOf(originY, childYs.minOrNull() ?: originY)
+    val barEnd: Float get() = maxOf(originY, childYs.maxOrNull() ?: originY)
+}
+
+/**
+ * A bracket beside siblings whose shared parents are unknown.
  *
  * Derived siblings hang from their family's descent bar; these have no bar to hang from, so they
  * get a notation of their own. Dashed, because what joins them is the part nobody wrote down.
  */
 data class SiblingBracket(
-    val fromX: Float,
-    val toX: Float,
-    val y: Float,
+    val fromY: Float,
+    val toY: Float,
+    val x: Float,
     val aId: String = "",
     val bId: String = "",
 ) {
@@ -63,13 +111,13 @@ data class TreeGroup(
     val memberIds: List<String>,
 )
 
-/** A faint rule marking one generation across a shelf. */
-data class GenerationBand(val level: Int, val y: Float, val x: Float, val width: Float)
+/** A faint rule marking one generation down a shelf. */
+data class GenerationBand(val level: Int, val x: Float, val y: Float, val height: Float)
 
 data class WholeTreeLayout(
     val nodes: List<WholeTreeNode> = emptyList(),
     val spouseLinks: List<WholeSpouseLink> = emptyList(),
-    val descentLinks: List<DescentLink> = emptyList(),
+    val descentLinks: List<WholeDescentLink> = emptyList(),
     val siblingBrackets: List<SiblingBracket> = emptyList(),
     val groups: List<TreeGroup> = emptyList(),
     val bands: List<GenerationBand> = emptyList(),

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
@@ -1,14 +1,13 @@
 package com.vibethroughcode.ftree.graph
 
 import com.vibethroughcode.ftree.data.PartialDate
-import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.sqrt
 
 /**
- * Lays out the whole family at once.
+ * Lays out the whole family at once, sideways.
  *
  * [TreeLayoutEngine] draws one person's neighbourhood, which is the right answer on a phone: a
  * whole family laid out at once is something no phone can show *legibly*. This draws it anyway,
@@ -16,12 +15,20 @@ import kotlin.math.sqrt
  * glance, and because it is the only view that can show the people no relationship reaches — whom
  * an ego-centric chart has nowhere to put at all.
  *
- * The method is the standard layered one, adapted for genealogy:
+ * **A generation is a column, not a row.** See [WholeTreeLayout] for why: laid out the ordinary way
+ * round, a real record is a ribbon fifteen times wider than it is tall, and no packing improves it
+ * because the width is the widest generation and nothing else. Turning the chart through a right
+ * angle is the only thing that changes the shape, and it turns the long axis into the one a phone
+ * scrolls.
  *
- *  1. every person gets a generation, with spouses forced onto the same row
- *  2. each connected family is ordered within its rows to reduce crossings, couples locked together
- *  3. x comes from two opposing passes, averaged, which centres parents over children without
- *     letting rows overlap
+ * The method is the standard layered one, adapted for genealogy, and is unchanged by the rotation —
+ * only which axis carries which meaning:
+ *
+ *  1. every person gets a generation, with spouses forced into the same column
+ *  2. each connected family is ordered within its columns to reduce crossings, couples locked
+ *     together
+ *  3. position within a column comes from two opposing passes, averaged, which centres parents
+ *     beside their children without letting columns overlap
  *  4. families are packed onto shelves that share one generation grid, so a dozen small families
  *     read as strata rather than as scattered blocks
  *
@@ -36,22 +43,30 @@ object WholeTreeLayoutEngine {
     private const val CROSSING_PASSES = 8
     private const val PLACEMENT_PASSES = 10
 
-    private val rowPitch: Float get() = TreeMetrics.NODE_HEIGHT + TreeMetrics.LEVEL_GAP
+    /** One generation to the next, along the reading axis. */
+    private val generationPitch: Float
+        get() = TreeMetrics.NODE_WIDTH + TreeMetrics.GENERATION_GAP
 
-    /** A run of spouses that must stay side by side through every pass. */
+    /** How much room one person takes within their generation. */
+    private val personExtent: Float get() = TreeMetrics.NODE_HEIGHT
+
+    /** A run of spouses that must stay together through every pass. */
     private class Block(val members: List<String>) {
         var key = 0f
         var tie = 0
-        val width: Float
-            get() = members.size * TreeMetrics.NODE_WIDTH +
+
+        /** How far the block reaches along its own generation. */
+        val extent: Float
+            get() = members.size * TreeMetrics.NODE_HEIGHT +
                 (members.size - 1) * TreeMetrics.COUPLE_GAP
     }
 
     /**
      * @param aspect roughly how much wider than tall the finished chart should be. Below one it
-     *   packs taller, which suits a phone held upright.
+     *   packs taller, which is what a phone wants — and what the rotation exists to achieve, so the
+     *   default is well below one rather than close to it.
      */
-    fun layout(snapshot: FamilySnapshot, aspect: Float = 0.9f): WholeTreeLayout {
+    fun layout(snapshot: FamilySnapshot, aspect: Float = 0.45f): WholeTreeLayout {
         if (snapshot.people.isEmpty()) return WholeTreeLayout()
 
         val levels = assignLevels(snapshot)
@@ -62,59 +77,61 @@ object WholeTreeLayoutEngine {
         // Largest family first, so the trunk of the record lands top-left where reading starts.
         val laid = connected
             .map { placeComponent(snapshot, it, levels) }
-            .sortedWith(compareByDescending<Placed> { it.members.size }.thenByDescending { it.width })
+            .sortedWith(compareByDescending<Placed> { it.members.size }.thenByDescending { it.extent })
 
-        val area = laid.sumOf { ((it.width + GROUP_GAP) * (it.height + GROUP_GAP)).toDouble() } +
+        val area = laid.sumOf { ((it.span + GROUP_GAP) * (it.extent + GROUP_GAP)).toDouble() } +
             alone.size * (TreeMetrics.NODE_WIDTH + TreeMetrics.SIBLING_GAP).toDouble() *
-            (TreeMetrics.NODE_HEIGHT + TreeMetrics.SIBLING_GAP).toDouble()
-        val widest = laid.maxOfOrNull { it.width } ?: TreeMetrics.NODE_WIDTH
-        val shelfWidth = max(widest, sqrt(max(area, 1.0) * aspect).toFloat())
+            (TreeMetrics.NODE_HEIGHT + TreeMetrics.STACK_GAP).toDouble()
+        val tallest = laid.maxOfOrNull { it.extent } ?: TreeMetrics.NODE_HEIGHT
+        // Divided by the aspect rather than multiplied: the shelf now grows down the screen, so
+        // wanting a taller chart means wanting a taller shelf.
+        val shelfHeight = max(tallest, sqrt(max(area, 1.0) / aspect).toFloat())
 
         val nodes = mutableListOf<WholeTreeNode>()
         val groups = mutableListOf<TreeGroup>()
         val bands = mutableListOf<GenerationBand>()
 
-        var cursorX = GUTTER
-        var shelfTop = 0f
+        var cursorY = GUTTER
+        var shelfLeft = 0f
         var shelfDepth = 0
         var deepest = 0
 
         fun closeShelf() {
             if (shelfDepth == 0) return
             for (level in 0 until shelfDepth) {
-                bands += GenerationBand(level, shelfTop + level * rowPitch, 0f, cursorX)
+                bands += GenerationBand(level, shelfLeft + level * generationPitch, 0f, cursorY)
             }
             deepest = max(deepest, shelfDepth)
-            shelfTop += shelfDepth * rowPitch + GROUP_GAP
-            cursorX = GUTTER
+            shelfLeft += shelfDepth * generationPitch + GROUP_GAP
+            cursorY = GUTTER
             shelfDepth = 0
         }
 
         for (item in laid) {
-            if (cursorX > GUTTER && cursorX + item.width > shelfWidth) closeShelf()
-            val originX = cursorX
-            val originY = shelfTop
+            if (cursorY > GUTTER && cursorY + item.extent > shelfHeight) closeShelf()
+            val originX = shelfLeft
+            val originY = cursorY
             item.nodes.forEach { (id, point) ->
                 val person = snapshot.people[id] ?: return@forEach
                 nodes += WholeTreeNode(
                     person = person,
                     level = point.level,
-                    x = point.x + originX,
-                    y = point.y + originY,
+                    x = point.level * generationPitch + originX,
+                    y = point.across + originY,
                     groupIndex = groups.size,
                 )
             }
             groups += TreeGroup(
                 x = originX - GROUP_PAD,
                 y = originY - GROUP_PAD,
-                width = item.width + GROUP_PAD * 2,
-                height = item.height + GROUP_PAD * 2,
+                width = item.span + GROUP_PAD * 2,
+                height = item.extent + GROUP_PAD * 2,
                 memberCount = item.members.size,
                 generations = item.depth,
                 unconnected = false,
                 memberIds = item.members,
             )
-            cursorX += item.width + GROUP_GAP
+            cursorY += item.extent + GROUP_GAP
             shelfDepth = max(shelfDepth, item.depth)
         }
         closeShelf()
@@ -126,30 +143,30 @@ object WholeTreeLayoutEngine {
          * nowhere to put someone who is nobody's relative. A frame each would waste the screen, so
          * they go in one labelled grid: present and countable, without implying a structure the
          * record does not have. Its shape comes from its own size rather than the shelf, or a tree
-         * with no connected families at all would stack them into a single column.
+         * with no connected families at all would stack them into a single row.
          */
         if (alone.isNotEmpty()) {
-            val perRow = max(1, min(alone.size, ceil(sqrt(alone.size * aspect.toDouble())).toInt()))
-            val originX = GUTTER
-            val originY = shelfTop + GROUP_GAP
+            val perColumn = max(1, min(alone.size, ceil(sqrt(alone.size / aspect.toDouble())).toInt()))
+            val originX = shelfLeft + GROUP_GAP
+            val originY = GUTTER
             val stepX = TreeMetrics.NODE_WIDTH + TreeMetrics.SIBLING_GAP
-            val stepY = TreeMetrics.NODE_HEIGHT + TreeMetrics.SIBLING_GAP
+            val stepY = TreeMetrics.NODE_HEIGHT + TreeMetrics.STACK_GAP
             alone.forEachIndexed { i, id ->
                 val person = snapshot.people[id] ?: return@forEachIndexed
                 nodes += WholeTreeNode(
                     person = person,
                     level = -1,
-                    x = originX + (i % perRow) * stepX,
-                    y = originY + (i / perRow) * stepY,
+                    x = originX + (i / perColumn) * stepX,
+                    y = originY + (i % perColumn) * stepY,
                     groupIndex = groups.size,
                 )
             }
-            val rows = ceil(alone.size / perRow.toFloat()).toInt()
+            val columns = ceil(alone.size / perColumn.toFloat()).toInt()
             groups += TreeGroup(
                 x = originX - GROUP_PAD,
                 y = originY - GROUP_PAD,
-                width = min(alone.size, perRow) * stepX - TreeMetrics.SIBLING_GAP + GROUP_PAD * 2,
-                height = rows * stepY - TreeMetrics.SIBLING_GAP + GROUP_PAD * 2,
+                width = columns * stepX - TreeMetrics.SIBLING_GAP + GROUP_PAD * 2,
+                height = min(alone.size, perColumn) * stepY - TreeMetrics.STACK_GAP + GROUP_PAD * 2,
                 memberCount = alone.size,
                 generations = 1,
                 unconnected = true,
@@ -171,21 +188,23 @@ object WholeTreeLayoutEngine {
         val d = TreeMetrics.MARGIN
         return WholeTreeLayout(
             nodes = nodes.map { it.copy(x = it.x + d, y = it.y + d) },
-            spouseLinks = links.spouses.map { it.copy(fromX = it.fromX + d, toX = it.toX + d, y = it.y + d) },
+            spouseLinks = links.spouses.map {
+                it.copy(x = it.x + d, fromY = it.fromY + d, toY = it.toY + d)
+            },
             descentLinks = links.descents.map {
                 it.copy(
                     originX = it.originX + d,
                     originY = it.originY + d,
-                    busY = it.busY + d,
-                    childXs = it.childXs.map { x -> x + d },
-                    childTopY = it.childTopY + d,
+                    busX = it.busX + d,
+                    childYs = it.childYs.map { y -> y + d },
+                    childLeftX = it.childLeftX + d,
                 )
             },
             siblingBrackets = links.brackets.map {
-                it.copy(fromX = it.fromX + d, toX = it.toX + d, y = it.y + d)
+                it.copy(fromY = it.fromY + d, toY = it.toY + d, x = it.x + d)
             },
             groups = groups.map { it.copy(x = it.x + d, y = it.y + d) },
-            bands = bands.map { it.copy(x = it.x + d, y = it.y + d, width = width + d) },
+            bands = bands.map { it.copy(x = it.x + d, y = it.y + d, height = height + d) },
             width = width + d + TreeMetrics.MARGIN,
             height = height + d + TreeMetrics.MARGIN,
             unconnectedCount = alone.size,
@@ -198,30 +217,30 @@ object WholeTreeLayoutEngine {
     /**
      * Puts every person on a generation.
      *
-     * A generation is a *relative* fact and nothing else: a child stands exactly one row below each
-     * parent, and spouses — and siblings whose parents nobody recorded — stand on the same row as
-     * each other. Those constraints are propagated outward from one seed per connected family,
-     * which fixes every generation exactly, because the offset between two people is the same along
-     * every route between them. [layoutComponent] then normalises each family against its own
-     * topmost member.
+     * A generation is a *relative* fact and nothing else: a child stands exactly one column after
+     * each parent, and spouses — and siblings whose parents nobody recorded — stand in the same
+     * column as each other. Those constraints are propagated outward from one seed per connected
+     * family, which fixes every generation exactly, because the offset between two people is the
+     * same along every route between them. [placeComponent] then normalises each family against its
+     * own earliest member.
      *
      * It is worth saying what this deliberately is *not*, because the obvious alternative is wrong
      * in a way that takes a real family to notice. Ranking people by their longest path down from
-     * the oldest ancestor on record — the textbook layering — makes a person's row depend on how far
-     * back their ancestry happens to be written down. A maternal grandfather whose own parents are
-     * unknown lands on the top row beside a great-great-grandfather from the other side of the
-     * family; worse, his three children come out on different rows from each other, because each
-     * was dragged down by however deep their own spouse's ancestry ran. Generations are not depths.
-     * Two people are one generation apart or they are not, and how much of the record survives
-     * above them cannot change that.
+     * the oldest ancestor on record — the textbook layering — makes a person's column depend on how
+     * far back their ancestry happens to be written down. A maternal grandfather whose own parents
+     * are unknown lands in the first column beside a great-great-grandfather from the other side of
+     * the family; worse, his three children come out in different columns from each other, because
+     * each was dragged along by however deep their own spouse's ancestry ran. Generations are not
+     * depths. Two people are one generation apart or they are not, and how much of the record
+     * survives above them cannot change that.
      */
     private fun assignLevels(snapshot: FamilySnapshot): Map<String, Int> {
         val level = HashMap<String, Int>(snapshot.people.size)
 
         /*
          * Every constraint, as an offset. Derived siblings need no edge of their own — sharing a
-         * parent already puts them on one row — but an explicit sibling edge exists precisely where
-         * the parents are unknown, and without it those two would float apart.
+         * parent already puts them in one column — but an explicit sibling edge exists precisely
+         * where the parents are unknown, and without it those two would float apart.
          */
         fun stepsFrom(id: String): List<Pair<String, Int>> = buildList {
             snapshot.parentsOf[id].orEmpty().forEach { add(it to -1) }
@@ -249,19 +268,19 @@ object WholeTreeLayoutEngine {
 
         /*
          * The constraints can only disagree when the record itself does — somebody married to their
-         * own aunt gives one route saying "same row" and another saying "one row apart", and no
-         * assignment satisfies both. Where that happens the parent edge wins, because a connector
-         * running upward out of a child into their parent is unreadable in a way that a couple
-         * sitting a row apart is not. Bounded, so a cycle in an imported file still draws rather
-         * than hanging.
+         * own aunt gives one route saying "same column" and another saying "one column apart", and
+         * no assignment satisfies both. Where that happens the parent edge wins, because a
+         * connector running backwards out of a child into their parent is unreadable in a way that
+         * a couple sitting a column apart is not. Bounded, so a cycle in an imported file still
+         * draws rather than hanging.
          */
         repeat(40) {
             var changed = false
             snapshot.parentEdges.forEach { (from, to) ->
-                val above = level[from] ?: return@forEach
-                val below = level[to] ?: return@forEach
-                if (below <= above) {
-                    level[to] = above + 1
+                val before = level[from] ?: return@forEach
+                val after = level[to] ?: return@forEach
+                if (after <= before) {
+                    level[to] = before + 1
                     changed = true
                 }
             }
@@ -301,13 +320,15 @@ object WholeTreeLayoutEngine {
 
     /* ------------------------------------------------------------------ one family */
 
-    private class Point(val level: Int, val x: Float, val y: Float)
+    private class Point(val level: Int, val across: Float)
 
     private class Placed(
         val members: List<String>,
         val nodes: Map<String, Point>,
-        val width: Float,
-        val height: Float,
+        /** How far the family reaches along a generation. */
+        val extent: Float,
+        /** How far it reaches across the generations. */
+        val span: Float,
         val depth: Int,
     )
 
@@ -319,21 +340,21 @@ object WholeTreeLayoutEngine {
         val base = members.minOf { globalLevels.getValue(it) }
         val levels = members.associateWith { globalLevels.getValue(it) - base }
 
-        val rows = initialOrder(snapshot, members, levels)
-        reduceCrossings(snapshot, rows)
-        val xs = assignX(snapshot, rows)
+        val columns = initialOrder(snapshot, members, levels)
+        reduceCrossings(snapshot, columns)
+        val across = assignAcross(snapshot, columns)
 
-        val minX = members.minOf { xs.getValue(it) }
-        val maxX = members.maxOf { xs.getValue(it) } + TreeMetrics.NODE_WIDTH
+        val minAcross = members.minOf { across.getValue(it) }
+        val maxAcross = members.maxOf { across.getValue(it) } + personExtent
         val depth = members.maxOf { levels.getValue(it) } + 1
 
         return Placed(
             members = members,
             nodes = members.associateWith {
-                Point(levels.getValue(it), xs.getValue(it) - minX, levels.getValue(it) * rowPitch)
+                Point(levels.getValue(it), across.getValue(it) - minAcross)
             },
-            width = maxX - minX,
-            height = depth * rowPitch - TreeMetrics.LEVEL_GAP,
+            extent = maxAcross - minAcross,
+            span = depth * generationPitch - TreeMetrics.GENERATION_GAP,
             depth = depth,
         )
     }
@@ -352,7 +373,7 @@ object WholeTreeLayoutEngine {
     }
 
     /**
-     * A first ordering, walked family by family: spouses beside each other, then down through each
+     * A first ordering, walked family by family: spouses beside each other, then along each
      * family's children in birth order. This alone lays out a tree-shaped family correctly, so the
      * sweeps that follow only have to fix the places where it is not a tree.
      */
@@ -361,7 +382,7 @@ object WholeTreeLayoutEngine {
         members: List<String>,
         levels: Map<String, Int>,
     ): MutableMap<Int, MutableList<String>> {
-        val rows = mutableMapOf<Int, MutableList<String>>()
+        val columns = mutableMapOf<Int, MutableList<String>>()
         val seen = mutableSetOf<String>()
         val compare = birthOrder(snapshot)
         val explicitSiblings = snapshot.siblingEdges
@@ -370,7 +391,7 @@ object WholeTreeLayoutEngine {
 
         fun place(id: String): Boolean {
             if (!seen.add(id)) return false
-            rows.getOrPut(levels.getValue(id)) { mutableListOf() } += id
+            columns.getOrPut(levels.getValue(id)) { mutableListOf() } += id
             return true
         }
 
@@ -406,15 +427,15 @@ object WholeTreeLayoutEngine {
         )
         roots.forEach { visit(it) }
         roots.forEach { place(it) }
-        return rows
+        return columns
     }
 
-    private fun buildBlocks(snapshot: FamilySnapshot, row: List<String>): List<Block> {
-        val present = row.toSet()
+    private fun buildBlocks(snapshot: FamilySnapshot, column: List<String>): List<Block> {
+        val present = column.toSet()
         val taken = mutableSetOf<String>()
         val blocks = mutableListOf<Block>()
 
-        row.forEach { id ->
+        column.forEach { id ->
             if (id in taken) return@forEach
             val group = mutableListOf(id)
             taken += id
@@ -444,160 +465,161 @@ object WholeTreeLayoutEngine {
     }
 
     /**
-     * Barycentre sweeps: each block moves to the average position of what it connects to on the
-     * neighbouring row. Alternating direction a few times settles the ordering.
+     * Barycentre sweeps: each block moves to the average position of what it connects to in the
+     * neighbouring column. Alternating direction a few times settles the ordering.
      */
     private fun reduceCrossings(
         snapshot: FamilySnapshot,
-        rows: MutableMap<Int, MutableList<String>>,
+        columns: MutableMap<Int, MutableList<String>>,
     ) {
-        val keys = rows.keys.sorted()
+        val keys = columns.keys.sorted()
         if (keys.size < 2) return
 
         repeat(CROSSING_PASSES) { pass ->
-            val downward = pass % 2 == 0
-            val order = if (downward) keys else keys.reversed()
+            val forward = pass % 2 == 0
+            val order = if (forward) keys else keys.reversed()
 
             order.forEach { level ->
-                val neighbourRow = rows[level + if (downward) -1 else 1] ?: return@forEach
-                val positions = neighbourRow.withIndex().associate { (i, id) -> id to i }
-                val row = rows.getValue(level)
-                val current = row.withIndex().associate { (i, id) -> id to i }
-                val blocks = buildBlocks(snapshot, row)
+                val neighbour = columns[level + if (forward) -1 else 1] ?: return@forEach
+                val positions = neighbour.withIndex().associate { (i, id) -> id to i }
+                val column = columns.getValue(level)
+                val current = column.withIndex().associate { (i, id) -> id to i }
+                val blocks = buildBlocks(snapshot, column)
 
                 blocks.forEach { block ->
                     val seen = block.members.flatMap { id ->
-                        val related = if (downward) snapshot.parentsOf[id].orEmpty()
+                        val related = if (forward) snapshot.parentsOf[id].orEmpty()
                         else snapshot.childrenOf[id].orEmpty()
                         related.mapNotNull { positions[it] }
                     }
-                    // A block with nothing on the neighbouring row keeps its place rather than
-                    // drifting to the start of the row.
+                    // A block with nothing in the neighbouring column keeps its place rather than
+                    // drifting to the start of it.
                     block.key = if (seen.isNotEmpty()) {
                         seen.sum().toFloat() / seen.size
                     } else {
                         current.getValue(block.members.first()).toFloat() *
-                            (positions.size.toFloat() / max(1, row.size))
+                            (positions.size.toFloat() / max(1, column.size))
                     }
                     block.tie = current.getValue(block.members.first())
                 }
 
                 blocks.sortedWith(compareBy({ it.key }, { it.tie }))
                     .flatMap { it.members }
-                    .let { rows[level] = it.toMutableList() }
+                    .let { columns[level] = it.toMutableList() }
             }
         }
     }
 
     /**
-     * Places one row, pulling each block toward where it wants to be without letting blocks
-     * overlap. Run from both ends and averaged: a single left-to-right pass jams everything against
-     * the left whenever a row is crowded.
+     * Places one column, pulling each block toward where it wants to be without letting blocks
+     * overlap. Run from both ends and averaged: a single pass jams everything against the top
+     * whenever a column is crowded.
      */
-    private fun placeRow(blocks: List<Block>, desired: Map<Block, Float>): FloatArray {
-        val gap = TreeMetrics.SIBLING_GAP
-        val left = FloatArray(blocks.size)
+    private fun placeColumn(blocks: List<Block>, desired: Map<Block, Float>): FloatArray {
+        val gap = TreeMetrics.STACK_GAP
+        val near = FloatArray(blocks.size)
         var cursor = Float.NEGATIVE_INFINITY
         blocks.forEachIndexed { i, block ->
             val packed = if (cursor.isFinite()) cursor else 0f
-            val want = desired[block]?.minus(block.width / 2f) ?: packed
-            left[i] = max(want, cursor)
-            cursor = left[i] + block.width + gap
+            val want = desired[block]?.minus(block.extent / 2f) ?: packed
+            near[i] = max(want, cursor)
+            cursor = near[i] + block.extent + gap
         }
 
         /*
          * A block with nothing pulling on it must nestle against its neighbour rather than keep
          * whatever coordinate it happens to hold: treating its own position as its wish makes the
-         * placement a ratchet that can only move right, stranding anyone childless at the edge.
+         * placement a ratchet that can only move one way, stranding anyone childless at the edge.
          */
-        val right = FloatArray(blocks.size)
-        cursor = left[blocks.size - 1] + blocks[blocks.size - 1].width
+        val far = FloatArray(blocks.size)
+        cursor = near[blocks.size - 1] + blocks[blocks.size - 1].extent
         for (i in blocks.indices.reversed()) {
-            val packed = cursor - blocks[i].width
-            val want = desired[blocks[i]]?.minus(blocks[i].width / 2f) ?: packed
-            right[i] = min(want, packed)
-            cursor = right[i] - gap
+            val packed = cursor - blocks[i].extent
+            val want = desired[blocks[i]]?.minus(blocks[i].extent / 2f) ?: packed
+            far[i] = min(want, packed)
+            cursor = far[i] - gap
         }
 
         // Averaging two feasible placements can breach the minimum gap, so restore it once.
-        val out = FloatArray(blocks.size) { (left[it] + right[it]) / 2f }
+        val out = FloatArray(blocks.size) { (near[it] + far[it]) / 2f }
         cursor = Float.NEGATIVE_INFINITY
         for (i in blocks.indices) {
             out[i] = max(out[i], cursor)
-            cursor = out[i] + blocks[i].width + gap
+            cursor = out[i] + blocks[i].extent + gap
         }
         return out
     }
 
-    private fun assignX(
+    private fun assignAcross(
         snapshot: FamilySnapshot,
-        rows: Map<Int, MutableList<String>>,
+        columns: Map<Int, MutableList<String>>,
     ): Map<String, Float> {
-        val keys = rows.keys.sorted()
-        val x = mutableMapOf<String, Float>()
+        val keys = columns.keys.sorted()
+        val across = mutableMapOf<String, Float>()
         val blocksByLevel = mutableMapOf<Int, List<Block>>()
+        val step = personExtent + TreeMetrics.COUPLE_GAP
 
         keys.forEach { level ->
-            val blocks = buildBlocks(snapshot, rows.getValue(level))
+            val blocks = buildBlocks(snapshot, columns.getValue(level))
             blocksByLevel[level] = blocks
             var cursor = 0f
             blocks.forEach { block ->
-                var bx = cursor
+                var at = cursor
                 block.members.forEach { id ->
-                    x[id] = bx
-                    bx += TreeMetrics.NODE_WIDTH + TreeMetrics.COUPLE_GAP
+                    across[id] = at
+                    at += step
                 }
-                cursor += block.width + TreeMetrics.SIBLING_GAP
+                cursor += block.extent + TreeMetrics.STACK_GAP
             }
         }
 
-        val rowSets = keys.associateWith { rows.getValue(it).toSet() }
+        val columnSets = keys.associateWith { columns.getValue(it).toSet() }
 
         repeat(PLACEMENT_PASSES) { pass ->
-            val upward = pass % 2 == 0
-            val order = if (upward) keys.reversed() else keys
+            val backward = pass % 2 == 0
+            val order = if (backward) keys.reversed() else keys
 
             order.forEach { level ->
                 val blocks = blocksByLevel.getValue(level)
-                val neighbours = rowSets[level + if (upward) 1 else -1]
+                val neighbours = columnSets[level + if (backward) 1 else -1]
                 val desired = mutableMapOf<Block, Float>()
 
                 blocks.forEach { block ->
                     val targets = block.members.flatMap { id ->
-                        // Going up a parent wants to sit over the middle of their children; going
-                        // down a child wants to sit under the middle of their parents.
-                        val related = if (upward) snapshot.childrenOf[id].orEmpty()
+                        // Going back a parent wants to sit beside the middle of their children;
+                        // going on a child wants to sit beside the middle of their parents.
+                        val related = if (backward) snapshot.childrenOf[id].orEmpty()
                         else snapshot.parentsOf[id].orEmpty()
                         related.mapNotNull { other ->
                             if (neighbours?.contains(other) == true) {
-                                x[other]?.plus(TreeMetrics.NODE_WIDTH / 2f)
+                                across[other]?.plus(personExtent / 2f)
                             } else null
                         }
                     }
-                    // A block with no relatives on the neighbouring row states no wish at all;
-                    // placeRow packs it against its neighbours instead.
+                    // A block with no relatives in the neighbouring column states no wish at all;
+                    // placeColumn packs it against its neighbours instead.
                     if (targets.isNotEmpty()) desired[block] = targets.sum() / targets.size
                 }
 
-                val placed = placeRow(blocks, desired)
+                val placed = placeColumn(blocks, desired)
                 blocks.forEachIndexed { i, block ->
-                    var bx = placed[i]
+                    var at = placed[i]
                     block.members.forEach { id ->
-                        x[id] = bx
-                        bx += TreeMetrics.NODE_WIDTH + TreeMetrics.COUPLE_GAP
+                        across[id] = at
+                        at += step
                     }
                 }
             }
         }
 
-        return x
+        return across
     }
 
     /* ------------------------------------------------------------------ connectors */
 
     private class Links(
         val spouses: List<WholeSpouseLink>,
-        val descents: List<DescentLink>,
+        val descents: List<WholeDescentLink>,
         val brackets: List<SiblingBracket>,
     )
 
@@ -609,16 +631,16 @@ object WholeTreeLayoutEngine {
         snapshot.spouseEdges.forEach { (a, b) ->
             val na = byId[a] ?: return@forEach
             val nb = byId[b] ?: return@forEach
-            if (na.y != nb.y) return@forEach
-            val left = if (na.x < nb.x) na else nb
-            val right = if (na.x < nb.x) nb else na
+            if (na.x != nb.x) return@forEach
+            val upper = if (na.y < nb.y) na else nb
+            val lower = if (na.y < nb.y) nb else na
             // Drawn only when they are actually adjacent; a rule spanning three cards would read as
             // a marriage to whoever sits in between.
-            if (right.x - (left.x + TreeMetrics.NODE_WIDTH) > TreeMetrics.SIBLING_GAP) return@forEach
+            if (lower.y - upper.bottom > TreeMetrics.STACK_GAP) return@forEach
             spouses += WholeSpouseLink(
-                fromX = left.x + TreeMetrics.NODE_WIDTH,
-                toX = right.x,
-                y = left.centerY,
+                x = upper.centerX,
+                fromY = upper.bottom,
+                toY = lower.y,
                 ended = false,
                 aId = a,
                 bId = b,
@@ -627,7 +649,7 @@ object WholeTreeLayoutEngine {
 
         // One descent per parent *set*, which is what puts a couple's children on a single bar and
         // hangs a half-sibling from their own.
-        val descents = mutableListOf<DescentLink>()
+        val descents = mutableListOf<WholeDescentLink>()
         snapshot.people.keys
             .mapNotNull { child ->
                 val parents = snapshot.parentsOf[child].orEmpty().sorted()
@@ -636,19 +658,19 @@ object WholeTreeLayoutEngine {
             .groupBy({ it.first }, { it.second })
             .forEach { (parentIds, childIds) ->
                 val parentNodes = parentIds.mapNotNull { byId[it] }
-                val childNodes = childIds.mapNotNull { byId[it] }.sortedBy { it.x }
+                val childNodes = childIds.mapNotNull { byId[it] }.sortedBy { it.y }
                 if (parentNodes.isEmpty() || childNodes.isEmpty()) return@forEach
 
-                val originY = parentNodes.maxOf { it.bottom }
-                val childTopY = childNodes.minOf { it.y }
-                descents += DescentLink(
-                    originX = parentNodes.map { it.centerX }.average().toFloat(),
-                    originY = originY,
-                    // Just above the shallowest child, so a child placed further down gets a longer
-                    // drop rather than dragging the whole bar out of place.
-                    busY = max(childTopY - TreeMetrics.LEVEL_GAP * 0.42f, originY + 10f),
-                    childXs = childNodes.map { it.centerX },
-                    childTopY = childTopY,
+                val originX = parentNodes.maxOf { it.right }
+                val childLeftX = childNodes.minOf { it.x }
+                descents += WholeDescentLink(
+                    originX = originX,
+                    originY = parentNodes.map { it.centerY }.average().toFloat(),
+                    // Just before the nearest child, so a child placed further along gets a longer
+                    // stub rather than dragging the whole bar out of place.
+                    busX = max(childLeftX - TreeMetrics.GENERATION_GAP * 0.42f, originX + 10f),
+                    childYs = childNodes.map { it.centerY },
+                    childLeftX = childLeftX,
                     parentIds = parentNodes.map { it.person.id },
                     childIds = childNodes.map { it.person.id },
                 )
@@ -658,10 +680,10 @@ object WholeTreeLayoutEngine {
         snapshot.siblingEdges.forEach { (a, b) ->
             val na = byId[a] ?: return@forEach
             val nb = byId[b] ?: return@forEach
-            if (na.y != nb.y) return@forEach
-            val left = if (na.x < nb.x) na else nb
-            val right = if (na.x < nb.x) nb else na
-            brackets += SiblingBracket(left.centerX, right.centerX, left.y, aId = a, bId = b)
+            if (na.x != nb.x) return@forEach
+            val upper = if (na.y < nb.y) na else nb
+            val lower = if (na.y < nb.y) nb else na
+            brackets += SiblingBracket(upper.centerY, lower.centerY, upper.x, aId = a, bId = b)
         }
 
         return Links(spouses, descents, brackets)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
@@ -24,6 +24,7 @@ import com.vibethroughcode.ftree.data.PartialDate
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.graph.DescentLink
 import com.vibethroughcode.ftree.graph.TreeMetrics
+import com.vibethroughcode.ftree.graph.WholeDescentLink
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import kotlin.math.max
 import kotlin.math.min
@@ -103,6 +104,51 @@ fun DrawScope.drawDescent(
             color = color,
             start = Offset(x, busY),
             end = Offset(x, link.childTopY * unitPx),
+            strokeWidth = strokeWidth,
+            alpha = alpha,
+        )
+    }
+}
+
+/**
+ * The same descent, drawn sideways: out to the right of the parents, a bar down the children, and a
+ * stub into each.
+ *
+ * The whole-tree chart runs left to right, so its connectors are this one turned through a right
+ * angle. Written beside [drawDescent] rather than derived from it: they are the same idea in the
+ * same notation, and keeping them next to each other is how they stay that way.
+ */
+fun DrawScope.drawDescentSideways(
+    link: WholeDescentLink,
+    unitPx: Float,
+    color: Color,
+    strokeWidth: Float,
+    alpha: Float = 1f,
+) {
+    val originY = link.originY * unitPx
+    val busX = link.busX * unitPx
+    val ys = link.childYs.map { it * unitPx }
+    if (ys.isEmpty()) return
+
+    drawLine(
+        color = color,
+        start = Offset(link.originX * unitPx, originY),
+        end = Offset(busX, originY),
+        strokeWidth = strokeWidth,
+        alpha = alpha,
+    )
+    drawLine(
+        color = color,
+        start = Offset(busX, link.barStart * unitPx),
+        end = Offset(busX, link.barEnd * unitPx),
+        strokeWidth = strokeWidth,
+        alpha = alpha,
+    )
+    ys.forEach { y ->
+        drawLine(
+            color = color,
+            start = Offset(busX, y),
+            end = Offset(link.childLeftX * unitPx, y),
             strokeWidth = strokeWidth,
             alpha = alpha,
         )

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.drawscope.translate
@@ -145,6 +146,13 @@ fun FamilyChart(
     Canvas(
         modifier = modifier
             .fillMaxSize()
+            /*
+             * A canvas does not clip its own drawing, so a chart panned past its top edge paints
+             * over the header above it. Latent until the chart started opening centred on
+             * something rather than tucked against a corner, at which point a generation of
+             * cards appeared behind the title.
+             */
+            .clipToBounds()
             .testTag(FamilyChartTag)
             .semantics { contentDescription = chartDescription }
             .onSizeChanged { viewport = it }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -143,24 +144,45 @@ fun WholeFamilyChart(
                 )
             } else {
                 /*
-                 * Too wide to fit and stay legible.
+                 * Too tall to fit and stay legible.
                  *
-                 * Generations are the axis that carries the meaning, so all of them on screen with
-                 * the width running off the side beats a whole chart too small to read. Panning
-                 * sideways through a generation is how a family tree is read on paper anyway.
+                 * Generations are the axis that carries the meaning, and here they run across, so
+                 * all of them on screen with the people running off the bottom beats a whole chart
+                 * too small to read. What is left over is then a scroll down a generation, which is
+                 * the gesture a phone is for — and is the whole reason the chart was turned on its
+                 * side. Before the rotation this branch fitted the other axis and left the reader
+                 * panning sideways through sixty-four people.
                  */
-                zoom = minOf(byHeight, MAX_FIT).coerceAtLeast(LEGIBLE)
-                val first = layout.groups.firstOrNull { !it.unconnected } ?: layout.groups.first()
+                zoom = minOf(byWidth, MAX_FIT).coerceAtLeast(LEGIBLE)
                 val inset = 16.dp.toPx()
-                val startX = if (tracing) originX else first.x.dp.toPx()
-                val startY = if (tracing) originY else first.y.dp.toPx()
+
+                /*
+                 * Opened on the family's origin rather than on the corner of its frame.
+                 *
+                 * A frame's top-left corner is not where anybody is. The earliest generation holds
+                 * two or three people and the latest holds sixty, and every column is centred
+                 * against its own descendants, so the oldest couple sit halfway down a chart whose
+                 * first screenful is otherwise blank. Opening there showed a reader an empty page
+                 * with a few faint generation rules on it. So: the earliest generation against the
+                 * left edge, and that generation's own middle against the middle of the screen.
+                 */
+                val startX = if (tracing) originX else layout.nodes.minOf { it.x }.dp.toPx()
+                val middleY = if (tracing) {
+                    originY + chartHeight / 2f
+                } else {
+                    val firstColumn = layout.nodes.minOf { it.x }
+                    val root = layout.nodes.filter { it.x <= firstColumn + 0.5f }
+                    val top = root.minOf { it.y }
+                    val bottom = root.maxOf { it.y } + TreeMetrics.NODE_HEIGHT
+                    ((top + bottom) / 2f).dp.toPx()
+                }
                 pan = Offset(
-                    inset - startX * zoom,
-                    if (chartHeight * zoom <= viewport.height) {
-                        (viewport.height - chartHeight * zoom) / 2f - startY * zoom
+                    if (chartWidth * zoom <= viewport.width) {
+                        (viewport.width - chartWidth * zoom) / 2f - originX * zoom
                     } else {
-                        inset - startY * zoom
+                        inset - startX * zoom
                     },
+                    viewport.height / 2f - middleY * zoom,
                 )
             }
         }
@@ -201,6 +223,13 @@ fun WholeFamilyChart(
     Canvas(
         modifier = modifier
             .fillMaxSize()
+            /*
+             * A canvas does not clip its own drawing, so a chart panned past its top edge paints
+             * over the header above it. Latent until the chart started opening centred on
+             * something rather than tucked against a corner, at which point a generation of
+             * cards appeared behind the title.
+             */
+            .clipToBounds()
             .testTag(WholeFamilyChartTag)
             .semantics { contentDescription = description }
             .onSizeChanged { viewport = it }
@@ -259,14 +288,15 @@ fun WholeFamilyChart(
         translate(currentPan.x, currentPan.y) {
             scale(currentZoom, currentZoom, Offset.Zero) {
 
-                // Generation rules, faint, so the strata read even when the names cannot.
+                // Generation rules, faint, so the strata read even when the names cannot. Down
+                // the middle of each generation's column, since a generation is a column here.
                 layout.bands.forEach { band ->
-                    val y = (band.y + TreeMetrics.NODE_HEIGHT / 2f) * unitPx
-                    if (band.y < visible.top || band.y > visible.bottom) return@forEach
+                    val x = (band.x + TreeMetrics.NODE_WIDTH / 2f) * unitPx
+                    if (band.x < visible.left || band.x > visible.right) return@forEach
                     drawLine(
                         color = accents.rule.copy(alpha = 0.22f),
-                        start = Offset(band.x * unitPx, y),
-                        end = Offset((band.x + band.width) * unitPx, y),
+                        start = Offset(x, band.y * unitPx),
+                        end = Offset(x, (band.y + band.height) * unitPx),
                         strokeWidth = rulePx * 0.7f,
                     )
                 }
@@ -341,9 +371,9 @@ fun WholeFamilyChart(
                  * and in the selection's own colour, and every other line recedes with the cards.
                  */
                 layout.descentLinks.forEach { link ->
-                    if (link.busY < visible.top || link.originY > visible.bottom) return@forEach
+                    if (link.busX < visible.left || link.originX > visible.right) return@forEach
                     val on = lit != null && link.touches(lit)
-                    drawDescent(
+                    drawDescentSideways(
                         link = link,
                         unitPx = unitPx,
                         color = if (on) colors.primary else accents.rule,
@@ -355,14 +385,14 @@ fun WholeFamilyChart(
                 // Siblings whose shared parents are unknown: bracketed above, dashed, because what
                 // joins them is exactly the part nobody wrote down.
                 layout.siblingBrackets.forEach { bracket ->
-                    val lift = TreeMetrics.LEVEL_GAP * 0.22f
-                    val top = (bracket.y - lift) * unitPx
+                    val lift = TreeMetrics.GENERATION_GAP * 0.22f
+                    val back = (bracket.x - lift) * unitPx
                     val on = lit != null && bracket.touches(lit)
                     val path = Path().apply {
-                        moveTo(bracket.fromX * unitPx, bracket.y * unitPx)
-                        lineTo(bracket.fromX * unitPx, top)
-                        lineTo(bracket.toX * unitPx, top)
-                        lineTo(bracket.toX * unitPx, bracket.y * unitPx)
+                        moveTo(bracket.x * unitPx, bracket.fromY * unitPx)
+                        lineTo(back, bracket.fromY * unitPx)
+                        lineTo(back, bracket.toY * unitPx)
+                        lineTo(bracket.x * unitPx, bracket.toY * unitPx)
                     }
                     drawPath(
                         path = path,
@@ -376,17 +406,17 @@ fun WholeFamilyChart(
                 }
 
                 layout.spouseLinks.forEach { link ->
-                    if (link.y < visible.top || link.y > visible.bottom) return@forEach
-                    val y = link.y * unitPx
+                    if (link.x < visible.left || link.x > visible.right) return@forEach
+                    val x = link.x * unitPx
                     val on = lit != null && link.touches(lit)
-                    listOf(-spouseGapPx, spouseGapPx).forEach { dy ->
+                    listOf(-spouseGapPx, spouseGapPx).forEach { dx ->
                         drawLine(
                             // The doubled rule keeps its own colour when lit: widened and at full
-                            // strength it is already the loudest thing on the row, and a marriage
-                            // recoloured to match a selection stops reading as a marriage.
+                            // strength it is already the loudest thing in the column, and a
+                            // marriage recoloured to match a selection stops reading as a marriage.
                             color = accents.spouseLink,
-                            start = Offset(link.fromX * unitPx, y + dy),
-                            end = Offset(link.toX * unitPx, y + dy),
+                            start = Offset(x + dx, link.fromY * unitPx),
+                            end = Offset(x + dx, link.toY * unitPx),
                             strokeWidth = if (on) rulePx * 1.6f else rulePx,
                             alpha = if (!dimming || on) 1f else FADED,
                         )

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngineTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngineTest.kt
@@ -55,8 +55,9 @@ class WholeTreeLayoutEngineTest {
         .person("stranger-1", "1930").person("stranger-2").person("stranger-3", "1955")
         .build()
 
+    /** The people of one generation: a column now, since the chart reads left to right. */
     private fun WholeTreeLayout.rows(): Map<Int, List<WholeTreeNode>> =
-        nodes.groupBy { it.y.toInt() }
+        nodes.groupBy { it.x.toInt() }
 
     @Test
     fun `every person is placed exactly once`() {
@@ -69,14 +70,14 @@ class WholeTreeLayoutEngineTest {
     }
 
     @Test
-    fun `nobody overlaps anybody on their own row`() {
+    fun `nobody overlaps anybody in their own generation`() {
         val layout = WholeTreeLayoutEngine.layout(archive())
 
-        layout.rows().forEach { (_, row) ->
-            row.sortedBy { it.x }.zipWithNext { left, right ->
-                val gap = right.x - (left.x + TreeMetrics.NODE_WIDTH)
+        layout.rows().forEach { (_, column) ->
+            column.sortedBy { it.y }.zipWithNext { upper, lower ->
+                val gap = lower.y - (upper.y + TreeMetrics.NODE_HEIGHT)
                 assertTrue(
-                    "${left.person.id} and ${right.person.id} overlap by ${-gap}",
+                    "${upper.person.id} and ${lower.person.id} overlap by ${-gap}",
                     gap >= -0.5f,
                 )
             }
@@ -89,24 +90,25 @@ class WholeTreeLayoutEngineTest {
         val me = layout.node("me")!!
         val spouse = layout.node("spouse")!!
 
-        assertEquals("partners share a row", me.y, spouse.y, 0.01f)
-        val between = abs(spouse.x - me.x) - TreeMetrics.NODE_WIDTH
+        assertEquals("partners share a generation", me.x, spouse.x, 0.01f)
+        val between = abs(spouse.y - me.y) - TreeMetrics.NODE_HEIGHT
         assertTrue(
-            "partners $between apart, which is not closer than the $${TreeMetrics.SIBLING_GAP} " +
+            "partners $between apart, which is not closer than the ${TreeMetrics.STACK_GAP} " +
                 "that separates strangers",
-            between <= TreeMetrics.SIBLING_GAP,
+            between <= TreeMetrics.STACK_GAP,
         )
     }
 
     @Test
-    fun `children are drawn below their parents`() {
+    fun `children are drawn after their parents`() {
         val snapshot = archive()
         val layout = WholeTreeLayoutEngine.layout(snapshot)
 
+        // The chart reads left to right, so descent runs along x rather than down y.
         snapshot.parentEdges.forEach { (parent, child) ->
-            val above = layout.node(parent)!!
-            val below = layout.node(child)!!
-            assertTrue("$child is not below $parent", below.y > above.y)
+            val before = layout.node(parent)!!
+            val after = layout.node(child)!!
+            assertTrue("$child is not after $parent", after.x > before.x)
         }
     }
 
@@ -136,7 +138,7 @@ class WholeTreeLayoutEngineTest {
     }
 
     @Test
-    fun `a parent sits directly above their earliest child, however deep that child is`() {
+    fun `a parent sits directly beside their earliest child, however deep that child is`() {
         // Longest-path ranking alone would strand the in-law at the top of the chart, trailing a
         // connector the height of it, because their only child married three generations down.
         val snapshot = Builder()
@@ -152,9 +154,9 @@ class WholeTreeLayoutEngineTest {
         val inLaw = layout.node("in-law")!!
         val inLawParent = layout.node("in-law-parent")!!
 
-        assertEquals("married pair share a row", layout.node("g4")!!.y, inLaw.y, 0.01f)
+        assertEquals("married pair share a generation", layout.node("g4")!!.x, inLaw.x, 0.01f)
         assertEquals(
-            "the in-law's parent belongs one row above them, not at the top of the chart",
+            "the in-law's parent belongs one generation before them, not at the start of the chart",
             inLaw.level - 1,
             inLawParent.level,
         )
@@ -176,9 +178,9 @@ class WholeTreeLayoutEngineTest {
             .build()
 
         val layout = WholeTreeLayoutEngine.layout(snapshot)
-        val husband = layout.node("husband")!!.x
-        val first = layout.node("first-wife")!!.x
-        val second = layout.node("second-wife")!!.x
+        val husband = layout.node("husband")!!.y
+        val first = layout.node("first-wife")!!.y
+        val second = layout.node("second-wife")!!.y
 
         assertTrue(
             "the husband must separate his two wives, not stand beside both of them",
@@ -203,7 +205,7 @@ class WholeTreeLayoutEngineTest {
         assertEquals(2, layout.descentLinks.size)
         assertEquals(
             listOf(1, 2),
-            layout.descentLinks.map { it.childXs.size }.sorted(),
+            layout.descentLinks.map { it.childYs.size }.sorted(),
         )
     }
 
@@ -383,9 +385,9 @@ class WholeTreeLayoutEngineTest {
         layout.descentLinks.forEach { link ->
             assertTrue(
                 "the bar must reach the parents it descends from",
-                link.originX in link.barStart..link.barEnd,
+                link.originY in link.barStart..link.barEnd,
             )
-            link.childXs.forEach {
+            link.childYs.forEach {
                 assertTrue("the bar must reach every child", it in link.barStart..link.barEnd)
             }
         }
@@ -412,13 +414,56 @@ class WholeTreeLayoutEngineTest {
     }
 
     @Test
-    fun `a drop matches the child underneath it`() {
+    fun `a stub matches the child beside it`() {
         val layout = WholeTreeLayoutEngine.layout(archive())
         layout.descentLinks.forEach { link ->
-            assertEquals(link.childXs.size, link.childIds.size)
+            assertEquals(link.childYs.size, link.childIds.size)
             link.childIds.forEachIndexed { index, id ->
-                assertEquals(layout.node(id)!!.centerX, link.childXs[index], 0.01f)
+                assertEquals(layout.node(id)!!.centerY, link.childYs[index], 0.01f)
             }
         }
+    }
+
+    /**
+     * The point of the rotation, as an assertion.
+     *
+     * A family record's size shows up as one very populous generation, and a generation to a row
+     * turns that into a ribbon no phone can show: Ankit's is 78 cards wide and 5 tall. Turned on its
+     * side the same shape becomes something a phone scrolls. If this ever inverts, the chart has
+     * gone back to being the wrong way round for the thing it is read on.
+     */
+    @Test
+    fun `a populous generation makes a tall chart rather than a wide one`() {
+        val builder = Builder()
+            .person("dad", "1900").person("mum", "1904")
+            .married("dad", "mum")
+        repeat(30) { i ->
+            builder.person("child-$i", (1925 + i).toString())
+            builder.parentOf("dad", "child-$i").parentOf("mum", "child-$i")
+        }
+
+        val layout = WholeTreeLayoutEngine.layout(builder.build())
+
+        assertEquals(32, layout.nodes.size)
+        assertTrue(
+            "thirty siblings should run down the screen, not across it — " +
+                "got ${layout.width} x ${layout.height}",
+            layout.height > layout.width * 2f,
+        )
+        // Two generations, so the chart is two columns wide however many children there are.
+        assertEquals(2, layout.nodes.map { it.x }.distinct().size)
+        assertEquals(30, layout.nodes.count { it.level == 1 })
+    }
+
+    @Test
+    fun `a marriage is a rule down the side of the couple, not across it`() {
+        val layout = WholeTreeLayoutEngine.layout(archive())
+        val marriage = layout.spouseLinks.single { it.touches("me") && it.touches("spouse") }
+
+        val me = layout.node("me")!!
+        val spouse = layout.node("spouse")!!
+        assertEquals("a couple shares a generation", me.x, spouse.x, 0.01f)
+        assertTrue("the rule runs down, from one to the other", marriage.toY > marriage.fromY)
+        assertEquals(me.centerX, marriage.x, 0.01f)
     }
 }


### PR DESCRIPTION
A generation is a **column** now, not a row. Ancestors at the left, descendants to the right, and the people of one generation stacked down the screen.

## The width was never an algorithm to fix

I proposed narrowing the layout last time. Measuring first disproved it. Over Ankit's real 148-person record and mock fans of every shape:

| shape | actual | floor (widest row, shoulder to shoulder) | waste |
|---|---|---|---|
| fan 3×3, 4×3, 6×2 (mock) | — | — | **1.0×** |
| lopsided: 1 heavy child, 3 leaves | 23.4 cards | 19.7 | 1.2× |
| **real: whole record** | **77.9 cards** | **78.4** | **1.0×** |

There is no packing to be won — contour packing would have recovered ~26% on the single worst case and nothing at all on regular shapes. The chart was simply **the wrong way round for the thing it is read on**: 78 cards wide and 5 tall is an aspect of **15.3**, against a phone's of about **0.46**, and the widest generation genuinely holds **64 people**.

## What rotating buys

| | before | after |
|---|---|---|
| size | 77.9 × 5.1 cards | **9.7 × 33.0 cards** |
| aspect | 15.28 | **0.29** |
| zoom to fit all generations | 0.033 (card 5×2 dp) | **0.264** (card 42×16 dp) |
| what's left over | pan across ~12 screens | **scroll down 1.6 screens** |

The long axis is now the one a phone scrolls.

Every connector rotates with it — a marriage is a doubled rule down the side of a couple, a descent leaves sideways before it spreads. These are **separate types** from the ego chart's rather than the same ones with the axes quietly swapped, because a coordinate whose meaning depends on which chart is reading it is a bug that compiles.

## Two things this turned up

**The chart opened on the corner of a frame, where nobody is.** The earliest generation holds two people and the latest sixty, and every column is centred against its own descendants, so the oldest couple sit halfway down a chart whose first screenful is otherwise blank. Opening there showed an empty page with a few faint generation rules on it. It now opens with the earliest generation against the left edge and that generation's own middle against the middle of the screen.

**Neither chart clipped its own canvas.** Compose does not clip drawing to a composable's bounds, so a chart panned past its top edge painted over the header. Latent until the framing above stopped tucking content into a corner — then a row of cards appeared behind the title. Fixed in both charts.

## Deliberately unchanged

The **web viewer keeps generations as rows**. It has a television to fill, and rows are right for a wide screen. The app and the viewer now differ in orientation on purpose — unlike the kinship model, where they must agree.

The **focused "Chart"** is untouched: it draws one person's neighbourhood, which is a shape that already fits.

## Verification

- **208 unit tests**, including a new one asserting the shape claim directly — thirty siblings must run down the screen, not across it — and the marriage rule running down the side of a couple. Every row-axis invariant in the existing suite was rotated rather than relaxed: nobody overlaps in their own *generation*, children are drawn *after* their parents, a twice-married person still separates his two wives.
- **155 instrumented tests**, including relation tracing, which draws on this chart.
- **lint unchanged** at 82 findings.
- Confirmed on the real record on device, portrait and landscape, with a selection active — the lit connectors and the fade work the same way rotated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)