### PR TITLE
Version 0.7.0-beta.3

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 18
-        versionName = "0.7.0-beta.2"
+        versionCode = 19
+        versionName = "0.7.0-beta.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 19, `versionName` 0.7.0-beta.3 — a pre-release, so `releases/latest` keeps answering v0.6.0.

Ships [#69](https://github.com/thisisankit27/f-tree/pull/69): **the whole-tree chart turned on its side.**

A generation is a column now. Ancestors at the left, descendants to the right, people stacked down the screen.

| | before | after |
|---|---|---|
| the 148-person record | 77.9 × 5.1 cards | **9.7 × 33.0 cards** |
| aspect | 15.28 | **0.29** |
| zoom to see all 6 generations | 0.033 | **0.264** |
| what's left over | pan across ~12 screens | **scroll down 1.6 screens** |

Also fixed on the way: the chart opened on the corner of a frame where nobody is, and neither chart clipped its own canvas — a chart panned past its top edge painted over the header.

208 unit, 155 instrumented, lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)