### PR TITLE
Version 0.7.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 21
-        versionName = "0.7.0-beta.5"
+        versionCode = 22
+        versionName = "0.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`versionCode` 22, `versionName` 0.7.0 — the first **stable** release since v0.6.0, so `releases/latest` moves and existing users are offered it.

Checked before cutting:

- all five 0.7.0 betas and v0.6.0 are ancestors of `main`; nothing on `main` since beta.5; no unmerged branches
- `versionCode` 16 → 22, monotonic
- **signing certificate identical to v0.6.0** (`395d8e62…`), so v0.6.0 updates in place

## What 0.7.0 brings over 0.6.0

**"How are we related?" is one thing again** ([#65](https://github.com/thisisankit27/f-tree/pull/65)). The answer and the chart that draws it were two destinations holding two halves of one result, and "Show on the chart" was a one-way door. Now the question opens over the chart, the line is drawn where it is worked out, and you can pick both people by tapping their cards. A whole destination was deleted rather than a button added.

**The chart's connectors tell the truth** ([#67](https://github.com/thisisankit27/f-tree/pull/67)). A descent bar was drawn between the first and last child and never extended to the parents, so a couple sitting outside the run of their own children left a connector hanging in mid-air — 18 of 45 bars on a real 148-person record. Selecting somebody now lights the lines that run to them and fades the rest, instead of dimming the cards and leaving the lattice at full strength. And a tap selects before it offers to do anything, rather than covering the selection with a sheet.

**Both charts read left to right** ([#69](https://github.com/thisisankit27/f-tree/pull/69), [#71](https://github.com/thisisankit27/f-tree/pull/71)). A generation is a column. The measurements said the layout wasted nothing — it sat at 99% of the least width it could occupy — so the width was never an algorithm to fix; the chart was the wrong way round for a phone. The whole record went from 78 × 5 cards to 9.7 × 33, and the focused chart from 45 × 3.2 to 7.9 × 19.

**Landscape lines up** ([#67](https://github.com/thisisankit27/f-tree/pull/67)). A reading column anchors to the navigation rail, and the top bar, list and button share its edges instead of scattering across the width.

**Panning survives re-centring** ([#73](https://github.com/thisisankit27/f-tree/pull/73)). The pan gesture was clamping against the family the chart first drew, so re-centring and then touching it threw the chart off screen.

213 unit tests, 156 instrumented, lint unchanged at 82 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)