### PR TITLE
Version 0.7.0-beta.4

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 19
-        versionName = "0.7.0-beta.3"
+        versionCode = 20
+        versionName = "0.7.0-beta.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 20, `versionName` 0.7.0-beta.4 — a pre-release, so `releases/latest` keeps answering v0.6.0.

Ships [#71](https://github.com/thisisankit27/f-tree/pull/71): **the focused chart turned on its side too.**

Both views now read left to right. A generation is a column, ancestors before the focus, descendants after, partners and siblings stacked beside them.

| focused on | before | after | aspect |
|---|---|---|---|
| Laxmi (68 nodes) | 45.0 × 3.2 cards | **7.9 × 19.0** | 14 → **0.42** |
| Durga (44 nodes) | 38.5 × ~3 | **6.3 × 16.3** | → 0.38 |

A phone's aspect is about 0.46. Small families were never the problem and are unchanged.

Also: with both charts sideways their connectors became the same shape, so `WholeSpouseLink` and `WholeDescentLink` are gone and there is one shared `SpouseLink`, `DescentLink` and `drawDescent`.

208 unit, 155 instrumented, lint unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)