### PR TITLE
Turn the focused chart on its side too

### DIFF
--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayout.kt
@@ -22,45 +22,66 @@ data class TreeNode(
     val bottom: Float get() = y + height
 }
 
-/** The doubled rule drawn between partners. */
-data class SpouseLink(val fromX: Float, val toX: Float, val y: Float)
+/**
+ * The doubled rule drawn between partners, down the side of the couple.
+ *
+ * Vertical because both charts run sideways: a generation is a column, so a couple is stacked one
+ * above the other and the rule that marries them runs between their facing edges.
+ */
+data class SpouseLink(
+    val x: Float,
+    val fromY: Float,
+    val toY: Float,
+    val aId: String = "",
+    val bId: String = "",
+) {
+    fun touches(personId: String): Boolean = personId == aId || personId == bId
+}
 
 /**
- * One family's descent: a drop from the parents, a bar across the children, and a drop to each.
+ * One family's descent: out to the right of the parents, a bar down the children, and a stub into
+ * each.
  *
  * Grouped by *parent set* rather than by individual parent, so a couple's children hang from one
  * connector while a half-sibling hangs from their own — which is what makes a second marriage
  * legible instead of a tangle of crossing lines.
  *
  * It carries the people it joins as well as the coordinates, because a connector that cannot say
- * whose it is cannot take part in anything the chart does with a selection. Without them the only
+ * whose it is cannot take part in anything a chart does with a selection. Without them the only
  * honest thing a highlight could do was fade the cards and leave every line at full strength —
  * which is to dim the hundred and forty people you can already tell apart and keep the lattice you
  * cannot.
+ *
+ * One type for both charts. They drew the same idea on different axes until each was turned
+ * sideways, and two shapes for one notation is how a coordinate ends up meaning different things
+ * depending on who is reading it.
  */
 data class DescentLink(
+    /** Where the stem leaves the parents: their right edge, at their middle. */
     val originX: Float,
     val originY: Float,
-    val busY: Float,
-    val childXs: List<Float>,
-    val childTopY: Float,
+    /** The column the bar stands in, between the parents and the children. */
+    val busX: Float,
+    val childYs: List<Float>,
+    /** The left edge of the children's column, where each stub arrives. */
+    val childLeftX: Float,
     val parentIds: List<String> = emptyList(),
-    /** In the same order as [childXs], so a drop and a child can be matched up. */
+    /** In the same order as [childYs], so a stub and a child can be matched up. */
     val childIds: List<String> = emptyList(),
 ) {
     /** Whether this connector runs to or from [personId] — a parent on it, or one of the children. */
     fun touches(personId: String): Boolean = personId in parentIds || personId in childIds
 
     /**
-     * The horizontal bar's extent: from the parents' stem across to the far side of the children.
+     * The bar's extent: from the parents' stem across to the far side of the children.
      *
      * Expressed here rather than worked out at drawing time so that "the bar reaches everything it
      * has to join" is a property of the connector that a test can hold it to, instead of a detail
      * of one canvas that happened to be right. Drawing the bar between the children alone is what
      * left a stem hanging in mid-air whenever the parents sat outside their own children's span.
      */
-    val barStart: Float get() = minOf(originX, childXs.minOrNull() ?: originX)
-    val barEnd: Float get() = maxOf(originX, childXs.maxOrNull() ?: originX)
+    val barStart: Float get() = minOf(originY, childYs.minOrNull() ?: originY)
+    val barEnd: Float get() = maxOf(originY, childYs.maxOrNull() ?: originY)
 }
 
 data class TreeLayout(

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/TreeLayoutEngine.kt
@@ -5,12 +5,19 @@ import com.vibethroughcode.ftree.data.Person
 import kotlin.math.max
 
 /**
- * Arranges a slice of the family graph into a readable genealogical chart.
+ * Arranges a slice of the family graph into a readable genealogical chart, drawn sideways.
  *
  * The chart is ego-centric on purpose. Laying out an entire family produces something no phone can
- * show and no person can read, so this draws one person's ancestors above and descendants below,
- * with their siblings beside them, and everyone else is reached by re-focusing. That also keeps the
- * work proportional to what is on screen rather than to the size of the tree.
+ * show and no person can read, so this draws one person's ancestors before them and descendants
+ * after, with their siblings beside them, and everyone else is reached by re-focusing. That also
+ * keeps the work proportional to what is on screen rather than to the size of the tree.
+ *
+ * **A generation is a column, not a row** — the same way round as [WholeTreeLayoutEngine], and for
+ * the same reason. A person with six children and three generations below them makes a chart 45
+ * cards wide and 3 tall, which is a ribbon on a phone however well it is packed; the width is the
+ * widest generation and nothing else, so the only thing that changes the shape is turning it. Read
+ * left to right, the long axis becomes the one a phone scrolls, and the two charts agree about
+ * which way a family runs — a reader should not have to relearn the picture when they switch.
  *
  * Pure: it takes a loaded [FamilySnapshot] and returns coordinates. No database, no Compose, so it
  * runs off the main thread and is tested directly on the JVM.
@@ -22,17 +29,19 @@ object TreeLayoutEngine {
      *
      * Couples are laid out as one block rather than as independent nodes, because a marriage that
      * drifts apart on screen stops looking like a marriage, and children need a single point to
-     * descend from.
+     * descend from. Stacked, since the couple shares a generation and a generation is a column.
      */
-    private class Unit(val members: List<String>, val nodeWidth: Float) {
-        var x = 0f
-        val width: Float
-            get() = members.size * nodeWidth + (members.size - 1) * TreeMetrics.COUPLE_GAP
+    private class Unit(val members: List<String>, val nodeHeight: Float) {
+        /** Position along the generation, which is down the screen. */
+        var across = 0f
 
-        fun xOf(personId: String): Float =
-            x + members.indexOf(personId) * (nodeWidth + TreeMetrics.COUPLE_GAP)
+        val extent: Float
+            get() = members.size * nodeHeight + (members.size - 1) * TreeMetrics.COUPLE_GAP
 
-        val centerX: Float get() = x + width / 2f
+        fun acrossOf(personId: String): Float =
+            across + members.indexOf(personId) * (nodeHeight + TreeMetrics.COUPLE_GAP)
+
+        val centerAcross: Float get() = across + extent / 2f
     }
 
     fun layout(
@@ -43,17 +52,17 @@ object TreeLayoutEngine {
         nodeWidth: Float = TreeMetrics.NODE_WIDTH,
         nodeHeight: Float = TreeMetrics.NODE_HEIGHT,
     ): TreeLayout {
-        val rowHeight = nodeHeight + TreeMetrics.LEVEL_GAP
+        val columnPitch = nodeWidth + TreeMetrics.GENERATION_GAP
         if (focusId !in snapshot.people) return TreeLayout()
 
         val included = collect(snapshot, focusId, generationsUp, generationsDown)
         val levels = included.levels
 
-        // --- Build the units, one per person-and-partners group, per level. ---
+        // --- Build the units, one per person-and-partners group, per generation. ---
         val unitOf = mutableMapOf<String, Unit>()
         val unitsByLevel = mutableMapOf<Int, MutableList<Unit>>()
         levels.entries.groupBy({ it.value }, { it.key }).forEach { (level, ids) ->
-            buildUnits(ids.toSet(), snapshot, nodeWidth).forEach { unit ->
+            buildUnits(ids.toSet(), snapshot, nodeHeight).forEach { unit ->
                 unit.members.forEach { unitOf[it] = unit }
                 unitsByLevel.getOrPut(level) { mutableListOf() } += unit
             }
@@ -61,18 +70,18 @@ object TreeLayoutEngine {
 
         val focusUnit = unitOf[focusId] ?: return TreeLayout()
 
-        // --- Level 0: the focus and their siblings, in birth order. ---
+        // --- The focus's own generation: they and their siblings, in birth order. ---
         val row0 = unitsByLevel[0] ?: mutableListOf()
         orderByBirth(row0, snapshot)
 
         // Siblings sit directly beside the focus. Their own descendants are not drawn (see
-        // `collect`), so the focus's subtree can spread out on the rows below without ever
-        // colliding with them — reserving the subtree's whole width up here would only shove the
-        // siblings, and the ancestors centred above them, far off to one side.
+        // `collect`), so the focus's subtree can spread out in the columns after without ever
+        // colliding with them — reserving the subtree's whole extent here would only shove the
+        // siblings, and the ancestors centred beside them, far off to one side.
         var cursor = 0f
         row0.forEach { unit ->
-            unit.x = cursor
-            cursor += unit.width + TreeMetrics.SIBLING_GAP
+            unit.across = cursor
+            cursor += unit.extent + TreeMetrics.STACK_GAP
         }
 
         placeDescendants(focusUnit, unitOf, unitsByLevel, snapshot, included)
@@ -80,19 +89,19 @@ object TreeLayoutEngine {
 
         // --- Normalise so the chart starts at the margin. ---
         val allUnits = unitsByLevel.values.flatten()
-        val minX = allUnits.minOfOrNull { it.x } ?: 0f
+        val minAcross = allUnits.minOfOrNull { it.across } ?: 0f
         val minLevel = levels.values.minOrNull() ?: 0
-        allUnits.forEach { it.x += TreeMetrics.MARGIN - minX }
+        allUnits.forEach { it.across += TreeMetrics.MARGIN - minAcross }
 
-        fun yOf(level: Int) = TreeMetrics.MARGIN + (level - minLevel) * rowHeight
+        fun xOf(level: Int) = TreeMetrics.MARGIN + (level - minLevel) * columnPitch
 
         val nodes = levels.mapNotNull { (id, level) ->
             val person = snapshot.people[id] ?: return@mapNotNull null
             TreeNode(
                 person = person,
                 level = level,
-                x = unitOf.getValue(id).xOf(id),
-                y = yOf(level),
+                x = xOf(level),
+                y = unitOf.getValue(id).acrossOf(id),
                 isFocus = id == focusId,
                 width = nodeWidth,
                 height = nodeHeight,
@@ -101,10 +110,10 @@ object TreeLayoutEngine {
 
         return TreeLayout(
             nodes = nodes,
-            spouseLinks = spouseLinks(unitsByLevel, nodeWidth, nodeHeight, ::yOf),
-            descentLinks = descentLinks(included, unitOf, levels, nodeWidth, nodeHeight, ::yOf),
-            width = (allUnits.maxOfOrNull { it.x + it.width } ?: 0f) + TreeMetrics.MARGIN,
-            height = yOf(levels.values.maxOrNull() ?: 0) + nodeHeight + TreeMetrics.MARGIN,
+            spouseLinks = spouseLinks(unitsByLevel, nodeWidth, nodeHeight, ::xOf),
+            descentLinks = descentLinks(included, unitOf, levels, nodeWidth, nodeHeight, ::xOf),
+            width = xOf(levels.values.maxOrNull() ?: 0) + nodeWidth + TreeMetrics.MARGIN,
+            height = (allUnits.maxOfOrNull { it.across + it.extent } ?: 0f) + TreeMetrics.MARGIN,
             focusId = focusId,
             truncated = included.truncated,
         )
@@ -187,7 +196,7 @@ object TreeLayoutEngine {
     private fun buildUnits(
         ids: Set<String>,
         snapshot: FamilySnapshot,
-        nodeWidth: Float,
+        nodeHeight: Float,
     ): List<Unit> {
         val remaining = ids.toMutableSet()
         val units = mutableListOf<Unit>()
@@ -205,9 +214,9 @@ object TreeLayoutEngine {
             remaining -= group
 
             // The person with the most partners sits in the middle, so someone who married twice
-            // has a spouse on each side rather than both crowded to one. Ties are broken by birth
-            // and then by id so the order is the same every time: a chart that reshuffles its
-            // couples when the screen rotates is disorienting for no reason.
+            // has a spouse above and one below rather than both crowded to one side. Ties are
+            // broken by birth and then by id so the order is the same every time: a chart that
+            // reshuffles its couples when the screen rotates is disorienting for no reason.
             val ordered = group.sortedWith(
                 compareByDescending<String> { id ->
                     snapshot.spousesOf[id].orEmpty().count { it in group }
@@ -224,7 +233,7 @@ object TreeLayoutEngine {
                     rest.take(rest.size / 2) + hub + rest.drop(rest.size / 2)
                 }
             }
-            units += Unit(members, nodeWidth)
+            units += Unit(members, nodeHeight)
         }
         return units
     }
@@ -250,7 +259,7 @@ object TreeLayoutEngine {
         .mapNotNull { unitOf[it] }
         .distinct()
 
-    /** Width the focus's descendants will need, before anything is positioned. */
+    /** How far along its generation the focus's descendants reach, before anything is positioned. */
     private fun measureDescendants(
         unit: Unit,
         unitOf: Map<String, Unit>,
@@ -259,14 +268,14 @@ object TreeLayoutEngine {
         included: Included,
     ): Float {
         val children = childUnitsOf(unit, unitOf, snapshot, included)
-        if (children.isEmpty()) return unit.width
-        val childrenWidth = children.sumOf {
+        if (children.isEmpty()) return unit.extent
+        val childrenExtent = children.sumOf {
             measureDescendants(it, unitOf, unitsByLevel, snapshot, included).toDouble()
-        }.toFloat() + (children.size - 1) * TreeMetrics.SIBLING_GAP
-        return max(unit.width, childrenWidth)
+        }.toFloat() + (children.size - 1) * TreeMetrics.STACK_GAP
+        return max(unit.extent, childrenExtent)
     }
 
-    /** Packs each generation of children beneath and centred on their parents. */
+    /** Packs each generation of children into the next column, centred beside their parents. */
     private fun placeDescendants(
         unit: Unit,
         unitOf: Map<String, Unit>,
@@ -278,23 +287,23 @@ object TreeLayoutEngine {
         if (children.isEmpty()) return
         orderByBirth(children, snapshot)
 
-        val widths = children.map {
+        val extents = children.map {
             measureDescendants(it, unitOf, unitsByLevel, snapshot, included)
         }
-        val total = widths.sum() + (children.size - 1) * TreeMetrics.SIBLING_GAP
-        var cursor = unit.centerX - total / 2f
+        val total = extents.sum() + (children.size - 1) * TreeMetrics.STACK_GAP
+        var cursor = unit.centerAcross - total / 2f
 
         children.forEachIndexed { index, child ->
-            child.x = cursor + (widths[index] - child.width) / 2f
-            cursor += widths[index] + TreeMetrics.SIBLING_GAP
+            child.across = cursor + (extents[index] - child.extent) / 2f
+            cursor += extents[index] + TreeMetrics.STACK_GAP
             placeDescendants(child, unitOf, unitsByLevel, snapshot, included)
         }
     }
 
     /**
-     * Places each generation of parents above and centred on their children, then pushes apart any
-     * that collide. Ancestors fan out faster than descendants, so the separation sweep matters more
-     * here than the centring does.
+     * Places each generation of parents in the column before their children and centred beside
+     * them, then pushes apart any that collide. Ancestors fan out faster than descendants, so the
+     * separation sweep matters more here than the centring does.
      */
     private fun placeAncestors(
         row0: List<Unit>,
@@ -316,10 +325,10 @@ object TreeLayoutEngine {
                     .filter { included.levels[it] == level + 1 }
                     .mapNotNull { unitOf[it] }
                     .distinct()
-                unit.x = if (theirChildren.isEmpty()) {
-                    childRow.firstOrNull()?.centerX?.minus(unit.width / 2f) ?: 0f
+                unit.across = if (theirChildren.isEmpty()) {
+                    childRow.firstOrNull()?.centerAcross?.minus(unit.extent / 2f) ?: 0f
                 } else {
-                    theirChildren.map { it.centerX }.average().toFloat() - unit.width / 2f
+                    theirChildren.map { it.centerAcross }.average().toFloat() - unit.extent / 2f
                 }
             }
 
@@ -328,13 +337,13 @@ object TreeLayoutEngine {
         }
     }
 
-    /** Sweeps a row left to right, shifting anything that overlaps its neighbour. */
-    private fun separate(row: List<Unit>) {
-        val sorted = row.sortedBy { it.x }
+    /** Sweeps a column top to bottom, shifting anything that overlaps its neighbour. */
+    private fun separate(column: List<Unit>) {
+        val sorted = column.sortedBy { it.across }
         for (i in 1 until sorted.size) {
             val previous = sorted[i - 1]
-            val minimum = previous.x + previous.width + TreeMetrics.SIBLING_GAP
-            if (sorted[i].x < minimum) sorted[i].x = minimum
+            val minimum = previous.across + previous.extent + TreeMetrics.STACK_GAP
+            if (sorted[i].across < minimum) sorted[i].across = minimum
         }
     }
 
@@ -344,14 +353,16 @@ object TreeLayoutEngine {
         unitsByLevel: Map<Int, List<Unit>>,
         nodeWidth: Float,
         nodeHeight: Float,
-        yOf: (Int) -> Float,
+        xOf: (Int) -> Float,
     ): List<SpouseLink> = unitsByLevel.flatMap { (level, units) ->
         units.flatMap { unit ->
             unit.members.zipWithNext { a, b ->
                 SpouseLink(
-                    fromX = unit.xOf(a) + nodeWidth,
-                    toX = unit.xOf(b),
-                    y = yOf(level) + nodeHeight / 2f,
+                    x = xOf(level) + nodeWidth / 2f,
+                    fromY = unit.acrossOf(a) + nodeHeight,
+                    toY = unit.acrossOf(b),
+                    aId = a,
+                    bId = b,
                 )
             }
         }
@@ -363,30 +374,30 @@ object TreeLayoutEngine {
         levels: Map<String, Int>,
         nodeWidth: Float,
         nodeHeight: Float,
-        yOf: (Int) -> Float,
+        xOf: (Int) -> Float,
     ): List<DescentLink> = included.families.mapNotNull { (parents, children) ->
         val parentLevel = parents.firstNotNullOfOrNull { levels[it] } ?: return@mapNotNull null
         val childLevel = children.firstNotNullOfOrNull { levels[it] } ?: return@mapNotNull null
         if (childLevel != parentLevel + 1) return@mapNotNull null
 
-        val parentXs = parents.mapNotNull { id -> unitOf[id]?.xOf(id) }
-        if (parentXs.isEmpty()) return@mapNotNull null
-        val originX = parentXs.map { it + nodeWidth / 2f }.average().toFloat()
+        val parentAcross = parents.mapNotNull { id -> unitOf[id]?.acrossOf(id) }
+        if (parentAcross.isEmpty()) return@mapNotNull null
+        val originY = parentAcross.map { it + nodeHeight / 2f }.average().toFloat()
 
-        // Kept together as pairs through the sort, so a drop and the child under it stay matched.
+        // Kept together as pairs through the sort, so a stub and the child beside it stay matched.
         val placed = children
-            .mapNotNull { id -> unitOf[id]?.xOf(id)?.plus(nodeWidth / 2f)?.let { id to it } }
+            .mapNotNull { id -> unitOf[id]?.acrossOf(id)?.plus(nodeHeight / 2f)?.let { id to it } }
             .sortedBy { it.second }
         if (placed.isEmpty()) return@mapNotNull null
 
-        val parentBottom = yOf(parentLevel) + nodeHeight
-        val childTop = yOf(childLevel)
+        val parentRight = xOf(parentLevel) + nodeWidth
+        val childLeft = xOf(childLevel)
         DescentLink(
-            originX = originX,
-            originY = parentBottom,
-            busY = parentBottom + (childTop - parentBottom) / 2f,
-            childXs = placed.map { it.second },
-            childTopY = childTop,
+            originX = parentRight,
+            originY = originY,
+            busX = parentRight + (childLeft - parentRight) / 2f,
+            childYs = placed.map { it.second },
+            childLeftX = childLeft,
             parentIds = parents.toList(),
             childIds = placed.map { it.first },
         )

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayout.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayout.kt
@@ -19,11 +19,10 @@ import com.vibethroughcode.ftree.data.Person
  * about five columns by sixty-four people: you scroll down through a generation, which is what a
  * phone is for, and step sideways only a handful of times to cross the whole family.
  *
- * The cost is that every connector is rotated too, so this file carries its own — a marriage is a
- * doubled rule down the side of a couple rather than across it, and a descent runs out to the right
- * before it spreads. They are separate types rather than the ego chart's reused with the axes
- * quietly swapped, because a coordinate whose meaning depends on which chart is reading it is a bug
- * that compiles.
+ * Every connector is rotated with it — a marriage is a doubled rule down the side of a couple
+ * rather than across it, and a descent runs out to the right before it spreads. [SpouseLink] and
+ * [DescentLink] are shared with the ego-centric chart, which reads the same way: one notation, one
+ * pair of types, and no coordinate whose meaning depends on which chart is looking at it.
  */
 data class WholeTreeNode(
     val person: Person,
@@ -37,49 +36,6 @@ data class WholeTreeNode(
     val centerY: Float get() = y + TreeMetrics.NODE_HEIGHT / 2f
     val right: Float get() = x + TreeMetrics.NODE_WIDTH
     val bottom: Float get() = y + TreeMetrics.NODE_HEIGHT
-}
-
-/**
- * The doubled rule between partners, drawn down the side of the couple.
- *
- * Vertical, because the couple is stacked: one above the other in their generation's column.
- */
-data class WholeSpouseLink(
-    val x: Float,
-    val fromY: Float,
-    val toY: Float,
-    val ended: Boolean,
-    val aId: String = "",
-    val bId: String = "",
-) {
-    fun touches(personId: String): Boolean = personId == aId || personId == bId
-}
-
-/**
- * One family's descent, running sideways: out to the right of the parents, a bar down the children,
- * and a stub into each.
- *
- * [DescentLink] turned through a right angle, and the same rule holds — the bar spans the parents'
- * stem as well as every child, so a couple sitting outside the run of their own children still has
- * a connector that reaches them rather than one ending in mid-air.
- */
-data class WholeDescentLink(
-    /** Where the stem leaves the parents: their right edge, at their middle. */
-    val originX: Float,
-    val originY: Float,
-    /** The column the bar stands in, between the parents and the children. */
-    val busX: Float,
-    val childYs: List<Float>,
-    /** The left edge of the children's column, where each stub arrives. */
-    val childLeftX: Float,
-    val parentIds: List<String> = emptyList(),
-    /** In the same order as [childYs], so a stub and a child can be matched up. */
-    val childIds: List<String> = emptyList(),
-) {
-    fun touches(personId: String): Boolean = personId in parentIds || personId in childIds
-
-    val barStart: Float get() = minOf(originY, childYs.minOrNull() ?: originY)
-    val barEnd: Float get() = maxOf(originY, childYs.maxOrNull() ?: originY)
 }
 
 /**
@@ -116,8 +72,8 @@ data class GenerationBand(val level: Int, val x: Float, val y: Float, val height
 
 data class WholeTreeLayout(
     val nodes: List<WholeTreeNode> = emptyList(),
-    val spouseLinks: List<WholeSpouseLink> = emptyList(),
-    val descentLinks: List<WholeDescentLink> = emptyList(),
+    val spouseLinks: List<SpouseLink> = emptyList(),
+    val descentLinks: List<DescentLink> = emptyList(),
     val siblingBrackets: List<SiblingBracket> = emptyList(),
     val groups: List<TreeGroup> = emptyList(),
     val bands: List<GenerationBand> = emptyList(),

--- a/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/graph/WholeTreeLayoutEngine.kt
@@ -618,8 +618,8 @@ object WholeTreeLayoutEngine {
     /* ------------------------------------------------------------------ connectors */
 
     private class Links(
-        val spouses: List<WholeSpouseLink>,
-        val descents: List<WholeDescentLink>,
+        val spouses: List<SpouseLink>,
+        val descents: List<DescentLink>,
         val brackets: List<SiblingBracket>,
     )
 
@@ -627,7 +627,7 @@ object WholeTreeLayoutEngine {
         snapshot: FamilySnapshot,
         byId: Map<String, WholeTreeNode>,
     ): Links {
-        val spouses = mutableListOf<WholeSpouseLink>()
+        val spouses = mutableListOf<SpouseLink>()
         snapshot.spouseEdges.forEach { (a, b) ->
             val na = byId[a] ?: return@forEach
             val nb = byId[b] ?: return@forEach
@@ -637,11 +637,10 @@ object WholeTreeLayoutEngine {
             // Drawn only when they are actually adjacent; a rule spanning three cards would read as
             // a marriage to whoever sits in between.
             if (lower.y - upper.bottom > TreeMetrics.STACK_GAP) return@forEach
-            spouses += WholeSpouseLink(
+            spouses += SpouseLink(
                 x = upper.centerX,
                 fromY = upper.bottom,
                 toY = lower.y,
-                ended = false,
                 aId = a,
                 bId = b,
             )
@@ -649,7 +648,7 @@ object WholeTreeLayoutEngine {
 
         // One descent per parent *set*, which is what puts a couple's children on a single bar and
         // hangs a half-sibling from their own.
-        val descents = mutableListOf<WholeDescentLink>()
+        val descents = mutableListOf<DescentLink>()
         snapshot.people.keys
             .mapNotNull { child ->
                 val parents = snapshot.parentsOf[child].orEmpty().sorted()
@@ -663,7 +662,7 @@ object WholeTreeLayoutEngine {
 
                 val originX = parentNodes.maxOf { it.right }
                 val childLeftX = childNodes.minOf { it.x }
-                descents += WholeDescentLink(
+                descents += DescentLink(
                     originX = originX,
                     originY = parentNodes.map { it.centerY }.average().toFloat(),
                     // Just before the nearest child, so a child placed further along gets a longer

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartDrawing.kt
@@ -24,7 +24,6 @@ import com.vibethroughcode.ftree.data.PartialDate
 import com.vibethroughcode.ftree.data.Person
 import com.vibethroughcode.ftree.graph.DescentLink
 import com.vibethroughcode.ftree.graph.TreeMetrics
-import com.vibethroughcode.ftree.graph.WholeDescentLink
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import kotlin.math.max
 import kotlin.math.min
@@ -60,11 +59,12 @@ internal fun visibleRegion(pan: Offset, zoom: Float, unitPx: Float, viewport: Si
     visibleRegion(pan, zoom, unitPx, viewport.width, viewport.height)
 
 /**
- * One family's descent: a drop from the parents, a bar across the children, and a drop to each.
+ * One family's descent: out to the right of the parents, a bar down the children, and a stub into
+ * each.
  *
  * The bar runs from the parents' stem to the far side of the children, rather than only between the
- * first child and the last. That is not a flourish: the parents' midpoint is regularly *outside* the
- * span of their own children — a couple whose eldest child has a wide subtree of their own gets
+ * first child and the last. That is not a flourish: the parents' middle is regularly *outside* the
+ * run of their own children — a couple whose eldest child has a large family of their own gets
  * pushed clear of the whole run — and a bar drawn only between the children then leaves the stem
  * ending in mid-air. The chart silently stops claiming the parentage it was drawn to state, and a
  * reader quite reasonably concludes those children have no recorded parents. It is one line of
@@ -75,51 +75,6 @@ internal fun visibleRegion(pan: Offset, zoom: Float, unitPx: Float, viewport: Si
  */
 fun DrawScope.drawDescent(
     link: DescentLink,
-    unitPx: Float,
-    color: Color,
-    strokeWidth: Float,
-    alpha: Float = 1f,
-) {
-    val originX = link.originX * unitPx
-    val busY = link.busY * unitPx
-    val xs = link.childXs.map { it * unitPx }
-    if (xs.isEmpty()) return
-
-    drawLine(
-        color = color,
-        start = Offset(originX, link.originY * unitPx),
-        end = Offset(originX, busY),
-        strokeWidth = strokeWidth,
-        alpha = alpha,
-    )
-    drawLine(
-        color = color,
-        start = Offset(link.barStart * unitPx, busY),
-        end = Offset(link.barEnd * unitPx, busY),
-        strokeWidth = strokeWidth,
-        alpha = alpha,
-    )
-    xs.forEach { x ->
-        drawLine(
-            color = color,
-            start = Offset(x, busY),
-            end = Offset(x, link.childTopY * unitPx),
-            strokeWidth = strokeWidth,
-            alpha = alpha,
-        )
-    }
-}
-
-/**
- * The same descent, drawn sideways: out to the right of the parents, a bar down the children, and a
- * stub into each.
- *
- * The whole-tree chart runs left to right, so its connectors are this one turned through a right
- * angle. Written beside [drawDescent] rather than derived from it: they are the same idea in the
- * same notation, and keeping them next to each other is how they stay that way.
- */
-fun DrawScope.drawDescentSideways(
-    link: WholeDescentLink,
     unitPx: Float,
     color: Color,
     strokeWidth: Float,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -196,14 +196,15 @@ fun FamilyChart(
                     drawDescent(link, unitPx, accents.rule, rulePx)
                 }
 
-                // Marriage is the doubled rule, as on a drawn pedigree.
+                // Marriage is the doubled rule, as on a drawn pedigree — down the side of the
+                // couple, since a generation is a column and the two are stacked.
                 layout.spouseLinks.forEach { link ->
-                    val y = link.y * unitPx
-                    listOf(-spouseGapPx, spouseGapPx).forEach { dy ->
+                    val x = link.x * unitPx
+                    listOf(-spouseGapPx, spouseGapPx).forEach { dx ->
                         drawLine(
                             color = accents.spouseLink,
-                            start = Offset(link.fromX * unitPx, y + dy),
-                            end = Offset(link.toX * unitPx, y + dy),
+                            start = Offset(x + dx, link.fromY * unitPx),
+                            end = Offset(x + dx, link.toY * unitPx),
                             strokeWidth = rulePx,
                         )
                     }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -373,7 +373,7 @@ fun WholeFamilyChart(
                 layout.descentLinks.forEach { link ->
                     if (link.busX < visible.left || link.originX > visible.right) return@forEach
                     val on = lit != null && link.touches(lit)
-                    drawDescentSideways(
+                    drawDescent(
                         link = link,
                         unitPx = unitPx,
                         color = if (on) colors.primary else accents.rule,

--- a/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/graph/TreeLayoutEngineTest.kt
@@ -31,6 +31,7 @@ class TreeLayoutEngineTest {
 
     private fun TreeLayout.levelOf(id: String) = node(id)?.level
     private fun TreeLayout.xOf(id: String) = node(id)!!.centerX
+    private fun TreeLayout.yOf(id: String) = node(id)!!.centerY
 
     private fun nuclearFamily() = Builder()
         .person("father", "1962").person("mother", "1965")
@@ -60,7 +61,7 @@ class TreeLayoutEngineTest {
     }
 
     @Test
-    fun `generations sit on their own rows above and below the focus`() {
+    fun `generations sit in their own columns before and after the focus`() {
         val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
 
         assertEquals(-1, layout.levelOf("father"))
@@ -72,31 +73,32 @@ class TreeLayoutEngineTest {
     }
 
     @Test
-    fun `a row shares one y and rows are ordered top to bottom`() {
+    fun `a generation shares one x and generations run left to right`() {
         val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
 
-        assertEquals(layout.node("father")!!.y, layout.node("mother")!!.y, 0.01f)
-        assertTrue(layout.node("father")!!.y < layout.node("me")!!.y)
-        assertTrue(layout.node("me")!!.y < layout.node("child")!!.y)
+        assertEquals(layout.node("father")!!.x, layout.node("mother")!!.x, 0.01f)
+        assertTrue(layout.node("father")!!.x < layout.node("me")!!.x)
+        assertTrue(layout.node("me")!!.x < layout.node("child")!!.x)
     }
 
     @Test
-    fun `partners are placed side by side`() {
+    fun `partners are placed one above the other, at couple spacing`() {
         val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
 
-        val gap = abs(layout.xOf("me") - layout.xOf("wife"))
-        assertEquals(TreeMetrics.NODE_WIDTH + TreeMetrics.COUPLE_GAP, gap, 0.01f)
+        assertEquals("a couple shares a generation", layout.xOf("me"), layout.xOf("wife"), 0.01f)
+        val gap = abs(layout.yOf("me") - layout.yOf("wife"))
+        assertEquals(TreeMetrics.NODE_HEIGHT + TreeMetrics.COUPLE_GAP, gap, 0.01f)
     }
 
     @Test
-    fun `no two people on the same row overlap`() {
+    fun `no two people in the same generation overlap`() {
         val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
 
-        layout.nodes.groupBy { it.level }.forEach { (_, row) ->
-            row.sortedBy { it.x }.zipWithNext { left, right ->
+        layout.nodes.groupBy { it.level }.forEach { (_, column) ->
+            column.sortedBy { it.y }.zipWithNext { upper, lower ->
                 assertTrue(
-                    "${left.person.id} overlaps ${right.person.id}",
-                    right.x >= left.x + TreeMetrics.NODE_WIDTH - 0.01f,
+                    "${upper.person.id} overlaps ${lower.person.id}",
+                    lower.y >= upper.y + TreeMetrics.NODE_HEIGHT - 0.01f,
                 )
             }
         }
@@ -107,12 +109,12 @@ class TreeLayoutEngineTest {
         val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
 
         // father+mother -> me, sister is one family; me+wife -> child is another.
-        val toSiblings = layout.descentLinks.first { it.childXs.size == 2 }
-        assertEquals(2, toSiblings.childXs.size)
-        // The drop starts between the two parents.
-        val between = layout.xOf("father") to layout.xOf("mother")
-        assertTrue(toSiblings.originX > minOf(between.first, between.second))
-        assertTrue(toSiblings.originX < maxOf(between.first, between.second))
+        val toSiblings = layout.descentLinks.first { it.childYs.size == 2 }
+        assertEquals(2, toSiblings.childYs.size)
+        // The stem leaves from between the two parents.
+        val between = layout.yOf("father") to layout.yOf("mother")
+        assertTrue(toSiblings.originY > minOf(between.first, between.second))
+        assertTrue(toSiblings.originY < maxOf(between.first, between.second))
     }
 
     @Test
@@ -128,9 +130,9 @@ class TreeLayoutEngineTest {
         val layout = TreeLayoutEngine.layout(snapshot, "father")
 
         // Two separate descents, not one bar spanning both children.
-        val descents = layout.descentLinks.filter { it.childTopY > it.originY }
+        val descents = layout.descentLinks.filter { it.childLeftX > it.originX }
         assertEquals(2, descents.size)
-        assertTrue(descents.all { it.childXs.size == 1 })
+        assertTrue(descents.all { it.childYs.size == 1 })
     }
 
     @Test
@@ -142,9 +144,9 @@ class TreeLayoutEngineTest {
 
         val layout = TreeLayoutEngine.layout(snapshot, "me")
 
-        val me = layout.xOf("me")
-        val a = layout.xOf("first")
-        val b = layout.xOf("second")
+        val me = layout.yOf("me")
+        val a = layout.yOf("first")
+        val b = layout.yOf("second")
         assertTrue("expected $me between $a and $b", me > minOf(a, b) && me < maxOf(a, b))
     }
 
@@ -157,8 +159,8 @@ class TreeLayoutEngineTest {
 
         val layout = TreeLayoutEngine.layout(snapshot, "me")
 
-        assertTrue(layout.xOf("eldest") < layout.xOf("me"))
-        assertTrue(layout.xOf("me") < layout.xOf("youngest"))
+        assertTrue(layout.yOf("eldest") < layout.yOf("me"))
+        assertTrue(layout.yOf("me") < layout.yOf("youngest"))
     }
 
     @Test
@@ -189,7 +191,7 @@ class TreeLayoutEngineTest {
     }
 
     @Test
-    fun `siblings joined only by an explicit edge still share the row`() {
+    fun `siblings joined only by an explicit edge still share the generation`() {
         val snapshot = Builder()
             .person("me", "1990").person("brother", "1992")
             .siblingOf("me", "brother")
@@ -289,9 +291,9 @@ class TreeLayoutEngineTest {
         assertTrue(large.node("me")!!.width > normal.node("me")!!.width)
         assertTrue(large.height > normal.height)
         // And nothing overlaps at the larger size either.
-        large.nodes.groupBy { it.level }.forEach { (_, row) ->
-            row.sortedBy { it.x }.zipWithNext { left, right ->
-                assertTrue(right.x >= left.x + left.width - 0.01f)
+        large.nodes.groupBy { it.level }.forEach { (_, column) ->
+            column.sortedBy { it.y }.zipWithNext { upper, lower ->
+                assertTrue(lower.y >= upper.y + upper.height - 0.01f)
             }
         }
     }
@@ -332,10 +334,10 @@ class TreeLayoutEngineTest {
             // children, because a child's subtree pushed the run clear of them.
             assertTrue(
                 "fixture no longer reproduces the stranded stem",
-                link.originX < link.childXs.min() || link.originX > link.childXs.max(),
+                link.originY < link.childYs.min() || link.originY > link.childYs.max(),
             )
-            assertTrue("bar does not reach the stem", link.originX in link.barStart..link.barEnd)
-            link.childXs.forEach {
+            assertTrue("bar does not reach the stem", link.originY in link.barStart..link.barEnd)
+            link.childYs.forEach {
                 assertTrue("bar does not reach a child", it in link.barStart..link.barEnd)
             }
         }
@@ -346,8 +348,8 @@ class TreeLayoutEngineTest {
         val layout = TreeLayoutEngine.layout(nuclearFamily(), "me")
         assertTrue(layout.descentLinks.isNotEmpty())
         layout.descentLinks.forEach { link ->
-            assertTrue(link.originX in link.barStart..link.barEnd)
-            link.childXs.forEach { assertTrue(it in link.barStart..link.barEnd) }
+            assertTrue(link.originY in link.barStart..link.barEnd)
+            link.childYs.forEach { assertTrue(it in link.barStart..link.barEnd) }
         }
     }
 
@@ -363,14 +365,14 @@ class TreeLayoutEngineTest {
     }
 
     @Test
-    fun `a drop matches the child underneath it`() {
+    fun `a stub matches the child beside it`() {
         val layout = TreeLayoutEngine.layout(twoMarriages(), "father", generationsDown = 2)
         layout.descentLinks.forEach { link ->
-            assertEquals(link.childXs.size, link.childIds.size)
+            assertEquals(link.childYs.size, link.childIds.size)
             link.childIds.forEachIndexed { index, id ->
-                // The ids are carried in the same order as the drops, so a drop and the card
-                // beneath it can be matched up rather than assumed to correspond.
-                assertEquals(layout.xOf(id), link.childXs[index], 0.01f)
+                // The ids are carried in the same order as the stubs, so a stub and the card
+                // beside it can be matched up rather than assumed to correspond.
+                assertEquals(layout.yOf(id), link.childYs[index], 0.01f)
             }
         }
     }
@@ -402,10 +404,10 @@ class TreeLayoutEngineTest {
         assertEquals(1 + 4 + 16 + 64 + 256, layout.nodes.size)
         assertTrue("layout took ${millis}ms", millis < 1_000)
 
-        // Still no overlaps at 256 nodes on the bottom row.
-        layout.nodes.groupBy { it.level }.forEach { (_, row) ->
-            row.sortedBy { it.x }.zipWithNext { left, right ->
-                assertTrue(right.x >= left.x + TreeMetrics.NODE_WIDTH - 0.01f)
+        // Still no overlaps at 256 nodes in the last generation.
+        layout.nodes.groupBy { it.level }.forEach { (_, column) ->
+            column.sortedBy { it.y }.zipWithNext { upper, lower ->
+                assertTrue(lower.y >= upper.y + TreeMetrics.NODE_HEIGHT - 0.01f)
             }
         }
     }


### PR DESCRIPTION
"Chart" now reads left to right like "Everyone". A generation is a column, ancestors before the focus, descendants after, partners and siblings stacked beside them.

## Same shape, same reason

| focused on | before | after | aspect |
|---|---|---|---|
| Laxmi (68 nodes) | 45.0 × 3.2 cards | **7.9 × 19.0** | 14 → **0.42** |
| Durga (44 nodes) | 38.5 × ~3 | **6.3 × 16.3** | → 0.38 |
| Ankit (12 nodes) | 5.2 × ~2 | 6.3 × 2.3 | small either way |

A phone's aspect is about 0.46. Small families were never the problem and are unchanged.

**Consistency is half the point.** Two charts one switch apart, disagreeing about which way a family runs, made the reader relearn the picture every time they moved between them.

## One notation instead of two

With both charts sideways the two sets of connectors became the same shape, so they are now one:

- `WholeSpouseLink` and `WholeDescentLink` deleted — `SpouseLink` and `DescentLink` are shared
- one `drawDescent` rather than one per chart
- `ended` deleted with them: written as `false`, never read

That removes the thing the previous PR had to warn about — a coordinate whose meaning depended on which chart was reading it.

## Verification

- **208 unit tests.** Every row-axis assertion in the focused chart's suite was **rotated, not relaxed**: partners at couple spacing one above the other, nobody overlapping within a generation, siblings ordered by birth down the column, a twice-married person still between their partners, half-siblings on separate connectors, the descent bar still reaching a stem that sits outside its children's run.
- **155 instrumented tests.**
- **lint unchanged** at 82 findings.
- Checked on the real 148-person record on device, portrait and landscape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)