### PR TITLE
Version 0.7.0-beta.5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 20
-        versionName = "0.7.0-beta.4"
+        versionCode = 21
+        versionName = "0.7.0-beta.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 21, `versionName` 0.7.0-beta.5 — a pre-release, so `releases/latest` keeps answering v0.6.0.

Ships [#73](https://github.com/thisisankit27/f-tree/pull/73):

- **The reported bug.** Re-centring the chart and then touching it threw the chart off the screen, after which nothing could be reached. The pan/zoom gesture is built once and was still clamping against the size of the family the chart *first* drew. Reproduced on device before the fix and confirmed after.
- **Scrolling a generation stops at the end of what is drawn**, instead of carrying on into blank paper — a weakness the sideways layout made easy to hit.
- **"How are we related?" lines its two people up**: one column for "Between" and "and", measured from the words themselves, and the face's place kept before there is a face in it.

213 unit, 156 instrumented, lint unchanged. The new instrumented test was confirmed to fail without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)