### PR TITLE
Clamp the pan against the chart that is on screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -130,6 +130,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.room.testing)

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/ChartPanningTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/ChartPanningTest.kt
@@ -1,0 +1,135 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.click
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.swipe
+import androidx.compose.ui.unit.dp
+import androidx.test.espresso.Espresso
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.RelativeKind
+import com.vibethroughcode.ftree.ui.tree.FamilyChartTag
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Panning a chart that has been re-centred without the screen being rebuilt.
+ *
+ * The gesture that pans and zooms is built once and never rebuilt, so anything it closes over is
+ * frozen at the moment the chart first appeared. It clamps the pan against the size of the drawing,
+ * and holding a stale size meant the pan was kept inside the extent of a family that was no longer
+ * on screen: the first drag after re-centring snapped the chart into that old window — a jump of
+ * hundreds of points from a touch of twenty — and most of the real chart became unreachable.
+ *
+ * Reported from a real tree, and reproducible only through this exact shape: the chart has to be
+ * built while showing a *small* family and then re-centred, in place, on a much larger one.
+ * Re-centring from a person's page navigates, which rebuilds the screen and hides the fault.
+ */
+class ChartPanningTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    /** The chart opened on Padma is two cards; re-centred on Sunita it is thirty-one. */
+    private val siblings = (1..31).map { "Sibling %02d".format(it) }
+    private val middleSibling = siblings[19]
+
+    @Before
+    fun seed() {
+        app.container.updatePreferences.setEnabled(false)
+        app.container.database.clearAllTables()
+
+        val repository = app.container.familyRepository
+        runBlocking {
+            val parent = Person(name = "Ram Prasad", birthDate = "1920")
+            repository.addPerson(parent)
+            siblings.forEachIndexed { index, name ->
+                val child = Person(name = name, birthDate = (1945 + index).toString())
+                repository.addPerson(child)
+                repository.addRelative(child.id, parent.id, RelativeKind.PARENT)
+                if (name == middleSibling) {
+                    // Married in from outside: nobody else in this person's chart, so the chart
+                    // built for them is the smallest one the app can draw.
+                    val spouse = Person(name = "Padma", birthDate = "1960")
+                    repository.addPerson(spouse)
+                    repository.addRelative(spouse.id, child.id, RelativeKind.SPOUSE)
+                }
+            }
+        }
+        rule.waitUntil(10_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    @Test
+    fun aSmallDragDoesNotThrowARecentredChartOffTheScreen() {
+        // The chart is built showing Padma, whose family is her husband and nobody else.
+        rule.onNodeWithTag(NavPeopleTag).performClick()
+        rule.waitForIdle()
+        rule.onNodeWithText("Padma").performScrollTo().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithContentDescription("Show on the tree").performClick()
+        rule.waitUntil(10_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        /*
+         * Her husband is stacked directly under her, a couple's spacing away, and the pair are
+         * centred on a chart that holds nothing else — so where he is can be worked out rather
+         * than hunted for.
+         */
+        rule.onNodeWithTag(FamilyChartTag).performTouchInput {
+            click(center + Offset(0f, 60.dp.toPx()))
+        }
+        rule.waitForIdle()
+        rule.onNodeWithText("Centre the tree here").performClick()
+        rule.waitForIdle()
+
+        // Re-centred, in place, on a chart thirty-one people tall. He is at the middle of it.
+        rule.onNodeWithTag(FamilyChartTag).performTouchInput { click(center) }
+        rule.waitForIdle()
+        rule.onNodeWithText("Open $middleSibling").assertIsDisplayed()
+
+        // Put the sheet away and make sure it is gone: left open, its text would still be on
+        // screen at the end and the assertion below would pass without the chart being asked
+        // anything at all.
+        Espresso.pressBack()
+        rule.waitUntil(5_000) {
+            rule.onAllNodesWithText("Open $middleSibling").fetchSemanticsNodes().isEmpty()
+        }
+
+        // A drag of twenty points is a third of a card. Whoever was under the middle of the screen
+        // must still be under it.
+        rule.onNodeWithTag(FamilyChartTag).performTouchInput {
+            swipe(start = center, end = center - Offset(0f, 20.dp.toPx()), durationMillis = 200)
+        }
+        rule.waitForIdle()
+        rule.onNodeWithTag(FamilyChartTag).performTouchInput { click(center) }
+        rule.waitForIdle()
+
+        assertTrue(
+            "a twenty-point drag moved the chart far enough to lose the person under the middle " +
+                "of the screen, so the pan was clamped against a family that is no longer drawn",
+            rule.onAllNodesWithText("Open $middleSibling").fetchSemanticsNodes().isNotEmpty(),
+        )
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationSheet.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/relation/RelationSheet.kt
@@ -60,6 +60,9 @@ import com.vibethroughcode.ftree.ui.common.isShortWindow
 import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.text.rememberTextMeasurer
 
 const val RelationSheetTag = "relation-sheet"
 const val RelationCloseTag = "relation-close"
@@ -282,9 +285,30 @@ private fun Headline(state: RelationUiState, onShare: () -> Unit, onClose: () ->
  */
 @Composable
 private fun Pair(state: RelationUiState, onPick: (RelationSlot) -> Unit, onSwap: () -> Unit) {
+    val between = stringResource(R.string.relation_between)
+    val and = stringResource(R.string.relation_and)
+
+    /*
+     * One column for both words, as wide as the longer of them.
+     *
+     * "Between" and "and" are not the same length, so setting each card's name straight after its
+     * own word put the two people at different distances from the edge — a stagger of a few points
+     * that reads as a mistake, because the two rows are plainly meant to be the same shape. The
+     * width is measured from the words themselves rather than set to a number, so it survives
+     * translation and the reader's text size, both of which change the answer.
+     */
+    val measurer = rememberTextMeasurer()
+    val labelWidth = with(LocalDensity.current) {
+        maxOf(
+            measurer.measure(between, FTreeText.recordSmall).size.width,
+            measurer.measure(and, FTreeText.recordSmall).size.width,
+        ).toDp()
+    }
+
     val from: @Composable (Modifier) -> Unit = { modifier ->
         Slot(
-            label = stringResource(R.string.relation_between),
+            label = between,
+            labelWidth = labelWidth,
             person = state.from,
             tag = RelationSlotFromTag,
             modifier = modifier,
@@ -293,7 +317,8 @@ private fun Pair(state: RelationUiState, onPick: (RelationSlot) -> Unit, onSwap:
     }
     val to: @Composable (Modifier) -> Unit = { modifier ->
         Slot(
-            label = stringResource(R.string.relation_and),
+            label = and,
+            labelWidth = labelWidth,
             person = state.to,
             tag = RelationSlotToTag,
             modifier = modifier,
@@ -337,11 +362,16 @@ private fun Pair(state: RelationUiState, onPick: (RelationSlot) -> Unit, onSwap:
     }
 }
 
+/** The face beside a name, and the space kept for it before there is one. */
+private val AVATAR = 28.dp
+
 /** One of the two people, or an invitation to choose one. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun Slot(
     label: String,
+    /** Shared with the other slot, so both names start at the same place. */
+    labelWidth: Dp,
     person: Person?,
     tag: String,
     onClick: () -> Unit,
@@ -362,9 +392,19 @@ private fun Slot(
                 text = label,
                 style = FTreeText.recordSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(end = 12.dp),
+                modifier = Modifier.width(labelWidth),
             )
-            person?.let { PersonAvatar(it, diameter = 28.dp, decorative = true) }
+            Spacer(Modifier.width(12.dp))
+            /*
+             * The face's place is held whether or not there is a face in it. Drawing it only once
+             * somebody is chosen moved the name sideways at the moment of choosing, and left a
+             * filled slot and an empty one disagreeing about where a name begins — which is the
+             * same misalignment again, from the other direction.
+             */
+            Box(Modifier.size(AVATAR), contentAlignment = Alignment.Center) {
+                person?.let { PersonAvatar(it, diameter = AVATAR, decorative = true) }
+            }
+            Spacer(Modifier.width(10.dp))
             Text(
                 text = person?.displayName() ?: stringResource(R.string.relation_choose),
                 style = MaterialTheme.typography.titleSmall,
@@ -374,7 +414,6 @@ private fun Slot(
                 else FontStyle.Normal,
                 color = if (person == null) MaterialTheme.colorScheme.onSurfaceVariant
                 else MaterialTheme.colorScheme.onSurface,
-                modifier = Modifier.padding(start = if (person == null) 0.dp else 10.dp),
             )
         }
     }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartViewport.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/ChartViewport.kt
@@ -4,6 +4,23 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.IntSize
 
 /**
+ * One generation's cards: how far they reach along both axes, in layout units.
+ *
+ * A chart that runs sideways is mostly empty paper. The earliest generation holds two people and
+ * the latest holds sixty, so a column is short exactly where its neighbour is long — and a rule
+ * that only kept the middle of the screen inside the chart's *rectangle* let a reader scroll down
+ * past the end of the column they were following into a blank sheet, with the populated columns
+ * beside them off the edge. Knowing where each generation starts and stops is what lets the clamp
+ * follow the drawing rather than the page it is drawn on.
+ */
+internal data class ChartColumn(
+    val left: Float,
+    val right: Float,
+    val top: Float,
+    val bottom: Float,
+)
+
+/**
  * Keeps a chart from being dragged off its own page.
  *
  * Both charts are a canvas the size of the family, panned by a finger with nothing to stop it. Six
@@ -18,26 +35,61 @@ import androidx.compose.ui.unit.IntSize
  * corner is usually empty paper, and a clamp that only kept the rectangle honest still allowed a
  * blank screen — which is how this was first written, and what measuring the pixels caught.
  *
- * Keeping the centre inside the drawing is a real guarantee instead. The outermost cards are what
- * define the edges of it, so wherever the centre lands, one of them is within half a screen and
- * therefore in view. It is also the rule a map uses, and it reads the same way: the paper can be
- * pushed until its edge reaches the middle, and no further.
+ * Keeping the centre inside the drawing is a real guarantee instead. It is also the rule a map
+ * uses, and it reads the same way: the paper can be pushed until its edge reaches the middle, and
+ * no further.
+ *
+ * "The drawing" means the cards, not the rectangle around them — see [ChartColumn]. Turning the
+ * charts sideways made the difference matter: a chart is now tall and its generations are short
+ * exactly where their neighbours are long, so the outline is mostly paper nobody has drawn on.
  */
 internal fun clampPan(
     pan: Offset,
     contentWidth: Float,
     contentHeight: Float,
     viewport: IntSize,
+    /** The generations, in layout units. Empty falls back to the chart's outline. */
+    columns: List<ChartColumn> = emptyList(),
+    /** Layout units to screen pixels, at the current zoom. */
+    scale: Float = 1f,
 ): Offset {
     if (viewport.width == 0 || viewport.height == 0) return pan
-    return Offset(
-        x = clampAxis(pan.x, contentWidth, viewport.width),
-        y = clampAxis(pan.y, contentHeight, viewport.height),
-    )
+    if (columns.isEmpty()) {
+        return Offset(
+            x = clampAxis(pan.x, contentWidth, viewport.width),
+            y = clampAxis(pan.y, contentHeight, viewport.height),
+        )
+    }
+
+    val midX = viewport.width / 2f
+    val midY = viewport.height / 2f
+
+    // Sideways, so the horizontal limit is the first and last generation.
+    val first = columns.minOf { it.left } * scale
+    val last = columns.maxOf { it.right } * scale
+    val x = pan.x.coerceIn(midX - last, midX - first)
+
+    /*
+     * Vertically, only the generations actually on screen have a say.
+     *
+     * Following one generation down and stopping at the end of it is right; being allowed to carry
+     * on into empty paper is not. Taking the union over what is visible rather than the column
+     * under the exact middle means a short generation beside a long one still scrolls — you keep
+     * going, and what you are following becomes the neighbour, which is what the eye does anyway.
+     */
+    val left = -x
+    val right = left + viewport.width
+    val onScreen = columns.filter { it.right * scale >= left && it.left * scale <= right }
+        .ifEmpty { columns }
+    val top = onScreen.minOf { it.top } * scale
+    val bottom = onScreen.maxOf { it.bottom } * scale
+    val y = pan.y.coerceIn(midY - bottom, midY - top)
+
+    return Offset(x, y)
 }
 
 /**
- * The range a single axis may be panned through.
+ * The range a single axis may be panned through, when all that is known is the chart's outline.
  *
  * The chart occupies `[offset, offset + content]` in screen space, so the point under the middle of
  * the screen is `viewport / 2 - offset` in the chart's own coordinates. Requiring that to stay

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/FamilyChart.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.input.pointer.pointerInput
@@ -141,6 +142,27 @@ fun FamilyChart(
         snapshotFlow { wantedPhotos.value }.distinctUntilChanged().collect(cache::request)
     }
 
+    /**
+     * How big the drawing is, kept current.
+     *
+     * Read by the gesture below, which is built once and would otherwise go on clamping against
+     * whatever family happened to be on screen when it was made.
+     */
+    val paper by rememberUpdatedState(Size(layout.width, layout.height))
+
+    /** Where the cards actually are, a generation at a time. Recomputed only when the chart is. */
+    val columns = remember(layout) {
+        layout.nodes.groupBy { it.x }.map { (x, ns) ->
+            ChartColumn(
+                left = x,
+                right = x + ns.maxOf { it.width },
+                top = ns.minOf { it.y },
+                bottom = ns.maxOf { it.y + it.height },
+            )
+        }
+    }
+    val paperColumns by rememberUpdatedState(columns)
+
     val tapped by rememberUpdatedState(onSelect)
 
     Canvas(
@@ -156,6 +178,18 @@ fun FamilyChart(
             .testTag(FamilyChartTag)
             .semantics { contentDescription = chartDescription }
             .onSizeChanged { viewport = it }
+            /*
+             * Keyed on nothing, so it is built once and never again — which is exactly why the
+             * size it clamps against is read from [paper] rather than from `layout`. A gesture
+             * block closing over the layout keeps the *first* one it ever saw: re-centre the chart
+             * on somebody else and the pan is still being held inside the extent of a family that
+             * is no longer on screen. The first drag then snaps the chart into that stale window
+             * and most of the real one becomes unreachable.
+             *
+             * This is the same trap as the tap handler below, which reads the latest callback for
+             * the same reason. A `pointerInput` key covers what restarts the gesture, never what
+             * the gesture reads.
+             */
             .pointerInput(Unit) {
                 detectTransformGestures { centroid, panChange, zoomChange, _ ->
                     val next = (zoom * zoomChange).coerceIn(MIN_ZOOM, MAX_ZOOM)
@@ -165,9 +199,11 @@ fun FamilyChart(
                     zoom = next
                     pan = clampPan(
                         pan = (pan - centroid) * factor + centroid + panChange,
-                        contentWidth = layout.width * unitPx * next,
-                        contentHeight = layout.height * unitPx * next,
+                        contentWidth = paper.width * unitPx * next,
+                        contentHeight = paper.height * unitPx * next,
                         viewport = viewport,
+                        columns = paperColumns,
+                        scale = unitPx * next,
                     )
                 }
             }

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/tree/WholeFamilyChart.kt
@@ -217,6 +217,27 @@ fun WholeFamilyChart(
         snapshotFlow { wantedPhotos.value }.distinctUntilChanged().collect(cache::request)
     }
 
+    /**
+     * How big the drawing is, kept current.
+     *
+     * Read by the gesture below, which is built once and would otherwise go on clamping against
+     * whatever family happened to be on screen when it was made.
+     */
+    val paper by rememberUpdatedState(Size(layout.width, layout.height))
+
+    /** Where the cards actually are, a generation at a time. Recomputed only when the chart is. */
+    val columns = remember(layout) {
+        layout.nodes.groupBy { it.x }.map { (x, ns) ->
+            ChartColumn(
+                left = x,
+                right = x + TreeMetrics.NODE_WIDTH,
+                top = ns.minOf { it.y },
+                bottom = ns.maxOf { it.y } + TreeMetrics.NODE_HEIGHT,
+            )
+        }
+    }
+    val paperColumns by rememberUpdatedState(columns)
+
     val tapped by rememberUpdatedState(onSelect)
     val tappedNobody by rememberUpdatedState(onDeselect)
 
@@ -233,6 +254,18 @@ fun WholeFamilyChart(
             .testTag(WholeFamilyChartTag)
             .semantics { contentDescription = description }
             .onSizeChanged { viewport = it }
+            /*
+             * Keyed on nothing, so it is built once and never again — which is exactly why the
+             * size it clamps against is read from [paper] rather than from `layout`. A gesture
+             * block closing over the layout keeps the *first* one it ever saw: re-centre the chart
+             * on somebody else and the pan is still being held inside the extent of a family that
+             * is no longer on screen. The first drag then snaps the chart into that stale window
+             * and most of the real one becomes unreachable.
+             *
+             * This is the same trap as the tap handler below, which reads the latest callback for
+             * the same reason. A `pointerInput` key covers what restarts the gesture, never what
+             * the gesture reads.
+             */
             .pointerInput(Unit) {
                 detectTransformGestures { centroid, panChange, zoomChange, _ ->
                     val next = (zoom * zoomChange).coerceIn(MIN_ZOOM, MAX_ZOOM)
@@ -240,9 +273,11 @@ fun WholeFamilyChart(
                     zoom = next
                     pan = clampPan(
                         pan = (pan - centroid) * factor + centroid + panChange,
-                        contentWidth = layout.width * unitPx * next,
-                        contentHeight = layout.height * unitPx * next,
+                        contentWidth = paper.width * unitPx * next,
+                        contentHeight = paper.height * unitPx * next,
                         viewport = viewport,
+                        columns = paperColumns,
+                        scale = unitPx * next,
                     )
                 }
             }

--- a/app/src/test/java/com/vibethroughcode/ftree/ui/tree/ChartViewportTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/ui/tree/ChartViewportTest.kt
@@ -71,4 +71,81 @@ class ChartViewportTest {
         val pan = Offset(-99999f, -99999f)
         assertEquals(pan, clampPan(pan, 4000f, 6000f, IntSize.Zero))
     }
+
+    /*
+     * A sideways chart is mostly empty paper: the earliest generation holds two people and the
+     * latest holds sixty. These are the cases where the outline and the drawing disagree.
+     */
+
+    /** A short generation beside a long one, the shape that made this matter. */
+    private val short = ChartColumn(left = 0f, right = 160f, top = 400f, bottom = 700f)
+    private val long = ChartColumn(left = 264f, right = 424f, top = 0f, bottom = 3000f)
+
+    @Test
+    fun `following a generation down stops at the end of what is drawn there`() {
+        // Only the short generation is on screen, and the drag runs far past its last card.
+        val narrow = IntSize(200, 2000)
+        val panned = clampPan(
+            pan = Offset(0f, -99999f),
+            contentWidth = 4000f, contentHeight = 6000f,
+            viewport = narrow,
+            columns = listOf(short, long),
+            scale = 1f,
+        )
+        val centre = 1000f - panned.y
+        assertEquals("the middle must rest on the last card, not below it", 700f, centre, 0.01f)
+    }
+
+    @Test
+    fun `a short generation still scrolls as far as the long one beside it`() {
+        // Both on screen: the eye follows the neighbour down, so the clamp lets it.
+        val panned = clampPan(
+            pan = Offset(0f, -99999f),
+            contentWidth = 4000f, contentHeight = 6000f,
+            viewport = viewport,
+            columns = listOf(short, long),
+            scale = 1f,
+        )
+        assertEquals(3000f, midY - panned.y, 0.01f)
+    }
+
+    @Test
+    fun `the middle never leaves the cards, whichever way it is dragged`() {
+        val columns = listOf(short, long)
+        listOf(
+            Offset(99999f, 99999f), Offset(-99999f, -99999f),
+            Offset(99999f, -99999f), Offset(-99999f, 99999f),
+        ).forEach { wild ->
+            val panned = clampPan(wild, 4000f, 6000f, viewport, columns, 1f)
+            val centre = centreOver(panned)
+            val onScreen = columns.filter {
+                it.right >= -panned.x && it.left <= -panned.x + viewport.width
+            }.ifEmpty { columns }
+            assertTrue(
+                "centre $centre is off the drawing",
+                centre.x >= columns.minOf { it.left } - 0.01f &&
+                    centre.x <= columns.maxOf { it.right } + 0.01f &&
+                    centre.y >= onScreen.minOf { it.top } - 0.01f &&
+                    centre.y <= onScreen.maxOf { it.bottom } + 0.01f,
+            )
+        }
+    }
+
+    @Test
+    fun `zoom is taken into account, so the rule holds at every scale`() {
+        val panned = clampPan(
+            pan = Offset(0f, -99999f),
+            contentWidth = 4000f, contentHeight = 6000f,
+            viewport = viewport,
+            columns = listOf(short, long),
+            scale = 0.5f,
+        )
+        // The cards are half as far apart on screen, so the limit halves with them.
+        assertEquals(1500f, midY - panned.y, 0.01f)
+    }
+
+    @Test
+    fun `with no columns given it falls back to the chart's outline`() {
+        assertEquals(clamp(-99999f, -99999f), clampPan(Offset(-99999f, -99999f), 4000f, 6000f, viewport))
+    }
 }


### PR DESCRIPTION
Reported from a real tree: re-centre the chart, and the next touch throws it off the screen.

## The bug

The pan/zoom gesture is `pointerInput(Unit)` — built once, never rebuilt — and it closed over `layout`:

```kotlin
.pointerInput(Unit) {
    detectTransformGestures { ...
        pan = clampPan(..., contentWidth = layout.width * unitPx * next, ...)
```

So it kept clamping against the size of the family the chart *first* drew. Re-centre on somebody else and the pan is held inside the extent of a chart nobody is looking at any more: the first drag snaps into that stale window — hundreds of points from a touch of twenty — and most of the real chart becomes unreachable, with taps landing near the top of the old extent.

The tap handler immediately below was already keyed correctly, and carries a comment about exactly this. **A `pointerInput` key covers what restarts a gesture, never what the gesture reads.**

**Why it survived several releases:** it needs this precise shape — the chart built while showing a *small* family, then re-centred **in place** on a larger one. Re-centring from a person's page navigates, which rebuilds the screen and hides the fault.

Reproduced on device before touching anything, and confirmed fixed after: the same drag now moves the chart 420px for a 500px swipe instead of throwing it off.

## The clamp now follows the drawing, not the page

Turning the charts sideways made a latent weakness matter. A chart is tall, and its generations are short exactly where their neighbours are long, so the chart's outline is mostly paper nobody has drawn on. Following a generation down ran off the end of it into a blank screen — which is the very thing `ChartViewport`'s rule was written to prevent.

The middle of the screen now stays within the **cards of the generations actually on screen**, not merely inside the outline. Taking the union over what is visible rather than the column under the exact middle means a short generation beside a long one still scrolls — you keep going, and what you are following becomes the neighbour.

## "How are we related?" alignment

`Between` and `and` are different lengths, and the avatar only appeared once somebody was chosen — so the two names sat at different distances from the edge, and jumped sideways at the moment of choosing.

Now: one column for both words, as wide as the longer, **measured from the words themselves** so it survives translation and the reader's text size; and the face's place kept whether or not there is a face in it.

## Verification

- **213 unit tests** — 5 new on the clamp: following a generation down stops at the end of what is drawn there; a short generation still scrolls as far as the long one beside it; the middle never leaves the cards whichever way it is dragged; zoom is accounted for; and the outline fallback still works.
- **156 instrumented tests** — 1 new, `ChartPanningTest`, which reproduces the reported sequence. **Confirmed to fail without the fix and pass with it** (it initially passed vacuously because the actions sheet was left open — it now asserts the sheet is gone before dragging).
- **lint unchanged** at 82 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)