### PR TITLE
Make the README a front door, and open the repo to contributors

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: 🐛 Bug report
+description: Something in the app does not behave the way it says it does.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. Two things matter most: **what you expected to happen**, and
+        **the shape of the family** it happened with.
+
+        ⚠️ **Please do not attach a real family's data or an unredacted `.ftree`.** Describe the
+        shape instead — "two half-siblings whose shared parent is unknown" — or reproduce it with
+        the debug seeder. If a file really is the only way to show it, invent the names.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did the app do?
+      placeholder: The chart drew my grandfather on the same row as my great-grandmother.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: How to reproduce it
+      description: Numbered steps, if you can. Include the shape of the family involved.
+      placeholder: |
+        1. Add a person with no name as a parent of …
+        2. Open the Everyone view
+        3. …
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which part of the app
+      options:
+        - The chart (Chart / Everyone)
+        - The compact view
+        - The relation finder
+        - Hindi kinship terms
+        - Adding or editing a person
+        - Import, export or merge
+        - Sharing a branch or a relationship card
+        - Photos
+        - Updating in place
+        - The website or the browser viewer
+        - Something else / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: f-tree version
+      description: Settings → About, or the name of the APK you installed.
+      placeholder: "0.7.0"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Phone and Android version
+      placeholder: "Pixel 6a, Android 15"
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Screenshots or anything else
+      description: |
+        Screenshots help a lot for layout problems. Blur or crop out real names first.
+        A `logcat` excerpt is welcome for a crash.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched the existing issues.
+          required: true
+        - label: I am on the latest release, or I have said which older one I am on.
+          required: true
+        - label: This report contains no real personal data belonging to anyone but me.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions and ideas
+    url: https://github.com/thisisankit27/f-tree/discussions
+    about: Ask how something works, or float an idea before it becomes an issue.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/thisisankit27/f-tree/security/advisories/new
+    about: Please do not open a public issue for a security problem. Report it privately here.
+  - name: 📖 Documentation
+    url: https://github.com/thisisankit27/f-tree/tree/main/docs
+    about: Architecture, the .ftree format, the data model, and how to build.
+  - name: 🌐 Website and install guide
+    url: https://ftree.vibethroughcode.com/
+    about: Download the app, check a release hash, or try the browser viewer.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: 💡 Feature request
+description: Suggest something f-tree should be able to do.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        f-tree is deliberately small, and some things are
+        [deliberately not built](https://github.com/thisisankit27/f-tree#deliberately-not-built) —
+        GEDCOM, cloud sync, transactional undo. Suggesting one of those is still fine; just say why
+        the stated reasoning does not hold for your case, because that is the interesting part.
+
+        The [design decisions table](https://github.com/thisisankit27/f-tree/blob/main/docs/architecture.md#design-decisions-worth-knowing)
+        records why the obvious alternative was not chosen in a dozen places. Worth a skim.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do?
+      description: Describe the situation, not the solution. What did you reach for the app to do?
+      placeholder: I wanted to record that my grandmother was adopted, but …
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like f-tree to do?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What do you do at the moment instead?
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Does this fit the project?
+      description: f-tree keeps everything on the device and asks for nothing.
+      options:
+        - label: This does not require an account, a server, or sending anything off the device.
+          required: false
+        - label: I have read "Deliberately not built" in the README.
+          required: true

--- a/.github/ISSUE_TEMPLATE/kinship_language.yml
+++ b/.github/ISSUE_TEMPLATE/kinship_language.yml
@@ -1,0 +1,67 @@
+name: 🌏 Kinship terms in another language
+description: Offer to help name relationships the way your family does.
+labels: ["kinship", "help wanted", "good first issue"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **This is the most valuable contribution the project can receive, and it needs a native
+        speaker far more than it needs a developer.**
+
+        English kinship is two numbers — generations up to a shared ancestor, generations back down
+        — which throws away the side of the family and the birth order. Most languages need both.
+        f-tree already carries a `KinshipPath` recording the genders the line ran through and,
+        where the dates prove it, which of two siblings was born first.
+
+        **Bengali, Marathi, Gujarati, Punjabi, Tamil and Telugu are structurally covered by that
+        model already.** Each is a word list plus a small rules file.
+
+        Terms will not ship in a language without a native speaker checking them, so an offer to
+        *review* a list is as useful as an offer to write one.
+
+        See [docs/kinship-hindi.md](https://github.com/thisisankit27/f-tree/blob/main/docs/kinship-hindi.md)
+        for the shape of an existing one.
+
+  - type: input
+    id: language
+    attributes:
+      label: Which language
+      placeholder: Bengali
+    validations:
+      required: true
+
+  - type: dropdown
+    id: help
+    attributes:
+      label: How would you like to help?
+      multiple: true
+      options:
+        - Write the word list
+        - Review a word list somebody else writes
+        - Write the rules file (Kotlin)
+        - Test it against my own family
+    validations:
+      required: true
+
+  - type: textarea
+    id: distinctions
+    attributes:
+      label: What distinctions does your language make that English does not?
+      description: |
+        This is the part that decides whether the existing model covers it. For example, Hindi
+        needs the side of the family and the relative birth order to pick between five words
+        English calls "uncle".
+      placeholder: |
+        - Mother's brother vs father's brother: different words
+        - Elder vs younger sibling: different words
+        - Does the speaker's gender change the term?
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else
+      description: Regional variation, script, transliteration preferences, or where a term is contested.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## What this changes
+
+<!-- In the terms a user would use. "Half-siblings drawn under the wrong connector" beats
+     "fix TreeLayoutEngine offset". -->
+
+## Why
+
+<!-- What was wrong, or what could not be done before. Link the issue if there is one. -->
+
+Closes #
+
+## How it was tested
+
+<!-- Which of these you ran, and what you exercised by hand. -->
+
+- [ ] `./gradlew testDebugUnitTest`
+- [ ] `./gradlew lintDebug`
+- [ ] `./gradlew connectedDebugAndroidTest` (needed if you touched `data/`, `transfer/`, or a screen)
+- [ ] Exercised by hand on a device
+
+<!-- Screenshots for anything visual, before and after. -->
+
+## Checklist
+
+- [ ] It does one thing.
+- [ ] Logic that could be wrong lives in `graph/` or `transfer/` and has a JVM test.
+- [ ] The notation is unchanged, or the change is applied everywhere: brass means *not known*,
+      a doubled rule means marriage, a dashed edge means an unrecorded name — in both charts,
+      the compact view and the web viewer.
+- [ ] No new dependency, or it was agreed in an issue first.
+- [ ] The `.ftree` format and the database schema are unchanged, or a migration is included and the
+      format's compatibility rules still hold.
+- [ ] Style matches the surrounding file.
+
+<!-- Thanks for contributing. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,135 @@
+# Changelog
+
+All notable changes to f-tree. Each entry links to the full release notes and the APK.
+
+Versions follow [Semantic Versioning](https://semver.org/). A tag with a `-beta.N` suffix is
+published as a GitHub pre-release and reaches only people who have opted into the beta channel; the
+betas leading up to a stable release are folded into that release's entry here.
+
+---
+
+## [0.7.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.7.0) — 2026-09-07
+
+**Ask how two people are related from the chart that answers it, and turn the whole thing sideways.**
+
+- The relation finder can be reached from the chart, which then draws just the line between the two
+  people rather than lighting it up inside the whole family.
+- Every descent bar is connected, and the lines themselves take part in a selection.
+- **Both charts turn on their side.** On a short window the destinations move to a navigation rail
+  and the chart's title bar, mode switch and actions fold into one row — about 140dp given back to
+  the drawing, which on a real family is two more generations on screen.
+- Panning is clamped against the chart that is actually on screen, fixing a stale clamp that let a
+  freshly re-laid-out chart be dragged out of view.
+
+## [0.6.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.6.0) — 2026-09-07
+
+**Send one person's family rather than the whole archive.**
+
+- **Share a branch.** Tap somebody and send their household — their partner, their children, and
+  everyone below them — as a small `.ftree`. The people *above* them stay behind.
+- **Send a relationship as a picture.** Chat apps quietly drop the message that comes with a
+  document but show it beside an image, so an answer can travel as a card in the app's own notation
+  rather than as a screenshot.
+- **Open a family tree somebody sent you** directly from the chat app.
+- A beta channel, at the bottom of Settings, behind a warning and a dialog.
+
+## [0.5.2](https://github.com/thisisankit27/f-tree/releases/tag/v0.5.2) — 2026-09-07
+
+- Adds the **beta releases** switch. Nothing else changes — this is 0.5.1 with the switch added, so
+  that anyone who wants to help test the next version can reach it.
+
+## [0.5.1](https://github.com/thisisankit27/f-tree/releases/tag/v0.5.1) — 2026-09-07
+
+**Four things a careful pass turned up, three of them the app quietly not doing what it said.**
+
+- The words under an empty heading — *"Add a parent"* — are now the button, not decoration.
+- The delete dialog reads in the order you decide, with Cancel at the foot rather than sitting
+  between the two real choices.
+- A chart can no longer be dragged off its own page; panning keeps the middle of the screen over
+  the chart, and a control puts a chart back on its family.
+- At a large text size a lifespan rendered as *"1905–197"* — a wrong date, not a clipped label.
+  Cards now grow with the reader's setting.
+
+## [0.5.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.5.0) — 2026-09-06
+
+**Compact — a third way to look at your tree, for anyone who would rather not pinch a canvas.**
+
+- Generations run down the page, oldest at the top, each headed by a ruled label with its count.
+- **A tap moves you.** No back button and no history, because every walk is undone by one tap in
+  the row it came from.
+- Compact and Chart share one centre, so switching never loses your place.
+- The mode switch reads **Compact · Chart · Everyone**.
+- In landscape the cards turn on their side: four generations in view where there were two.
+
+## [0.4.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.4.0) — 2026-09-06
+
+**Relationships named in Hindi.**
+
+- Turn on *Family words → हिन्दी* and the app names relationships the way the family does: your
+  mother's brother is **मामा**, your father's younger brother **चाचा**, his wife **चाची**.
+- A word is claimed only when the record earns it: ताऊ is an elder brother and चाचा a younger one,
+  so with no birth years the app says पिता के भाई and offers to sharpen it.
+- Hindi falls back to English where it genuinely has no word, because that is what Hindi speakers do.
+
+## [0.3.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.3.0) — 2026-09-06
+
+**Faces on the chart, and a landscape that is mostly chart.**
+
+- Every card carries a circular portrait — the square you framed, or the person's initial on a
+  ground coloured by gender.
+- Photographs can be switched off on a very large tree without a single card moving.
+
+## [0.2.2](https://github.com/thisisankit27/f-tree/releases/tag/v0.2.2) — 2026-09-06
+
+**"Related by marriage" is gone.**
+
+- The relation finder names relationships that run through a marriage: an uncle's wife is an
+  **aunt**, a wife's mother a **mother-in-law**, a father's second wife a **stepmother**.
+- Where English has no single word it still says who somebody married — *"married to Ankit's first
+  cousin once removed"* — rather than inventing one.
+- On a real 148-person tree this took the share of named pairs from 31% to 55%.
+
+## [0.2.1](https://github.com/thisisankit27/f-tree/releases/tag/v0.2.1) — 2026-09-05
+
+**The whole-tree chart was drawing real families wrongly.**
+
+- A generation is a relative fact, not a depth. Ranking people by their longest path down from the
+  oldest ancestor made a person's row depend on how far back *their* ancestry happened to be
+  written down. A child now sits exactly one row below each parent, and spouses and siblings share
+  a row.
+- On the reported 148-person tree, all 176 parent edges now span exactly one row, and no set of
+  siblings or couple is split.
+- A traced relation draws only the line, rather than fading a hundred and forty people who are
+  still on the page.
+
+## [0.2.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.2.0) — 2026-09-05
+
+**The first release you will not have to install by hand.**
+
+- **In-app updates, off until you turn them on.** f-tree checks GitHub for a new version and
+  installs it over the top, so your tree stays where it is.
+- Before installing anything it checks the SHA-256 against the digest GitHub published, the package
+  name, and **that it is signed by the same key as the copy you already have**.
+- Opt-in in the code, not just in the settings screen: with the switch off the app will not open a
+  socket. `update/` is the only package that can reach the network at all.
+- The whole tree on one chart.
+
+> Because of the signing check, this is the one upgrade that still has to be done by hand.
+
+## [0.1.1](https://github.com/thisisankit27/f-tree/releases/tag/v0.1.1) — 2026-08-31
+
+- Licensed under [MIT](LICENSE).
+- Signed releases built and published from a tag by CI.
+
+## [0.1.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.1.0) — 2026-08-30
+
+**The first installable build** — a local-first family tree for Android.
+
+- People, with almost nothing required. A blank person is a valid *unknown person*.
+- A graph, not a tree: multiple spouses, children across marriages, half-siblings and unknown
+  ancestors, with no special cases.
+- A focused family chart — ancestors above, descendants below, pan, zoom, tap to re-centre.
+- Export and import as a single `.ftree`, with merge semantics that never overwrite. A backup is
+  saved before every import.
+- Photos, kept inside the app and carried in the export.
+- Dark mode, and layouts that hold up at the largest system text size.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, caste, color, religion,
+or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive,
+and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the
+  experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their
+  explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### A note particular to this project
+
+f-tree is about families, and family structures differ enormously across cultures, religions and
+generations. Discussions here will touch on kinship terms, marriage, adoption, gender and naming
+conventions from many traditions.
+
+Treat a family shape you have not met before as something to learn about, not something to correct.
+"That is not how a family works" is never a useful contribution. Where a kinship term is contested,
+defer to native speakers of the language in question — and remember that a real family is behind
+every awkward case in the issue tracker.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior
+and will take appropriate and fair corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits,
+code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and
+will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is
+officially representing the community in public spaces. Examples of representing our community
+include using an official email address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+community leaders responsible for enforcement by opening a [private security
+advisory](https://github.com/thisisankit27/f-tree/security/advisories/new) — which is the private
+channel available on this repository — or by contacting the maintainer,
+[@thisisankit27](https://github.com/thisisankit27), directly.
+
+All complaints will be reviewed and investigated promptly and fairly. All community leaders are
+obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or
+unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the
+nature of the violation and an explanation of why the behavior was inappropriate. A public apology
+may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people
+involved, including unsolicited interaction with those enforcing the Code of Conduct, for a
+specified period of time. This includes avoiding interactions in community spaces as well as
+external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate
+behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the
+community for a specified period of time. No public or private interaction with the people involved,
+including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this
+period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including
+sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement
+of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,176 @@
+# Contributing to f-tree
+
+Thank you for looking. f-tree is a small app with a deliberately small dependency list, and it is
+possible to hold the whole thing in your head in an afternoon — which is the point.
+
+There are two ways to help that need no Android experience at all, so they come first.
+
+---
+
+## You do not need to write Kotlin to help
+
+### 🌏 Kinship terms in another language
+
+This is the single most valuable contribution the project can receive, and it needs a **native
+speaker** far more than it needs a developer.
+
+English kinship is two numbers: how many generations up to a shared ancestor, and how many back
+down. That throws away the side of the family and the birth order — which is fine for "uncle" and
+useless for most of the world. f-tree already carries a `KinshipPath` alongside those numbers,
+recording the genders the line ran through and, where the dates prove it, which of two siblings was
+born first.
+
+Bengali, Marathi, Gujarati, Punjabi, Tamil and Telugu are **structurally covered by that model
+already**. Each is a word list plus a small rules file, following the shape of
+[`graph/HindiKinship.kt`](app/src/main/java/com/vibethroughcode/ftree/graph/HindiKinship.kt) and
+[`res/values/kinship_hi.xml`](app/src/main/res/values/kinship_hi.xml).
+
+If you speak one of these and are willing to review a word list, **[open an
+issue](https://github.com/thisisankit27/f-tree/issues/new/choose)** and say so. Terms will not ship
+in a language without a native speaker checking them — a wrong kinship word is the kind of mistake
+a family notices immediately.
+
+Read [docs/kinship-hindi.md](docs/kinship-hindi.md) to see the shape of it.
+
+### 🐛 Real families that break things
+
+The chart layout is tested against deliberately awkward invented families. Actual ones are better.
+If your family produces a chart that looks wrong, an import that behaves oddly, or a relationship
+named incorrectly — that is a valuable bug report.
+
+**Please do not attach a real family's data.** Describe the shape instead ("two half-siblings whose
+shared parent is unknown"), or reproduce it with the seeder below.
+
+### ♿ Accessibility testing
+
+TalkBack, large system text sizes, and landscape on a small phone. The *Compact* view exists
+specifically so a family tree can be read aloud; reports about where it fails are welcome.
+
+### 📝 Documentation
+
+Anything on this repo's pages. Corrections, clarifications, or translation.
+
+---
+
+## Getting set up
+
+```bash
+git clone https://github.com/thisisankit27/f-tree.git
+cd f-tree
+./gradlew assembleDebug
+```
+
+You need **JDK 17+** and the Android SDK (platform 37, build-tools 36). Android Studio will offer
+to fetch both. The project always builds without a signing keystore.
+
+Install and run it:
+
+```bash
+./gradlew installDebug
+adb shell am start -n com.vibethroughcode.ftree/.MainActivity
+```
+
+**Do not tap through hundreds of forms to get test data.** Debug builds carry a seeder:
+
+```bash
+# A deliberately awkward family: unknown ancestors, two marriages, half-siblings, missing dates.
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode family
+
+# A large tree, for performance work.
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode large --ei size 2000
+
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode clear
+```
+
+Full detail in [docs/building.md](docs/building.md).
+
+---
+
+## How the code is laid out
+
+```
+data/       Room entities, DAOs, the repository, photo storage
+graph/      pure graph logic: traversal, relationship rules, chart layout
+transfer/   the .ftree format, export, import, duplicate matching
+update/     the optional updater — the only code that touches the network
+ui/         Compose screens, one package per area
+```
+
+Two rules shape it, and a change that respects them will review quickly:
+
+1. **Anything worth reasoning about is pure.** Chart layout, relationship rules and the duplicate
+   matcher take plain data and return plain data — no Room, no Compose. They run off the main
+   thread and are tested directly on the JVM. If you are adding logic that could be wrong, put it
+   in `graph/` or `transfer/` where a JVM test can reach it.
+2. **No DI framework.** [`AppContainer`](app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt)
+   wires one repository by hand. Please do not add one.
+
+[docs/architecture.md](docs/architecture.md) explains the reasoning behind each part in full, and
+the [design decisions table](docs/architecture.md#design-decisions-worth-knowing) records why the
+obvious alternative was not chosen. It is worth a skim before proposing a structural change —
+several of the surprising choices are load-bearing.
+
+---
+
+## Before you open a pull request
+
+```bash
+./gradlew testDebugUnitTest          # pure logic: dates, graph rules, layout, matching
+./gradlew connectedDebugAndroidTest  # database, transfer, Compose UI flows (needs a device)
+./gradlew lintDebug
+```
+
+CI runs the unit tests and lint on every pull request. The instrumented tests need a device, so
+run those locally if you touched `data/`, `transfer/` or a screen.
+
+A good pull request:
+
+- **Does one thing.** A layout fix and a new setting are two pull requests.
+- **Adds a test for logic that could be wrong.** Especially in `graph/` and `transfer/`, where it
+  costs nothing — no emulator, no device.
+- **Says what it is for**, in the terms a user would use. "Half-siblings drawn under the wrong
+  connector" beats "fix TreeLayoutEngine offset".
+- **Keeps the notation consistent.** Brass means *not known*, a doubled rule means marriage, a
+  dashed edge means an unrecorded name. These mean the same thing in every view, including the web
+  viewer, and that consistency is deliberate.
+- **Matches the surrounding style.** Match the comment density and naming of the file you are in
+  rather than a general standard.
+
+Branch names follow `feat/…`, `fix/…`, `chore/…`, `docs/…`. Commit messages are conventional
+(`fix(chart): …`) but this is not enforced by a hook.
+
+### Changes that need a conversation first
+
+Open an issue before starting on:
+
+- a new dependency (the list is deliberately short: Compose, Room, kotlinx-serialization, Coil,
+  Navigation),
+- anything that changes the `.ftree` format or the database schema,
+- a new screen or navigation destination,
+- anything touching `update/` — it is the only networked code and its checks are security-relevant.
+
+This is to save your time, not to gate-keep. A rejected PR you spent a weekend on is a worse
+outcome for everybody than a five-minute issue thread.
+
+---
+
+## Reporting a bug
+
+Use the [issue templates](https://github.com/thisisankit27/f-tree/issues/new/choose). The two
+things that matter most: **what you expected to happen**, and **the shape of the family** it
+happened with.
+
+For anything security-relevant, do not open an issue — see [SECURITY.md](SECURITY.md).
+
+---
+
+## Code of conduct
+
+By taking part you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Licence
+
+Contributions are accepted under the [MIT Licence](LICENSE), the same terms as the project.

--- a/README.md
+++ b/README.md
@@ -1,696 +1,263 @@
+<div align="center">
+
+<img src="site/favicon.svg" width="76" alt="f-tree">
+
 # f-tree
 
-A lightweight, local-first Android app for keeping a personal family tree.
+### Your family tree — including the people nobody can name.
 
-No account, no login, no backend, no cloud. One person keeps their own family graph on their own
-device. Trees are shared by exporting a file — and **importing one merges it into yours rather than
-replacing it**.
+**A free, offline, open-source family tree app for Android.**
+Ask how any two people are related and it names the relationship, in English or Hindi, and draws the line between them.
 
-<!-- Screenshots live in docs/screenshots once a release is tagged. -->
+**No account. No server. No analytics. Nothing leaves your phone.**
 
-## What it does
+<br>
 
-- **People, with almost nothing required.** A person needs no name, no dates, nothing. A blank
-  person is a valid *unknown person* — the grandfather's brother whose name nobody wrote down — and
-  can be named years later without disturbing a single relationship.
-- **A graph, not a tree.** Multiple spouses, children across different marriages, half-siblings,
-  adoptive and step relationships, and unknown ancestors all work without special cases.
-- **Three views of the tree.** *Compact* reads a family as text — generations down the page, a tap
-  to walk to anybody, no pinching and nothing that needs a steady hand. *Chart* draws the same
-  people, with pan, zoom and tap-to-recentre. *Everyone* draws the entire tree at once — every
-  generation, every household, and the people no relationship reaches, whom the other two have
-  nowhere to put. Compact and Chart share one centre, so switching between them never loses your
-  place.
-- **A relation finder.** Pick any two people and f-tree names the relationship — "first cousin once
-  removed", "great-great-grandfather" — and lists every person the line runs through, which is the
-  form that can also answer the ones English has no word for. It walks marriages as well as blood,
-  and will draw the line across the whole-tree chart.
-- **Relationships in Hindi.** Turn on *Family words → हिन्दी* and the app names relationships the way
-  the family does: your mother's brother is **मामा**, your father's younger brother **चाचा**, his
-  wife **चाची**. Not a translation — Hindi has five words where English has "uncle", and picking the
-  right one needs facts English discards. See [docs/kinship-hindi.md](docs/kinship-hindi.md).
-- **Optional in-app updates.** Off until switched on. Checks GitHub for a newer release and installs
-  it over the running copy, so a new version keeps your tree instead of costing an export and an
-  import.
-- **Export and import as a single `.ftree` file**, with merge semantics that never overwrite.
-- **Share one person's family.** Tap somebody and send their household — their partner, their
-  children, and everyone below them — as a small `.ftree` over WhatsApp or anything else. The people
-  *above* them stay behind. The recipient imports it and it merges into their own tree, which is
-  also how you graft a relative's branch onto yours: import it, then marry the two families together
-  with one relationship.
-- **Faces on the chart.** Every card carries a portrait, framed in a circle when the photograph was
-  added and a coloured initial when it was not. Photographs can be switched off for a very large
-  tree without a single card moving.
-- **Photos**, stored inside the app and carried in the export.
+[![Latest release](https://img.shields.io/github/v/release/thisisankit27/f-tree?style=for-the-badge&color=2a5138&labelColor=1a1c1a&label=release)](https://github.com/thisisankit27/f-tree/releases/latest)
+[![APK downloads](https://img.shields.io/github/downloads/thisisankit27/f-tree/total?style=for-the-badge&color=8a6420&labelColor=1a1c1a&label=downloads)](https://github.com/thisisankit27/f-tree/releases)
+[![Stars](https://img.shields.io/github/stars/thisisankit27/f-tree?style=for-the-badge&color=8a6420&labelColor=1a1c1a&label=stars)](https://github.com/thisisankit27/f-tree/stargazers)
+[![License: MIT](https://img.shields.io/badge/license-MIT-2a5138?style=for-the-badge&labelColor=1a1c1a)](LICENSE)
 
-## Build
+[![CI](https://img.shields.io/github/actions/workflow/status/thisisankit27/f-tree/ci.yml?branch=main&style=flat-square&label=CI&color=2a5138&labelColor=1a1c1a)](https://github.com/thisisankit27/f-tree/actions/workflows/ci.yml)
+[![Android 8.0+](https://img.shields.io/badge/Android-8.0%2B-2a5138?style=flat-square&labelColor=1a1c1a&logo=android&logoColor=white)](#install)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3-8a6420?style=flat-square&labelColor=1a1c1a&logo=kotlin&logoColor=white)](https://kotlinlang.org)
+[![Jetpack Compose](https://img.shields.io/badge/Jetpack%20Compose-2a5138?style=flat-square&labelColor=1a1c1a&logo=jetpackcompose&logoColor=white)](https://developer.android.com/compose)
+[![No trackers](https://img.shields.io/badge/trackers-0-2a5138?style=flat-square&labelColor=1a1c1a)](#privacy-the-short-version)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-8a6420?style=flat-square&labelColor=1a1c1a)](CONTRIBUTING.md)
 
-Requires **JDK 17+** and the Android SDK (platform 37, build-tools 36).
+<br>
+
+### [⬇️ Download the APK](https://github.com/thisisankit27/f-tree/releases/latest) · [🌐 Website](https://ftree.vibethroughcode.com/) · [🧪 Try it in your browser](https://ftree.vibethroughcode.com/playground/) · [📖 Docs](docs/)
+
+<br>
+
+<img src="site/shots/tree.webp" width="30%" alt="The family chart, showing an unknown grandmother as a dashed card">
+<img src="site/shots/compact.webp" width="30%" alt="The compact view — generations read down the page">
+<img src="site/shots/hindi.webp" width="30%" alt="A relationship named in Hindi">
+
+<sub><i>Chart · Compact · Hindi kinship terms</i></sub>
+
+</div>
+
+<br>
+
+---
+
+## Why this exists
+
+Every family tree app assumes you know who everybody is. Real families do not work that way. There
+is always a great-grandmother whose name nobody wrote down, an uncle nobody can place, and a cousin
+whose exact relationship starts an argument at every wedding.
+
+f-tree is built around those gaps instead of around a form you have to fill in completely.
+
+|  | |
+|---|---|
+| 🕳️ **A person needs no name.** | A blank person is a valid *unknown person* — the grandfather's brother nobody remembers — and can be named years later without disturbing a single relationship. |
+| 🔗 **A graph, not a tree.** | Multiple spouses, children across marriages, half-siblings, adoption, step-relations and unknown ancestors all work without special cases. |
+| ❓ **"How are we related?"** | Pick any two people. f-tree names it — *first cousin once removed*, *great-great-grandfather* — and lists every person the line runs through. It walks marriages as well as blood, because "my wife's mother" is what people actually ask. |
+| 🇮🇳 **Hindi kinship, done properly.** | Hindi has five words where English has "uncle". Your mother's brother is **मामा**, your father's younger brother **चाचा**, his wife **चाची**. Not a translation — a different model of the family. |
+| 📴 **Genuinely offline.** | No account, no login, no backend, no sync, no analytics. Two permissions exist, both only for the opt-in updater. |
+| 🤝 **Sharing that merges, never overwrites.** | Send one branch as a small file over WhatsApp. The recipient imports it and it *merges* into their tree. The worst an import can do is add a duplicate you can then merge. |
+
+<br>
+
+<div align="center">
+<img src="site/shots/relation-card.webp" width="45%" alt="A shareable card naming a relationship">
+&nbsp;&nbsp;
+<img src="site/shots/merge.webp" width="45%" alt="The merge screen, showing what an import will add">
+</div>
+
+<br>
+
+---
+
+## Install
+
+**[⬇️ Download the latest APK](https://github.com/thisisankit27/f-tree/releases/latest)** — Android 8.0 (Oreo) or newer, about 2 MB.
+
+It is not on the Play Store, so Android will ask you to allow installing from your browser or file
+manager once. The [website](https://ftree.vibethroughcode.com/) walks through it with the exact
+wording your phone shows, and publishes the SHA-256 of every release so you can check what you
+downloaded:
 
 ```bash
+sha256sum f-tree-0.7.0.apk
+```
+
+Once installed, **updates can happen in place** — an opt-in setting checks GitHub for a newer
+release and installs it over the running copy, so upgrading keeps your tree instead of costing an
+export and an import. It is off until you switch it on, and it verifies the download's hash,
+package name and signing certificate before it installs anything. See
+[Updating in place](docs/architecture.md#updating-in-place).
+
+### Try it without installing anything
+
+The **[browser viewer](https://ftree.vibethroughcode.com/playground/)** opens an exported `.ftree`
+and draws the whole family at once — every generation, and the people no relationship reaches.
+There is a sample family loaded on the page. Your file is never uploaded; it is read in the tab.
+
+### Build from source
+
+```bash
+git clone https://github.com/thisisankit27/f-tree.git
+cd f-tree
 ./gradlew assembleDebug
 ```
 
-`assembleRelease` produces an unsigned APK unless a `keystore.properties` exists at the repo root
-(see [Releasing](#releasing)). The project always builds without it.
+JDK 17+ and the Android SDK. Full instructions in [docs/building.md](docs/building.md).
 
-## Run
+<br>
 
-```bash
-./gradlew installDebug
-adb shell am start -n com.vibethroughcode.ftree/.MainActivity
-```
+---
 
-Debug builds carry a seeder for development, so the chart and the merge logic can be exercised
-without tapping through hundreds of forms:
+## What you get
 
-```bash
-# A deliberately awkward family: unknown ancestors, two marriages, half-siblings, missing dates.
-adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
-    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode family
+<table>
+<tr><td width="50%" valign="top">
 
-# A large tree, for performance work.
-adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
-    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode large --ei size 2000
+**Three views of one family**
 
-adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
-    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode clear
-```
+*Compact* reads the family as text — generations down the page, a tap to walk to anybody, no
+pinching and nothing that needs a steady hand. *Chart* draws the same people with pan, zoom and
+tap-to-recentre. *Everyone* draws the entire tree at once. Compact and Chart share one centre, so
+switching never loses your place.
 
-The receiver exists only in debug builds.
+**A relation finder that answers real questions**
 
-## Test
-
-```bash
-./gradlew testDebugUnitTest          # pure logic: dates, graph rules, layout, matching
-./gradlew connectedDebugAndroidTest  # database, transfer, and Compose UI flows (needs a device)
-./gradlew lintDebug
-```
+The word for it *and* the chain of people it runs through — which is the form that can also answer
+the relationships English has no word for. On a real 148-person tree it names 55% of all 21,756
+ordered pairs; the rest read their answer off the chain.
 
-## Architecture
-
-```
-data/       Room entities, DAOs, the repository, photo storage
-graph/      pure graph logic: traversal, relationship rules, chart layout
-transfer/   the .ftree format, export, import, duplicate matching
-update/     the optional updater — the only code that touches the network
-ui/         Compose screens, one package per area
-```
-
-Two rules shape the layout of the code:
-
-1. **Anything worth reasoning about is pure.** The chart layout, the relationship rules and the
-   duplicate matcher take plain data and return plain data — no Room, no Compose. They run off the
-   main thread and are tested directly on the JVM, which is why the trickiest logic in the app is
-   also the cheapest to test.
-2. **No DI framework.** [`AppContainer`](app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt)
-   wires one repository by hand. For an app this size a compiler plugin would add indirection
-   without removing any.
-
-### Data model
-
-A **graph of people and typed edges**, because real families are not trees.
-
-`people` — every descriptive field is optional. A null name *is* the unknown-person mechanism.
-Dates are partial ISO-8601 (`1938`, `1938-04`, `1938-04-17`), so nobody has to invent a day they do
-not know, and no separate "approximate" flag is needed: the precision is the statement. Age is
-derived, never stored. `photoId` is a bare file name, never a path, so a photo survives a reinstall.
-
-`relationships` — `PARENT` (directed, parent → child), `SPOUSE` and `SIBLING` (symmetric). Symmetric
-edges are stored in canonical id order, so a **unique index on `(from, to, type)`** makes duplicate
-prevention a database guarantee rather than a race the app has to win. The type is persisted by
-*name* with an `UNKNOWN` fallback, so a new relationship kind needs no migration and a row written by
-a newer version is degraded rather than dropped.
-
-`person_origins` — where an imported person came from. This is what makes a later import recognise
-them with certainty instead of by comparing names.
-
-**Siblings are derived** from shared parents in SQL rather than stored. They stay correct when a
-parent is added later, and the graph never accumulates O(n²) redundant edges. An explicit `SIBLING`
-edge exists only for siblings whose parents are unknown — the one case derivation cannot express.
-
-### Relationship rules
-
-Rejected at the point of creation, not defended against at every read: self-reference, a duplicate
-edge, an edge that would make someone their own ancestor, and a parent who is also recorded as their
-child's spouse or sibling.
-
-### Deletion
-
-Deleting asks *what happens to the connections*, not whether you are sure:
-
-- **Keep as unknown** — clears the details but keeps the node and every edge, so losing one name does
-  not tear a hole in the family.
-- **Delete completely** — removes the person and, by cascade, their edges.
-
-### The chart
-
-Ego-centric on purpose. Laying out a whole family produces something no phone can show and no person
-can read, so the chart draws one person's ancestors above and descendants below, siblings beside
-them, and everything else is reached by re-focusing. Cousins and siblings' descendants are left out:
-they multiply width far faster than they add meaning, and they are one tap away.
-
-Only the neighbourhood is loaded, a generation at a time, one batched query per ring — so a tree of
-thousands opens as fast as a tree of ten. Everything is painted into a single `Canvas`; pan and zoom
-live in float state read *only inside the draw lambda*, so dragging re-runs the draw phase and
-nothing else, and offscreen nodes cost a bounds check each.
-
-Notation: marriage is a doubled rule, a couple's children hang from one connector while a
-half-sibling hangs from their own, and a person with no name has a dashed brass edge — the gap is in
-what the family remembers, not a fault in the record.
-
-Every card opens with a circular portrait. With a photograph it is the square the reader framed;
-without one it is the person's initial on a ground coloured by gender, so a chart of a hundred
-faceless cards still reads as people rather than as a wall of identical discs. A person whose name
-was never recorded keeps the dashed brass ring they have everywhere else. The disc is part of the
-card at every zoom and whether or not photographs are switched on, which is what lets
-**Settings → Photos on the chart** be turned off on a very large tree without anybody moving.
-
-Photographs on a drawn surface have no `AsyncImage` to hang from, so `ui/tree/ChartPhotos.kt` is the
-equivalent for a canvas: it asks only for the faces the viewport can see, decodes them off the main
-thread at 160px in `RGB_565` — about fifty kilobytes each — and holds them in snapshot state, so a
-face arriving re-runs the draw phase and nothing else. What is held is capped, so panning across a
-thousand people trades faces in and out rather than accumulating them.
-
-### Reading it instead of drawing it
-
-Both charts are pictures. To read a name you pinch, to reach a relative you pan, and a canvas holds
-nothing at all for a screen reader — which is why the chart describes itself and then points at the
-people list. But that list is alphabetical and has no family in it. Between *a picture you must
-zoom* and *a list with no shape* there was nothing, and **Compact** is that missing middle: the same
-people the focused chart draws, composed rather than painted, so they can be read at any text size,
-tapped with a thumb and spoken aloud.
-
-Generations run down the page, oldest at the top, each headed by a ruled label carrying its count,
-with the people laid across it — a row is how a generation is drawn everywhere, and side by side is
-also what makes the view compact, since a column of full-width rows would show fewer people per
-screen than the chart it exists to relieve.
-
-**A tap moves you.** Touching anybody re-centres the whole view on them, and that is the only
-interaction. It needs no back button and keeps no history, because every walk is undone by a single
-tap in the band it came from: if she is now above you, you are now below her. The centre is a block
-of its own rather than a card in a row, and tapping it opens the same sheet the charts open, so
-there is one set of things you can do with a person rather than three.
-
-`CompactFamily` (`graph/CompactFamily.kt`) is built from the layout the chart has **already**
-produced, not from a second walk of the graph. The rules about who appears — ancestors, descendants,
-the focus's siblings, everyone's partners, and deliberately not cousins or nieces — are subtle and
-live in `TreeLayoutEngine`; deriving from its output means the two views cannot drift into showing
-different families, and switching between them costs nothing because nothing is loaded twice. It is
-pure data, so the awkward parts are tested on the JVM: who belongs to a generation by descent as
-against who married into it, and where the doubled rule may be drawn.
-
-That distinction is what the headings count. A step-grandmother is family and is shown, attached to
-the grandparent she married — but she is not a fifth grandparent, and *Grandparents · 4* means four
-grandparents. Someone who married twice is placed *between* their two spouses so the marriages read
-along the row, and the rule is drawn only between people who actually wed: three people in one group
-make two marriages, not three.
-
-Absence is shown rather than hidden. A generation nobody has recorded still gets its heading and an
-invitation to fill it in, exactly as on a person's page — an empty rule reads as "not written down
-yet", which is the subject of this app, while a missing one reads as "not supported". Only parents
-and children get that treatment: they are the two directions the view walks in, and four empty
-headings would bury the family that *is* recorded.
-
-Nothing here is a second notation. Marriage is the chart's doubled rule, an unrecorded name keeps
-its dashed brass ring, and the years are the same span in the same monospace as everywhere else a
-person is listed.
-
-### Photographs
-
-A picked photograph is always framed before it is kept. The window is a fixed circle and the picture
-moves behind it, which makes the awkward case impossible: the picture can never be smaller than the
-circle, so there is no way to frame a crescent of empty space and no error to explain. The sums are
-in `ui/person/CircleCrop.kt`, kept free of any Android type so the part that can be wrong — which
-pixels end up saved — is tested on the JVM rather than checked by eye.
-
-What is stored is the square, not a circle: roundness is drawn by every place that shows a face, so
-a round image would only mean carrying an alpha channel to save a shape we redraw anyway. It is kept
-at 512px, which is sharper than any circle in the app can show even on a 4x screen, and costs about
-twenty kilobytes a person rather than several hundred.
-
-### Naming a relationship in another language
-
-English kinship is two numbers: how many generations up to a shared ancestor, how many back down.
-"Uncle" needs neither the side of the family nor a birth order, so `termFor(up, down)` throws both
-away. Hindi needs them, and so does most of the world outside western Europe.
-
-So the distances stay exactly as they were and a `KinshipPath` rides alongside, carrying the genders
-the line actually ran through and — where the dates prove it — which of two siblings was born first.
-Nothing about English changed, which is why every existing answer and the web viewer still agree.
-
-`graph/HindiKinship.kt` reads that path and returns an *enum*, not a string, so the risky part —
-which of five words English calls "uncle" — is plain Kotlin under JVM test. The spelling lives in
-`res/values/kinship_hi.xml`, a flat list a Hindi speaker can review in one sitting.
-
-Two properties are worth the tests they get. First, **a word is claimed only when the record earns
-it**: ताऊ is an elder brother and चाचा a younger one, so with no birth years the app says
-पिता के भाई and offers to sharpen it. Second, **every relationship must agree with its opposite
-number** — if B is A's मामा then A must be B's भांजा or भांजी, computed independently from the other
-end of the graph. Over every ordered pair of a whole family that is not a property you can satisfy by
-accident, and cousins are the sharpest case: a फुफेरा भाई must see you as his ममेरा भाई.
-
-Hindi falls back to English where it genuinely has no word — second cousins, great-uncles — because
-that is what Hindi speakers do, and because a Devanagari compound nobody says would be worse than
-the English word.
-
-### Relating two people
-
-Two questions with different failure modes, so they are answered separately (`graph/Kinship.kt`,
-pure and JVM-tested):
-
-- **The word for it** comes from the nearest shared ancestor — generations *up* to them and back
-  *down* to the other person — and those two numbers produce every term English actually has.
-  Nearest, then most symmetric: measured through a grandparent instead, two siblings would come out
-  as first cousins. There is no word for most relationships, so this half is often absent.
-  An explicit `SIBLING` edge is recorded precisely when the parents are *not* known, so each such
-  group is given one unnamed stand-in ancestor to measure through — otherwise an aunt reachable only
-  through her brother comes back as merely "related", the gap in the record swallowing a word the
-  family uses every day. The stand-in is never shown; it has no name to show.
-  A marriage at one *end* of the line is named too, because English names those: an uncle's wife is
-  an aunt, a wife's mother a mother-in-law. Where it has no single word the pieces still say who
-  somebody married — "married to Ankit's first cousin once removed" — which beats the flat
-  "related by marriage" that every relative anybody married into the family used to get. A marriage
-  in the *middle* is not nameable and is not named; "my aunt's husband's brother" is what he is, and
-  the chain says it better than an invented word could.
-- **The line between them** is a breadth-first search over *every* edge kind. Marriage is walked as
-  well as blood, because "my wife's mother" is exactly what gets asked and no blood-only search can
-  answer it. Blood steps are enqueued before marriage ones, so where two routes are the same length
-  the one through the family wins — reaching a cousin via their husband is a true answer and a
-  useless one.
-
-The chain is always shown and the sentence only when there is one to give: a line amounting to
-"these two are related somehow" tells a reader nothing the chain does not tell them exactly. On a
-real 148-person tree that names 55% of all 21,756 ordered pairs, up from 31% when only blood
-counted; the rest read their answer off the chain. `Kinship` returns the term as a *structure*, not a
-string; the English lives in `ui/common/KinshipLabels.kt` with the rest of the app's words.
-
-**Shown on the chart, the line is drawn on its own** rather than lit up inside the whole tree.
-Fading the other hundred and forty people still leaves them on the page, and at the scale a whole
-family needs, a faded hundred and forty is what the eye actually sees. So the chart lays out just
-the people on the line — plus whoever holds it together, which is why `peopleToDraw` adds the parent
-two siblings are derived through: a sibling step carries no edge of its own, and without him the
-answer arrives as two loose cards. He is on the chart without being in the sentence. *Clear* puts
-the rest of the family back.
-
-## The `.ftree` format
-
-A ZIP. Version 1:
-
-```
-tree.json
-photos/<photoId>.jpg
-```
-
-```json
-{
-  "format": "f-tree",
-  "version": 1,
-  "exportedAt": "2026-08-31T00:00:00Z",
-  "sourceTreeId": "<uuid, stable for the life of an installation>",
-  "people": [
-    {
-      "id": "…", "name": "Ankit Kumar", "gender": "MALE",
-      "birthDate": "1990-05-01", "deathDate": null, "deceased": false,
-      "photo": "photos/….jpg", "notes": "…",
-      "origins": [{ "treeId": "…", "personId": "…" }]
-    }
-  ],
-  "relationships": [
-    { "id": "…", "from": "<parent>", "to": "<child>", "type": "PARENT", "subtype": null }
-  ]
-}
-```
-
-ZIP rather than one large JSON: base64-encoding a few hundred photographs would inflate them by a
-third and force the whole tree through memory to read one person's name.
-
-**Compatibility.** Every field but `format` and `version` is optional, and unknown keys are ignored
-on read, so a file written by a future release still opens. Those two are always written even though
-they equal their defaults, because they are how a reader knows what it is holding. A file claiming a
-*higher* version is refused rather than partly understood.
-
-`sourceTreeId` identifies the installation that wrote the file. With a person's id it forms a stable
-identity across exports; each person also carries the `origins` they were imported with, so a tree
-that has already been merged once still matches exactly on a later import.
-
-## Sharing one branch
-
-Export writes the whole archive, because it is the user's archive and they are keeping it. Sharing
-is a different act with a different shape: it is a message, it goes to somebody who may not have the
-app, and it should carry a part of the family rather than all of it.
-
-**What travels is a household and the households under it** — the person, everyone descended from
-them, and the partners of all of them. Sandeep's share is Sandeep, his wife, his children and their
-partners, and so on down. What stays behind is everything *above* and *beside* him: his parents, his
-siblings, their children. Sending somebody a branch should not quietly hand over the rest of the
-sharer's family, and a recipient starting their own tree from a relative's file wants the people
-below that relative, not the archive they came from.
-
-Partners come along at every level, because a couple is how a family is read and a child arriving
-without the parent they married is a hole in the story. Their *parents* do not: they are the doorway
-back into another whole family, which is exactly what this is not.
-
-A relationship travels only when **both** ends do. A shared branch therefore never carries an edge
-pointing at somebody who is not in the file — the reader could not resolve it, and it would leak the
-existence of a person deliberately left behind.
-
-The rule is [`FamilyGraph.branchFrom`](app/src/main/java/com/vibethroughcode/ftree/graph/FamilyGraph.kt),
-which is an ordinary function over adjacency lookups and is tested as one.
-
-### The file, and the message with it
-
-The whole-tree export asks where to put the file. A share does not: nobody wants to name a message.
-It is written to the cache as `Sandeep-Kumar-family.ftree`, handed over as a content URI for the
-length of one intent, and the previous one is deleted on the next share rather than leaving copies of
-a family in a temporary directory. It has its own `FileProvider` — a subclass, because two
-`<provider>` entries naming the same class are one component to Android, and the first version of
-this shipped URIs that arrived at the updater's provider and were refused.
-
-The message that goes with it has to work for somebody looking at an attachment in a chat who has
-never heard of this app: whose family it is, how many people, where to get the app, and that
-importing will not overwrite anything they already have. Whether a given chat app *shows* that
-message beside the document is that app's decision — which is why the file is named after whose
-family it is. The name is the part that always arrives.
-
-### Sharing a relationship as a picture
-
-Sending a `.ftree` taught us something: **a chat app handed a document quietly drops the message
-that came with it.** The file arrives, the sentence explaining it does not. Handed an `image/png`,
-the same app shows the text beside the picture — Android's own share sheet does it too, which is how
-this was confirmed rather than assumed.
-
-So a relationship can also be sent as a card. Not a screenshot: a screenshot carries a status bar, a
-navigation bar and whatever font size the sender happens to use, none of which is the answer. The
-card is the app's own sentence and its own notation, laid out for the purpose, in two drawings of
-the same line — **Tree**, cards down a spine with each step named on the rule that makes it, and
-**List**, a register with a rail through the faces. The reader sees it before sending and picks.
-
-The preview *is* the card. The same composable is drawn on screen and recorded into the file through
-a `GraphicsLayer`, so there is no second rendering that could disagree with what was shown. Its
-density is pinned at three pixels to the point rather than read from the device, which is what makes
-the picture 1080 x 1350 from every phone; the preview scales that to fit after layout, so nothing is
-re-measured. The ground is painted opaque, because a PNG with transparent corners is at the mercy of
-whatever it lands on.
-
-A line of any length fits, because both ends are always shown and a middle that will not fit is
-counted rather than cut — "+4 more" is true where a silently shortened chain is not.
-
-### Joining a shared branch to your own tree
-
-This is the other half of why it exists. Import the branch, then create one relationship between
-somebody in it and somebody in yours, and the two families are one graph: your wife's father is your
-father-in-law, her brother your brother-in-law, and the relation finder can walk between them. There
-is no special "merge two trees" mode, because there does not need to be — a tree is a graph and a
-marriage is an edge.
-
-Re-importing the same file is a no-op. Every record carries where it came from, so the second import
-recognises those people outright rather than proposing them as duplicates.
-
-## Merge behaviour
-
-**An import adds; it never replaces.** Nothing already in the tree is deleted, and no existing value
-is overwritten. The worst an import can do is add people who turn out to be duplicates — which can
-then be merged. The opposite mistake, silently collapsing two real people into one, cannot be undone.
-Every default follows from that asymmetry.
-
-Reading and judging a file **writes nothing**; only a plan the user has confirmed is applied, in one
-transaction.
-
-| Evidence | Default |
+**Faces on the chart**
+
+Every card carries a portrait — the square you framed, or a coloured initial when there is no
+photograph. Photographs can be switched off on a very large tree without a single card moving.
+
+</td><td width="50%" valign="top">
+
+**Export and import as one `.ftree` file**
+
+A documented ZIP. Every field optional, unknown keys ignored, so a file written by a future release
+still opens. [Format spec →](docs/ftree-format.md)
+
+**Share one person's family**
+
+Tap somebody and send their household — their partner, their children, everyone below them. The
+people *above* them stay behind. That is also how you graft a relative's branch onto yours: import
+it, then marry the two families together with one relationship.
+
+**Share an answer as a picture**
+
+A relationship can be sent as a card rather than a file, because chat apps quietly drop the message
+that comes with a document but show it beside an image.
+
+**Accessible by design**
+
+The canvas charts cannot be read by a screen reader, so *Compact* exists: the same family, composed
+rather than painted, at any text size, spoken aloud, one tap per person.
+
+</td></tr>
+</table>
+
+<br>
+
+---
+
+## Privacy — the short version
+
+| Question | Answer |
 |---|---|
-| Provable — the file's origins name someone already held | merge, without asking |
-| Same name **and a relative already matched** | proposed **merge** |
-| Same name alone | proposed **keep separate** |
-| Dates that cannot both be true, or an unnamed person | no match at all |
+| Where is my family tree stored? | On your phone, in the app's own storage. Nowhere else. |
+| Is there an account or a login? | No. There is nothing to log in to. |
+| Is there a server? | No. There is no backend to have one with. |
+| Analytics, crash reporting, ads? | None, in the app or on the website. |
+| What permissions does it ask for? | `INTERNET` and `REQUEST_INSTALL_PACKAGES` — both only for the opt-in updater, which refuses to make a request while the setting is off. |
+| Does the browser viewer upload my file? | No. It is read in the tab. |
+| Can I get my data out? | Any time, as a `.ftree` — a ZIP with plain JSON in it. [Documented here.](docs/ftree-format.md) |
 
-Matching runs in passes, so confirmed matches become evidence for their relatives: two people with
-the same name are far likelier to be the same once their father has already matched. Names are
-compared past accents, punctuation and spacing, but never abbreviations — guessing that "R. Kumar"
-is "Raj Kumar" is how a merge quietly destroys data.
+The updater is the only code in the app that opens a socket, and it is deliberately kept in one
+package (`update/`) so that claim is checkable by reading rather than by trust.
 
-Applying:
+<br>
 
-- Imported ids are **always remapped** to fresh local ones; an id in someone else's file may belong
-  to a different person here.
-- Merging **fills gaps only**. An empty field takes the imported value; a field that already says
-  something keeps saying it, and the disagreement is reported.
-- Existing relationships are skipped, not duplicated.
-- A **backup is written first**, to `files/backups/`, and the three most recent are kept.
+---
 
-Re-importing the same file, or the app's own export, is a no-op.
-
-## Design decisions worth knowing
-
-| Decision | Why |
-|---|---|
-| Edges, not a GEDCOM-style family/union table | Maps directly onto "add a parent", and makes merge far simpler |
-| Siblings derived, not stored | Stays correct as parents are added; avoids O(n²) edges |
-| Partial dates, no "approximate" flag | The precision *is* the statement about what is known |
-| Enum names persisted, not ordinals | Readable in the database and in exports; stable across releases (R8 is told not to rename them) |
-| No dynamic colour | Brass means "not known" throughout, including in the chart's notation; a wallpaper-derived palette would reassign that meaning |
-| One `Canvas` for the chart | At a few hundred people, a composable per node costs far more than the drawing |
-| Backup file instead of transactional undo | A file the user can re-import is a far simpler promise, and it cannot itself go wrong |
-| The path kept beside the distances, not instead of them | English answers, their tests, and the web viewer are all untouched by adding a second language |
-| Hindi rules return an enum, not a string | Puts the part that can be wrong under JVM test, and leaves the words in a list somebody can review |
-| Descriptive term rather than a guess at चाचा/ताऊ | Guessing is wrong half the time in a way a family notices at once |
-| A mandatory circular crop, stored square | The face is shown in a circle everywhere; framing it as a rectangle and hoping would mean choosing one thing and seeing another |
-| Photographs off changes drawing, never layout | A setting that rearranged a hundred and fifty people would cost more than the memory it saves |
-| A rail on a short window, not a bottom bar | A bottom bar takes eighty of a landscape phone's three hundred and sixty dp from the axis a tree is read along |
-| Compact derived from the chart's own layout, not a second walk of the graph | Two views of one family cannot disagree about who is in it, and switching costs nothing |
-| A tap in Compact walks rather than opens | Walking is the thing a family tree is *for*; opening a page is a step you take once you have arrived |
-| No history behind the walk | The graph is symmetric, so every walk is already undone by one tap in the band it came from |
-| Compact still shows photographs when the chart's are off | That switch buys back the cost of decoding faces while panning a canvas, which is a cost this view does not have |
-
-## Turned sideways
-
-A phone on its side has about three hundred and sixty density-independent pixels of height, and the
-app was spending a third of them on its own furniture: a title bar, a mode switch, a line of counts
-and a navigation bar, all stacked along the axis a family tree is read down.
-
-On a short window — which is a question about the window, not the orientation, so a tablet on its
-side keeps the bottom bar and a phone in a split screen does not — the three destinations move to a
-`NavigationRail` on the leading edge, and the chart's title bar, mode switch and actions fold into
-one row. That is roughly a hundred and forty dp given back to the drawing, which on a real family is
-the difference between two generations on screen and four.
-
-Reading matter goes the other way. A list of names stretched across a landscape phone puts the name
-at one edge and the date at the other with a hand's width of nothing between them, so the lists,
-forms and the settings are held to a readable measure and centred (`ui/common/Windowing.kt`). The
-charts are exempt: they are pictures, not prose, and they want every pixel.
-
-The compact view answers the same question a third way, because it is neither. Its cards turn on
-their side — a face above a name is the better shape when height is what there is plenty of, and in
-landscape that same card is a third of the screen — and the centre lays its marriages beside the
-name instead of under it. Together that is four generations in view where there would have been two,
-in the view whose whole purpose is fitting a family on a screen.
-
-## Accessibility
-
-The person list, person pages and every form honour the system text size in full and carry content
-descriptions. The chart grows its cards with the text size so nothing is clipped.
-
-Text painted onto a canvas is invisible to a screen reader, and giving every node its own semantics
-would mean composing a node per person on every pan. So the charts describe themselves and point
-elsewhere — and **Compact** is what they now point at: the same family, composed rather than
-painted, where every person is one stop that announces "Vinod Kumar, 1962" and one action that
-re-centres the view on them. Generations are headings, counts are text, and the whole thing grows
-with the system text size instead of being scaled down to fit a fixed card.
-
-A person's page remains the fullest account of any one individual, spelling out every relationship
-in words; Compact is the route *between* people that the charts could not offer.
-
-## Updating in place
-
-`update/` is the only code in the app that opens a socket, and it is deliberately kept in one
-package so that claim is checkable by reading rather than by trust. It is off until switched on in
-Settings: `UpdateRepository` refuses to make a request while the preference is false, so "no network
-unless you ask for it" is a property of the code and not of the interface.
-
-**Why it exists.** Sideloading a new APK over the old one keeps the app's data directory — that is
-ordinary Android behaviour, and it is the whole point. Without an updater, moving to a new version
-means exporting, uninstalling, reinstalling and importing, four steps in which a family can be lost.
-
-**What it checks before installing anything.** Three things, in this order:
-
-1. the download's SHA-256 against the `digest` GitHub publishes for the asset,
-2. that the archive's package name is this app,
-3. that its signing certificate matches the copy already installed.
-
-The third is the one that protects the tree. An APK signed with a different key *cannot* update this
-one — Android refuses it — and the only way to install it would be to uninstall first, taking the
-family with it. Checking here means that is refused by this app with an explanation, rather than
-discovered at the end of a download.
-
-The two permissions the app declares, `INTERNET` and `REQUEST_INSTALL_PACKAGES`, exist only for
-this. The tree itself never goes near the network; there is no sync, no account, and no backend to
-have one with.
-
-## Releasing
-
-Signing is driven by a gitignored `keystore.properties` at the repo root:
-
-```properties
-storeFile=/absolute/path/to/f-tree-release.jks
-storePassword=…
-keyAlias=ftree
-keyPassword=…
-```
-
-```bash
-./gradlew assembleRelease
-```
-
-**Or let CI do it.** Bump `versionName` in `app/build.gradle.kts`, tag it, push the tag:
-
-```bash
-git tag -a v0.2.0 -m "f-tree 0.2.0" && git push origin v0.2.0
-```
-
-[`.github/workflows/release.yml`](.github/workflows/release.yml) checks the tag matches the app's
-version, runs the tests, builds a signed APK from the keystore held in repository secrets
-(`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_PASSWORD`; the key alias is not secret and lives in the workflow), verifies the signature, and
-attaches it to the release. Write the release notes by hand first if you want them; the workflow
-attaches to an existing release rather than replacing it.
-
-Note that the secrets are a *deployment* mechanism, not a backup — a secret can never be read back
-out. Keep the keystore file itself somewhere safe: losing it means no in-place updates, ever.
-
-### Beta releases
-
-A tag with a suffix — `v0.6.0-beta.1`, matching a `versionName` of `0.6.0-beta.1` — is published as
-a GitHub **pre-release**. That single flag is the whole mechanism separating the two channels:
-GitHub's `releases/latest` endpoint skips pre-releases, and the ordinary updater reads that endpoint,
-so somebody who has not asked for betas cannot be handed one by accident.
-
-The beta channel reads the full `releases` list instead, and takes the newest thing on it — which
-means a beta reader is moved on to the stable release as soon as it supersedes the beta they are on,
-without having to change any setting.
-
-**Promoting a beta to stable** is a fresh tag without the suffix: bump `versionName` to `0.6.0`,
-tag `v0.6.0`. Everybody gets it, including the beta readers, because `0.6.0 > 0.6.0-beta.1`.
-
-Opting in lives at the very bottom of Settings, under the licence notice, behind copy that
-discourages it and a dialog that has to be agreed to. It says the thing somebody would otherwise only
-find out afterwards: Android will not install an older version over a newer one, so switching the
-setting back does not move you off a beta — the next stable release does.
-
-Release builds are minified. **Always install and exercise a release build before publishing it** —
-R8 has broken this app once already, by renaming an enum that navigation resolves by name and that
-the database persists by name. `app/proguard-rules.pro` explains what must be kept and why.
-
-## The site
-
-`site/` is the public landing page and install guide, deployed to GitHub Pages by
-`.github/workflows/pages.yml` on any push to `main` that touches it. There is no build step —
-edit the HTML and push.
-
-It reads version, size, release date, SHA-256 and the download count from the GitHub Releases API
-at run time, so cutting a release updates the site with no edit here, and the download count is
-real asset downloads rather than a third-party tracker. There is no analytics script on either
-page. Asset paths are relative, so the site works both at `thisisankit27.github.io/f-tree/` and at
-a custom domain.
-
-### The viewer
-
-`site/playground/` is a browser-only reader for an exported `.ftree`. Where the app draws the
-family *around one person* a few relationships deep — the right answer on a phone — the viewer
-draws the whole archive at once, on a tablet or a television, **including the people no
-relationship reaches**, who the app has nowhere to put at all.
-
-It is plain ES modules, no build, no dependencies:
+## Documentation
 
 | | |
 |---|---|
-| `archive.js` | reads the ZIP and validates the document |
-| `model.js` | derives siblings, family units, components, kinship terms |
-| `layout.js` | generations, crossing reduction, coordinates, packing |
-| `chart.js` | the canvas renderer |
-| `main.js` | the interface |
+| ❓ [**FAQ**](docs/faq.md) | Where the data lives, what leaves the phone, how merging behaves, and what happens when you update |
+| 🏗️ [**Architecture**](docs/architecture.md) | How the graph, the chart layout, the kinship rules and the photo pipeline work — and why |
+| 📦 [**The `.ftree` format**](docs/ftree-format.md) | The file spec, what travels when you share a branch, and the merge rules |
+| 🗂️ [**Data model**](docs/data-model.md) | Tables, fields and migrations |
+| 🇮🇳 [**Hindi kinship**](docs/kinship-hindi.md) | The term list and the rules that pick between them |
+| 🔤 [**Fonts**](docs/fonts.md) | Literata and JetBrains Mono, and why they are bundled |
+| 🔨 [**Building & releasing**](docs/building.md) | Build, run, test, sign, tag, ship |
+| 🌐 [**Site & browser viewer**](docs/site.md) | The landing page and the dependency-free `.ftree` reader |
+| 🤝 [**Contributing**](CONTRIBUTING.md) | Good first issues, project shape, and how a change gets reviewed |
+| 🔒 [**Security policy**](SECURITY.md) | How to report a vulnerability |
+| 📜 [**Changelog**](CHANGELOG.md) | What changed in each release |
 
-Three decisions in there are load-bearing:
+<br>
 
-**The ZIP is read through its central directory, never the local file headers.** The app writes
-the archive with `java.util.zip.ZipOutputStream`, which for DEFLATED entries emits a local header
-with the CRC and both sizes zeroed and puts the real values in a trailing data descriptor. A reader
-that trusts the local header sees a length of zero for every entry.
-`tools/make_sample_tree.py` therefore emits one fixture through an unseekable stream so CI keeps
-testing that path.
+---
 
-**Semantic zoom is what makes a large archive readable.** Drawing every name at every scale gives a
-grey wash the moment a whole family is on screen, so the chart draws less as it pulls back: at a
-distance the cards are plain shapes and what you read is the shape of the family — how many
-generations, how wide each got, and where the record has holes, because an unknown person keeps
-their brass dashed edge at every scale.
+## Contributing
 
-**A generation is a relative fact, not a depth.** A child sits exactly one row below each parent,
-and spouses — and siblings whose parents nobody recorded — sit on the same row; those offsets are
-propagated out from one seed per connected family, which fixes every row exactly, because the offset
-between two people is the same along every route between them.
+Contributions are very welcome, and the project is small enough to hold in your head in an
+afternoon. The parts most worth reasoning about — chart layout, kinship rules, duplicate matching —
+are **pure functions over plain data**, so they are tested on the JVM without a device and are the
+easiest place to start.
 
-The textbook alternative, ranking people by their longest path down from the oldest ancestor on
-record, is wrong in a way that takes a real family to notice: it makes a person's row depend on how
-far back *their* ancestry happens to be written down. A maternal grandfather whose own parents are
-unknown lands on the top row beside a great-great-grandfather from the other side of the family, and
-his children scatter across rows, each dragged down by however deep their own spouse's ancestry ran.
+Especially wanted:
 
-Everything happens in the tab. The file is never uploaded, there is no analytics on the page, and
-the only thing stored is four display preferences in `localStorage`.
+- 🌏 **Kinship terms in another language.** Bengali, Marathi, Gujarati, Punjabi, Tamil and Telugu
+  are structurally covered by the existing path model — each is a word list plus a small rules
+  file. This needs a native speaker more than it needs an Android developer.
+- 🐛 **Real families that break the layout.** The chart is tested against invented awkward cases;
+  actual ones are better.
+- ♿ **Accessibility testing** with TalkBack and large text sizes.
+- 📝 **Documentation and translation** of anything on this page.
 
-```bash
-python3 tools/make_sample_tree.py /tmp/fixtures   # .ftree files, including odd ones
-node tools/check_layout.mjs /tmp/fixtures         # layout invariants, run in CI
-```
+Start with [CONTRIBUTING.md](CONTRIBUTING.md) and the
+[good first issues](https://github.com/thisisankit27/f-tree/labels/good%20first%20issue).
 
-To preview it locally:
+<br>
 
-```bash
-python3 -m http.server 8731 --directory site
-```
+---
 
-### Custom domain
+## Deliberately not built
 
-The domain is claimed by a `site/CNAME` file. Add it only once DNS resolves — claiming it earlier
-redirects the working `github.io` URL to a hostname that does not answer yet. For a subdomain,
-add a `CNAME` record pointing `ftree` at `thisisankit27.github.io`, wait for it to resolve, then:
-
-```bash
-printf 'ftree.vibethroughcode.com' > site/CNAME
-git add site/CNAME && git commit -m "chore(site): claim the custom domain" && git push
-```
-
-## Toolchain
-
-| | |
-|---|---|
-| Gradle | 9.7.1 |
-| Android Gradle Plugin | 9.3.2 |
-| Kotlin | 2.3.21 |
-| compileSdk / targetSdk / minSdk | 37 / 36 / 26 |
-
-AGP 9 ships built-in Kotlin support, so `org.jetbrains.kotlin.android` is declared in the root build
-file with `apply false` — purely to pin the Kotlin version on the build classpath — and is never
-applied by a module.
-
-Dependencies are deliberately few: Compose, Room, kotlinx-serialization, Coil, Navigation. No DI
-framework, no networking, no analytics.
-
-## Not built (and why)
-
-- **Transactional undo of an import.** The backup file covers the same need far more simply.
 - **GEDCOM import/export.** A large format for a lightweight app; the documented `.ftree` schema
   covers sharing between users of this app.
-- **A whole-graph chart.** Unreadable at any real family size; re-focusing is the answer.
-- **A Hindi interface.** Only the family *words* change with the setting; buttons, settings and error
-  messages stay English. Translating those is a separate job needing a fluent reviewer, and a
-  half-translated app reads worse than an English one.
-- **Languages beyond Hindi.** The path model covers Bengali, Marathi, Gujarati, Punjabi, Tamil and
-  Telugu structurally, and each is then a word list plus a small rules file — but kinship terms
-  should not ship in a language without a native speaker checking them.
+- **Transactional undo of an import.** A backup file the user can re-import covers the same need
+  far more simply, and cannot itself go wrong.
+- **A Hindi interface.** Only the family *words* change with the setting. Translating the buttons
+  and error messages is a separate job needing a fluent reviewer, and a half-translated app reads
+  worse than an English one.
+- **Cloud sync.** The absence is the feature.
+
+<br>
+
+---
 
 ## Licence
 
 [MIT](LICENSE) — use it, change it, ship it; just keep the copyright notice.
 
-The bundled fonts (Literata, JetBrains Mono) are separately licensed under the SIL Open Font Licence
-1.1. Their licence texts ship inside the app and are surfaced on its About screen.
+The bundled fonts (Literata, JetBrains Mono) are separately licensed under the SIL Open Font
+Licence 1.1. Their licence texts ship inside the app and are surfaced on its About screen.
+
+<br>
+
+<div align="center">
+
+**If f-tree is useful to you — or if the idea of a family tree with room for the people nobody can
+name is one you want to exist — a ⭐ helps other families find it.**
+
+[⭐ Star this repo](https://github.com/thisisankit27/f-tree) · [⬇️ Download](https://github.com/thisisankit27/f-tree/releases/latest) · [🌐 ftree.vibethroughcode.com](https://ftree.vibethroughcode.com/) · [💬 Discussions](https://github.com/thisisankit27/f-tree/discussions)
+
+<sub>Built by <a href="https://github.com/thisisankit27">Ankit Srivastava</a> · <a href="https://ftree.vibethroughcode.com/">ftree.vibethroughcode.com</a></sub>
+
+</div>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,95 @@
+# Security Policy
+
+## Supported versions
+
+f-tree ships as a single APK from GitHub Releases. Only the **latest stable release** is supported.
+Pre-releases (`-beta.N`) are supported only in the sense that a report against one is welcome —
+fixes land in the next release rather than being backported.
+
+| Version | Supported |
+|---|---|
+| Latest stable release | ✅ |
+| Older releases | ❌ — please update |
+| Beta channel | ⚠️ reports welcome, fixes go forward |
+
+## Reporting a vulnerability
+
+**Please do not open a public issue for a security problem.**
+
+Report it privately through GitHub's [Report a
+vulnerability](https://github.com/thisisankit27/f-tree/security/advisories/new) form, which opens a
+private advisory visible only to the maintainer.
+
+Please include what you were able to do, the version you tested, and — if you have one — a proof of
+concept. You will get an acknowledgement within **7 days** and, where the report is valid, an
+estimate of when a fix will ship. You will be credited in the advisory and the release notes unless
+you would rather not be.
+
+## What is in scope
+
+The parts of f-tree where a vulnerability would have real consequences:
+
+### The updater (`update/`)
+
+This is the only code in the app that opens a socket, and the highest-value area to look at. Before
+installing anything it checks, in this order:
+
+1. the download's SHA-256 against the `digest` GitHub publishes for the asset,
+2. that the archive's package name is this app,
+3. that its signing certificate matches the copy already installed.
+
+Anything that defeats one of those checks, or that causes the app to install an artefact it should
+have refused, is in scope. So is any request made while the update preference is off — the
+repository is supposed to refuse outright.
+
+### Import (`transfer/`)
+
+A `.ftree` is an untrusted ZIP from a stranger in a chat app. In scope: path traversal via entry
+names, zip bombs, anything that writes outside the app's own storage, and any crafted file that
+causes data loss in an existing tree. Import is meant to be additive — nothing already held is
+deleted and no existing value is overwritten — so **any input that causes an import to destroy or
+overwrite existing data is a security bug**, not merely a bug.
+
+### File sharing
+
+The exported and shared files, the `FileProvider` configuration, and the content URIs handed to
+other apps. In scope: any way another app obtains a file it was not granted, or any way a shared
+branch carries a person who was meant to stay behind.
+
+### The website and browser viewer
+
+[ftree.vibethroughcode.com](https://ftree.vibethroughcode.com/) and its
+[playground](https://ftree.vibethroughcode.com/playground/). The viewer parses an untrusted ZIP in
+the browser; XSS through crafted names or notes is in scope. The viewer must never upload the file
+it opens.
+
+## What is out of scope
+
+- **Physical access to an unlocked phone.** The tree is stored in the app's own storage with no
+  separate passphrase. This is a documented limitation, not a defect — see below.
+- Anything requiring a rooted or already-compromised device.
+- The absence of at-rest encryption beyond Android's own full-disk encryption.
+- Reports that an exported `.ftree` is unencrypted. It is a plain ZIP on purpose, so the data
+  outlives the app.
+- Missing hardening headers on the static site, absent a demonstrated impact.
+- Automated scanner output with no working proof of concept.
+
+## Design notes a reporter should know
+
+These are deliberate, and knowing them may save you time:
+
+- **There is no server, account or sync.** There is no backend to attack; the entire threat surface
+  is the app on the device, the release artefacts, and the static site.
+- **The tree never touches the network.** The two permissions the app declares, `INTERNET` and
+  `REQUEST_INSTALL_PACKAGES`, exist only for the opt-in updater.
+- **An APK signed with a different key cannot update an installed f-tree** — Android refuses it.
+  The updater checks the certificate itself so that this is refused early, with an explanation,
+  rather than discovered at the end of a download.
+- **Verify your download.** Every release publishes a SHA-256, shown on the
+  [website](https://ftree.vibethroughcode.com/) and in the GitHub release:
+  `sha256sum f-tree-<version>.apk`.
+
+## Thank you
+
+f-tree holds something people cannot re-create if it is lost. Time spent looking at it carefully is
+genuinely appreciated.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# f-tree documentation
+
+[← back to the README](../README.md) · [website](https://ftree.vibethroughcode.com/) ·
+[browser viewer](https://ftree.vibethroughcode.com/playground/)
+
+## For people using the app
+
+| | |
+|---|---|
+| [**FAQ**](faq.md) | Where the data lives, what leaves the phone, how sharing and merging behave, and what happens when you update |
+| [**The `.ftree` format**](ftree-format.md) | The export file, what travels when you share a branch, and the merge rules — including how to read one yourself |
+| [**Hindi kinship**](kinship-hindi.md) | The terms, and the rules that pick between five words English calls "uncle" |
+
+## For people working on it
+
+| | |
+|---|---|
+| [**Building, testing and releasing**](building.md) | Set up, run, seed test data, sign, tag, ship |
+| [**Architecture**](architecture.md) | The graph model, chart layout, kinship rules, photo pipeline, accessibility, and the design decisions table |
+| [**Data model**](data-model.md) | Tables, fields and migrations |
+| [**Fonts**](fonts.md) | Literata and JetBrains Mono, and why they are bundled |
+| [**Site and browser viewer**](site.md) | The landing page and the dependency-free `.ftree` reader |
+| [**Contributing**](../CONTRIBUTING.md) | Where to start, and how a change gets reviewed |
+| [**Security policy**](../SECURITY.md) | What is in scope, and how to report privately |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,332 @@
+# Architecture
+
+How f-tree is built, and why it is built that way. This is the long-form companion to the
+[README](../README.md) — read it if you want to change the app, or if you are curious how a
+family tree is modelled once you accept that families are not trees.
+
+**Contents**
+
+- [Package layout](#package-layout)
+- [Data model](#data-model)
+- [Relationship rules](#relationship-rules)
+- [Deletion](#deletion)
+- [The chart](#the-chart)
+- [Reading it instead of drawing it](#reading-it-instead-of-drawing-it)
+- [Photographs](#photographs)
+- [Naming a relationship in another language](#naming-a-relationship-in-another-language)
+- [Relating two people](#relating-two-people)
+- [Turned sideways](#turned-sideways)
+- [Accessibility](#accessibility)
+- [Updating in place](#updating-in-place)
+- [Design decisions worth knowing](#design-decisions-worth-knowing)
+
+---
+
+## Package layout
+
+```
+data/       Room entities, DAOs, the repository, photo storage
+graph/      pure graph logic: traversal, relationship rules, chart layout
+transfer/   the .ftree format, export, import, duplicate matching
+update/     the optional updater — the only code that touches the network
+ui/         Compose screens, one package per area
+```
+
+Two rules shape the layout of the code:
+
+1. **Anything worth reasoning about is pure.** The chart layout, the relationship rules and the
+   duplicate matcher take plain data and return plain data — no Room, no Compose. They run off the
+   main thread and are tested directly on the JVM, which is why the trickiest logic in the app is
+   also the cheapest to test.
+2. **No DI framework.** [`AppContainer`](../app/src/main/java/com/vibethroughcode/ftree/AppContainer.kt)
+   wires one repository by hand. For an app this size a compiler plugin would add indirection
+   without removing any.
+
+## Data model
+
+A **graph of people and typed edges**, because real families are not trees.
+
+`people` — every descriptive field is optional. A null name *is* the unknown-person mechanism.
+Dates are partial ISO-8601 (`1938`, `1938-04`, `1938-04-17`), so nobody has to invent a day they do
+not know, and no separate "approximate" flag is needed: the precision is the statement. Age is
+derived, never stored. `photoId` is a bare file name, never a path, so a photo survives a reinstall.
+
+`relationships` — `PARENT` (directed, parent → child), `SPOUSE` and `SIBLING` (symmetric). Symmetric
+edges are stored in canonical id order, so a **unique index on `(from, to, type)`** makes duplicate
+prevention a database guarantee rather than a race the app has to win. The type is persisted by
+*name* with an `UNKNOWN` fallback, so a new relationship kind needs no migration and a row written by
+a newer version is degraded rather than dropped.
+
+`person_origins` — where an imported person came from. This is what makes a later import recognise
+them with certainty instead of by comparing names.
+
+**Siblings are derived** from shared parents in SQL rather than stored. They stay correct when a
+parent is added later, and the graph never accumulates O(n²) redundant edges. An explicit `SIBLING`
+edge exists only for siblings whose parents are unknown — the one case derivation cannot express.
+
+## Relationship rules
+
+Rejected at the point of creation, not defended against at every read: self-reference, a duplicate
+edge, an edge that would make someone their own ancestor, and a parent who is also recorded as their
+child's spouse or sibling.
+
+## Deletion
+
+Deleting asks *what happens to the connections*, not whether you are sure:
+
+- **Keep as unknown** — clears the details but keeps the node and every edge, so losing one name does
+  not tear a hole in the family.
+- **Delete completely** — removes the person and, by cascade, their edges.
+
+## The chart
+
+Ego-centric on purpose. Laying out a whole family produces something no phone can show and no person
+can read, so the chart draws one person's ancestors above and descendants below, siblings beside
+them, and everything else is reached by re-focusing. Cousins and siblings' descendants are left out:
+they multiply width far faster than they add meaning, and they are one tap away.
+
+Only the neighbourhood is loaded, a generation at a time, one batched query per ring — so a tree of
+thousands opens as fast as a tree of ten. Everything is painted into a single `Canvas`; pan and zoom
+live in float state read *only inside the draw lambda*, so dragging re-runs the draw phase and
+nothing else, and offscreen nodes cost a bounds check each.
+
+Notation: marriage is a doubled rule, a couple's children hang from one connector while a
+half-sibling hangs from their own, and a person with no name has a dashed brass edge — the gap is in
+what the family remembers, not a fault in the record.
+
+Every card opens with a circular portrait. With a photograph it is the square the reader framed;
+without one it is the person's initial on a ground coloured by gender, so a chart of a hundred
+faceless cards still reads as people rather than as a wall of identical discs. A person whose name
+was never recorded keeps the dashed brass ring they have everywhere else. The disc is part of the
+card at every zoom and whether or not photographs are switched on, which is what lets
+**Settings → Photos on the chart** be turned off on a very large tree without anybody moving.
+
+Photographs on a drawn surface have no `AsyncImage` to hang from, so `ui/tree/ChartPhotos.kt` is the
+equivalent for a canvas: it asks only for the faces the viewport can see, decodes them off the main
+thread at 160px in `RGB_565` — about fifty kilobytes each — and holds them in snapshot state, so a
+face arriving re-runs the draw phase and nothing else. What is held is capped, so panning across a
+thousand people trades faces in and out rather than accumulating them.
+
+## Reading it instead of drawing it
+
+Both charts are pictures. To read a name you pinch, to reach a relative you pan, and a canvas holds
+nothing at all for a screen reader — which is why the chart describes itself and then points at the
+people list. But that list is alphabetical and has no family in it. Between *a picture you must
+zoom* and *a list with no shape* there was nothing, and **Compact** is that missing middle: the same
+people the focused chart draws, composed rather than painted, so they can be read at any text size,
+tapped with a thumb and spoken aloud.
+
+Generations run down the page, oldest at the top, each headed by a ruled label carrying its count,
+with the people laid across it — a row is how a generation is drawn everywhere, and side by side is
+also what makes the view compact, since a column of full-width rows would show fewer people per
+screen than the chart it exists to relieve.
+
+**A tap moves you.** Touching anybody re-centres the whole view on them, and that is the only
+interaction. It needs no back button and keeps no history, because every walk is undone by a single
+tap in the band it came from: if she is now above you, you are now below her. The centre is a block
+of its own rather than a card in a row, and tapping it opens the same sheet the charts open, so
+there is one set of things you can do with a person rather than three.
+
+`CompactFamily` (`graph/CompactFamily.kt`) is built from the layout the chart has **already**
+produced, not from a second walk of the graph. The rules about who appears — ancestors, descendants,
+the focus's siblings, everyone's partners, and deliberately not cousins or nieces — are subtle and
+live in `TreeLayoutEngine`; deriving from its output means the two views cannot drift into showing
+different families, and switching between them costs nothing because nothing is loaded twice. It is
+pure data, so the awkward parts are tested on the JVM: who belongs to a generation by descent as
+against who married into it, and where the doubled rule may be drawn.
+
+That distinction is what the headings count. A step-grandmother is family and is shown, attached to
+the grandparent she married — but she is not a fifth grandparent, and *Grandparents · 4* means four
+grandparents. Someone who married twice is placed *between* their two spouses so the marriages read
+along the row, and the rule is drawn only between people who actually wed: three people in one group
+make two marriages, not three.
+
+Absence is shown rather than hidden. A generation nobody has recorded still gets its heading and an
+invitation to fill it in, exactly as on a person's page — an empty rule reads as "not written down
+yet", which is the subject of this app, while a missing one reads as "not supported". Only parents
+and children get that treatment: they are the two directions the view walks in, and four empty
+headings would bury the family that *is* recorded.
+
+Nothing here is a second notation. Marriage is the chart's doubled rule, an unrecorded name keeps
+its dashed brass ring, and the years are the same span in the same monospace as everywhere else a
+person is listed.
+
+## Photographs
+
+A picked photograph is always framed before it is kept. The window is a fixed circle and the picture
+moves behind it, which makes the awkward case impossible: the picture can never be smaller than the
+circle, so there is no way to frame a crescent of empty space and no error to explain. The sums are
+in `ui/person/CircleCrop.kt`, kept free of any Android type so the part that can be wrong — which
+pixels end up saved — is tested on the JVM rather than checked by eye.
+
+What is stored is the square, not a circle: roundness is drawn by every place that shows a face, so
+a round image would only mean carrying an alpha channel to save a shape we redraw anyway. It is kept
+at 512px, which is sharper than any circle in the app can show even on a 4x screen, and costs about
+twenty kilobytes a person rather than several hundred.
+
+## Naming a relationship in another language
+
+English kinship is two numbers: how many generations up to a shared ancestor, how many back down.
+"Uncle" needs neither the side of the family nor a birth order, so `termFor(up, down)` throws both
+away. Hindi needs them, and so does most of the world outside western Europe.
+
+So the distances stay exactly as they were and a `KinshipPath` rides alongside, carrying the genders
+the line actually ran through and — where the dates prove it — which of two siblings was born first.
+Nothing about English changed, which is why every existing answer and the web viewer still agree.
+
+`graph/HindiKinship.kt` reads that path and returns an *enum*, not a string, so the risky part —
+which of five words English calls "uncle" — is plain Kotlin under JVM test. The spelling lives in
+`res/values/kinship_hi.xml`, a flat list a Hindi speaker can review in one sitting.
+
+Two properties are worth the tests they get. First, **a word is claimed only when the record earns
+it**: ताऊ is an elder brother and चाचा a younger one, so with no birth years the app says
+पिता के भाई and offers to sharpen it. Second, **every relationship must agree with its opposite
+number** — if B is A's मामा then A must be B's भांजा or भांजी, computed independently from the other
+end of the graph. Over every ordered pair of a whole family that is not a property you can satisfy by
+accident, and cousins are the sharpest case: a फुफेरा भाई must see you as his ममेरा भाई.
+
+Hindi falls back to English where it genuinely has no word — second cousins, great-uncles — because
+that is what Hindi speakers do, and because a Devanagari compound nobody says would be worse than
+the English word.
+
+## Relating two people
+
+Two questions with different failure modes, so they are answered separately (`graph/Kinship.kt`,
+pure and JVM-tested):
+
+- **The word for it** comes from the nearest shared ancestor — generations *up* to them and back
+  *down* to the other person — and those two numbers produce every term English actually has.
+  Nearest, then most symmetric: measured through a grandparent instead, two siblings would come out
+  as first cousins. There is no word for most relationships, so this half is often absent.
+  An explicit `SIBLING` edge is recorded precisely when the parents are *not* known, so each such
+  group is given one unnamed stand-in ancestor to measure through — otherwise an aunt reachable only
+  through her brother comes back as merely "related", the gap in the record swallowing a word the
+  family uses every day. The stand-in is never shown; it has no name to show.
+  A marriage at one *end* of the line is named too, because English names those: an uncle's wife is
+  an aunt, a wife's mother a mother-in-law. Where it has no single word the pieces still say who
+  somebody married — "married to Ankit's first cousin once removed" — which beats the flat
+  "related by marriage" that every relative anybody married into the family used to get. A marriage
+  in the *middle* is not nameable and is not named; "my aunt's husband's brother" is what he is, and
+  the chain says it better than an invented word could.
+- **The line between them** is a breadth-first search over *every* edge kind. Marriage is walked as
+  well as blood, because "my wife's mother" is exactly what gets asked and no blood-only search can
+  answer it. Blood steps are enqueued before marriage ones, so where two routes are the same length
+  the one through the family wins — reaching a cousin via their husband is a true answer and a
+  useless one.
+
+The chain is always shown and the sentence only when there is one to give: a line amounting to
+"these two are related somehow" tells a reader nothing the chain does not tell them exactly. On a
+real 148-person tree that names 55% of all 21,756 ordered pairs, up from 31% when only blood
+counted; the rest read their answer off the chain. `Kinship` returns the term as a *structure*, not a
+string; the English lives in `ui/common/KinshipLabels.kt` with the rest of the app's words.
+
+**Shown on the chart, the line is drawn on its own** rather than lit up inside the whole tree.
+Fading the other hundred and forty people still leaves them on the page, and at the scale a whole
+family needs, a faded hundred and forty is what the eye actually sees. So the chart lays out just
+the people on the line — plus whoever holds it together, which is why `peopleToDraw` adds the parent
+two siblings are derived through: a sibling step carries no edge of its own, and without him the
+answer arrives as two loose cards. He is on the chart without being in the sentence. *Clear* puts
+the rest of the family back.
+
+
+---
+
+## Turned sideways
+
+A phone on its side has about three hundred and sixty density-independent pixels of height, and the
+app was spending a third of them on its own furniture: a title bar, a mode switch, a line of counts
+and a navigation bar, all stacked along the axis a family tree is read down.
+
+On a short window — which is a question about the window, not the orientation, so a tablet on its
+side keeps the bottom bar and a phone in a split screen does not — the three destinations move to a
+`NavigationRail` on the leading edge, and the chart's title bar, mode switch and actions fold into
+one row. That is roughly a hundred and forty dp given back to the drawing, which on a real family is
+the difference between two generations on screen and four.
+
+Reading matter goes the other way. A list of names stretched across a landscape phone puts the name
+at one edge and the date at the other with a hand's width of nothing between them, so the lists,
+forms and the settings are held to a readable measure and centred (`ui/common/Windowing.kt`). The
+charts are exempt: they are pictures, not prose, and they want every pixel.
+
+The compact view answers the same question a third way, because it is neither. Its cards turn on
+their side — a face above a name is the better shape when height is what there is plenty of, and in
+landscape that same card is a third of the screen — and the centre lays its marriages beside the
+name instead of under it. Together that is four generations in view where there would have been two,
+in the view whose whole purpose is fitting a family on a screen.
+
+## Accessibility
+
+The person list, person pages and every form honour the system text size in full and carry content
+descriptions. The chart grows its cards with the text size so nothing is clipped.
+
+Text painted onto a canvas is invisible to a screen reader, and giving every node its own semantics
+would mean composing a node per person on every pan. So the charts describe themselves and point
+elsewhere — and **Compact** is what they now point at: the same family, composed rather than
+painted, where every person is one stop that announces "Vinod Kumar, 1962" and one action that
+re-centres the view on them. Generations are headings, counts are text, and the whole thing grows
+with the system text size instead of being scaled down to fit a fixed card.
+
+A person's page remains the fullest account of any one individual, spelling out every relationship
+in words; Compact is the route *between* people that the charts could not offer.
+
+## Updating in place
+
+`update/` is the only code in the app that opens a socket, and it is deliberately kept in one
+package so that claim is checkable by reading rather than by trust. It is off until switched on in
+Settings: `UpdateRepository` refuses to make a request while the preference is false, so "no network
+unless you ask for it" is a property of the code and not of the interface.
+
+**Why it exists.** Sideloading a new APK over the old one keeps the app's data directory — that is
+ordinary Android behaviour, and it is the whole point. Without an updater, moving to a new version
+means exporting, uninstalling, reinstalling and importing, four steps in which a family can be lost.
+
+**What it checks before installing anything.** Three things, in this order:
+
+1. the download's SHA-256 against the `digest` GitHub publishes for the asset,
+2. that the archive's package name is this app,
+3. that its signing certificate matches the copy already installed.
+
+The third is the one that protects the tree. An APK signed with a different key *cannot* update this
+one — Android refuses it — and the only way to install it would be to uninstall first, taking the
+family with it. Checking here means that is refused by this app with an explanation, rather than
+discovered at the end of a download.
+
+The two permissions the app declares, `INTERNET` and `REQUEST_INSTALL_PACKAGES`, exist only for
+this. The tree itself never goes near the network; there is no sync, no account, and no backend to
+have one with.
+
+
+---
+
+## Design decisions worth knowing
+
+| Decision | Why |
+|---|---|
+| Edges, not a GEDCOM-style family/union table | Maps directly onto "add a parent", and makes merge far simpler |
+| Siblings derived, not stored | Stays correct as parents are added; avoids O(n²) edges |
+| Partial dates, no "approximate" flag | The precision *is* the statement about what is known |
+| Enum names persisted, not ordinals | Readable in the database and in exports; stable across releases (R8 is told not to rename them) |
+| No dynamic colour | Brass means "not known" throughout, including in the chart's notation; a wallpaper-derived palette would reassign that meaning |
+| One `Canvas` for the chart | At a few hundred people, a composable per node costs far more than the drawing |
+| Backup file instead of transactional undo | A file the user can re-import is a far simpler promise, and it cannot itself go wrong |
+| The path kept beside the distances, not instead of them | English answers, their tests, and the web viewer are all untouched by adding a second language |
+| Hindi rules return an enum, not a string | Puts the part that can be wrong under JVM test, and leaves the words in a list somebody can review |
+| Descriptive term rather than a guess at चाचा/ताऊ | Guessing is wrong half the time in a way a family notices at once |
+| A mandatory circular crop, stored square | The face is shown in a circle everywhere; framing it as a rectangle and hoping would mean choosing one thing and seeing another |
+| Photographs off changes drawing, never layout | A setting that rearranged a hundred and fifty people would cost more than the memory it saves |
+| A rail on a short window, not a bottom bar | A bottom bar takes eighty of a landscape phone's three hundred and sixty dp from the axis a tree is read along |
+| Compact derived from the chart's own layout, not a second walk of the graph | Two views of one family cannot disagree about who is in it, and switching costs nothing |
+| A tap in Compact walks rather than opens | Walking is the thing a family tree is *for*; opening a page is a step you take once you have arrived |
+| No history behind the walk | The graph is symmetric, so every walk is already undone by one tap in the band it came from |
+| Compact still shows photographs when the chart's are off | That switch buys back the cost of decoding faces while panning a canvas, which is a cost this view does not have |
+
+
+---
+
+## Where to go next
+
+- [The `.ftree` format and merge behaviour](ftree-format.md)
+- [The data model, field by field](data-model.md)
+- [Hindi kinship terms](kinship-hindi.md)
+- [Building, testing and releasing](building.md)
+- [The website and the browser viewer](site.md)

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,140 @@
+# Building, testing and releasing
+
+Everything you need to get f-tree running from source, and how a release is cut.
+
+New contributors: read [CONTRIBUTING.md](../CONTRIBUTING.md) first — it has the short version and
+a list of good first issues.
+
+**Contents**
+
+- [Build](#build)
+- [Run](#run)
+- [Test](#test)
+- [Toolchain](#toolchain)
+- [Releasing](#releasing)
+- [Beta releases](#beta-releases)
+
+---
+
+## Build
+
+Requires **JDK 17+** and the Android SDK (platform 37, build-tools 36).
+
+```bash
+./gradlew assembleDebug
+```
+
+`assembleRelease` produces an unsigned APK unless a `keystore.properties` exists at the repo root
+(see [Releasing](#releasing)). The project always builds without it.
+
+## Run
+
+```bash
+./gradlew installDebug
+adb shell am start -n com.vibethroughcode.ftree/.MainActivity
+```
+
+Debug builds carry a seeder for development, so the chart and the merge logic can be exercised
+without tapping through hundreds of forms:
+
+```bash
+# A deliberately awkward family: unknown ancestors, two marriages, half-siblings, missing dates.
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode family
+
+# A large tree, for performance work.
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode large --ei size 2000
+
+adb shell am broadcast -a com.vibethroughcode.ftree.SEED \
+    -n com.vibethroughcode.ftree/.debug.SeedReceiver --es mode clear
+```
+
+The receiver exists only in debug builds.
+
+## Test
+
+```bash
+./gradlew testDebugUnitTest          # pure logic: dates, graph rules, layout, matching
+./gradlew connectedDebugAndroidTest  # database, transfer, and Compose UI flows (needs a device)
+./gradlew lintDebug
+```
+
+## Toolchain
+
+| | |
+|---|---|
+| Gradle | 9.7.1 |
+| Android Gradle Plugin | 9.3.2 |
+| Kotlin | 2.3.21 |
+| compileSdk / targetSdk / minSdk | 37 / 36 / 26 |
+
+AGP 9 ships built-in Kotlin support, so `org.jetbrains.kotlin.android` is declared in the root build
+file with `apply false` — purely to pin the Kotlin version on the build classpath — and is never
+applied by a module.
+
+Dependencies are deliberately few: Compose, Room, kotlinx-serialization, Coil, Navigation. No DI
+framework, no networking, no analytics.
+
+
+## Releasing
+
+Signing is driven by a gitignored `keystore.properties` at the repo root:
+
+```properties
+storeFile=/absolute/path/to/f-tree-release.jks
+storePassword=…
+keyAlias=ftree
+keyPassword=…
+```
+
+```bash
+./gradlew assembleRelease
+```
+
+**Or let CI do it.** Bump `versionName` in `app/build.gradle.kts`, tag it, push the tag:
+
+```bash
+git tag -a v0.2.0 -m "f-tree 0.2.0" && git push origin v0.2.0
+```
+
+[`.github/workflows/release.yml`](../.github/workflows/release.yml) checks the tag matches the app's
+version, runs the tests, builds a signed APK from the keystore held in repository secrets
+(`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_PASSWORD`; the key alias is not secret and lives in the workflow), verifies the signature, and
+attaches it to the release. Write the release notes by hand first if you want them; the workflow
+attaches to an existing release rather than replacing it.
+
+Note that the secrets are a *deployment* mechanism, not a backup — a secret can never be read back
+out. Keep the keystore file itself somewhere safe: losing it means no in-place updates, ever.
+
+### Beta releases
+
+A tag with a suffix — `v0.6.0-beta.1`, matching a `versionName` of `0.6.0-beta.1` — is published as
+a GitHub **pre-release**. That single flag is the whole mechanism separating the two channels:
+GitHub's `releases/latest` endpoint skips pre-releases, and the ordinary updater reads that endpoint,
+so somebody who has not asked for betas cannot be handed one by accident.
+
+The beta channel reads the full `releases` list instead, and takes the newest thing on it — which
+means a beta reader is moved on to the stable release as soon as it supersedes the beta they are on,
+without having to change any setting.
+
+**Promoting a beta to stable** is a fresh tag without the suffix: bump `versionName` to `0.6.0`,
+tag `v0.6.0`. Everybody gets it, including the beta readers, because `0.6.0 > 0.6.0-beta.1`.
+
+Opting in lives at the very bottom of Settings, under the licence notice, behind copy that
+discourages it and a dialog that has to be agreed to. It says the thing somebody would otherwise only
+find out afterwards: Android will not install an older version over a newer one, so switching the
+setting back does not move you off a beta — the next stable release does.
+
+Release builds are minified. **Always install and exercise a release build before publishing it** —
+R8 has broken this app once already, by renaming an enum that navigation resolves by name and that
+the database persists by name. `app/proguard-rules.pro` explains what must be kept and why.
+
+
+---
+
+## Where to go next
+
+- [Architecture](architecture.md)
+- [The website and the browser viewer](site.md)
+- [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,259 @@
+# Frequently asked questions
+
+[← back to the README](../README.md) · [all documentation](README.md)
+
+---
+
+## Getting it
+
+### Is f-tree free?
+
+Yes, and open source under the [MIT licence](../LICENSE). There is no paid tier, no subscription,
+no advertisement and no upsell. There is nothing to buy because there is no server to pay for.
+
+### Is it on the Google Play Store?
+
+No. It is distributed as an APK from [GitHub
+Releases](https://github.com/thisisankit27/f-tree/releases/latest) and from
+[ftree.vibethroughcode.com](https://ftree.vibethroughcode.com/).
+
+Android will ask you to allow installing from your browser or file manager once. The website walks
+through it with the exact wording your phone shows.
+
+### How do I know the APK I downloaded is the real one?
+
+Every release publishes a SHA-256, shown on the website and in the GitHub release. Check it before
+installing:
+
+```bash
+sha256sum f-tree-0.7.0.apk
+```
+
+The APK is built and signed by [GitHub Actions from a
+tag](../.github/workflows/release.yml), not uploaded from a laptop.
+
+### What Android version do I need?
+
+Android 8.0 (Oreo, API 26) or newer. The app is about 2 MB.
+
+### Is there an iPhone, web or desktop version?
+
+No app, but there is a **[browser viewer](https://ftree.vibethroughcode.com/playground/)** that
+opens an exported `.ftree` on any device with a browser and draws the whole family at once. It is
+read-only. The file is never uploaded — it is read in the tab.
+
+---
+
+## Privacy and data
+
+### Where is my family tree stored?
+
+In the app's own storage on your phone, and nowhere else. There is no account, no login, no
+backend, and no sync.
+
+### Does anything leave my phone?
+
+Only what you send yourself: an export, a shared branch, or a relationship card. Nothing is
+transmitted automatically.
+
+The app declares two permissions, `INTERNET` and `REQUEST_INSTALL_PACKAGES`, and both exist only
+for the **opt-in updater**. `UpdateRepository` refuses to make a request while the preference is
+false, so "no network unless you ask for it" is a property of the code rather than of the interface.
+`update/` is deliberately the only package in the app that opens a socket, so that claim is
+checkable by reading it.
+
+### Is there analytics or crash reporting?
+
+None, in the app or on either web page. The download count shown on the website is read from the
+GitHub Releases API at run time — real asset downloads, not a third-party tracker.
+
+### Can I get my data out?
+
+At any time, as a single `.ftree` file. It is an ordinary ZIP with a `tree.json` and the
+photographs in it, and the [format is documented](ftree-format.md) so that anything can read it.
+`unzip -p family.ftree tree.json` works.
+
+### Is my tree encrypted?
+
+Beyond Android's own full-disk encryption, no, and the export is a plain ZIP on purpose — so the
+data outlives the app. Somebody with your unlocked phone can open f-tree. This is a documented
+limitation rather than an oversight; see the [security policy](../SECURITY.md).
+
+### What happens to my tree if this project is abandoned?
+
+You keep it. It is on your device in a documented open format, the app is MIT-licensed, and there
+is no server whose shutdown could take anything with it.
+
+---
+
+## Using it
+
+### How do I record someone whose name nobody remembers?
+
+Add them and leave the name blank. **A person with no name is a valid person in f-tree** — not a
+placeholder, not an error — and they appear on the chart with a dashed brass edge, meaning the gap
+is in what the family remembers rather than a fault in the record.
+
+They can be named years later without disturbing a single relationship. This is the thing the app
+is built around.
+
+### Can it handle remarriage, half-siblings, adoption, step-parents?
+
+Yes, and without special cases, because the underlying model is a **graph of people and typed
+edges** rather than a tree of households. Multiple spouses, children across different marriages,
+half-siblings, adoptive and step relationships and unknown ancestors are all ordinary states.
+
+### Do I have to know exact dates?
+
+No. Dates are partial ISO-8601 — `1938`, `1938-04`, or `1938-04-17` — so nobody has to invent a day
+they do not know. There is no separate "approximate" flag because the precision *is* the statement
+about what is known.
+
+### How does the relation finder work?
+
+Pick any two people. f-tree gives you two things:
+
+- **The word for it**, from the nearest shared ancestor — *first cousin once removed*,
+  *great-great-grandfather*, *mother-in-law*.
+- **The line between them**: every person the relationship runs through. This is the form that can
+  also answer the relationships English has no word for.
+
+It walks marriages as well as blood, because "my wife's mother" is what people actually ask. On a
+real 148-person tree it names 55% of all 21,756 ordered pairs; the rest read the answer off the
+chain.
+
+### Why does it sometimes not give me a single word?
+
+Because English often has none. "My aunt's husband's brother" is what he is, and the chain says it
+better than an invented word could. Rather than a flat "related by marriage", f-tree shows the
+chain and says who married whom.
+
+### What is the difference between Compact, Chart and Everyone?
+
+- **Compact** reads the family as text — generations down the page, a tap to walk to anybody. No
+  pinching, works at any text size, and can be read aloud by a screen reader.
+- **Chart** draws the same people as a picture, with pan, zoom and tap-to-recentre.
+- **Everyone** draws the entire tree at once, including the people no relationship reaches.
+
+Compact and Chart share one centre, so switching between them never loses your place.
+
+### Why does the chart not show my cousins?
+
+The focused chart is ego-centric on purpose: ancestors above, descendants below, siblings beside.
+Cousins and siblings' descendants multiply the width far faster than they add meaning, and they are
+one tap away — tap the relative they hang from and the chart re-centres. Use **Everyone** to see
+the whole graph at once.
+
+### Can I use it in Hindi?
+
+The **family words**, yes. Turn on *Family words → हिन्दी* and relationships are named the way the
+family does: your mother's brother is **मामा**, your father's younger brother **चाचा**, his wife
+**चाची**.
+
+The interface itself — buttons, settings, error messages — stays English. Translating those is a
+separate job needing a fluent reviewer, and a half-translated app reads worse than an English one.
+
+### Why does it say पिता के भाई instead of चाचा or ताऊ?
+
+Because it does not know which. ताऊ is a father's *elder* brother and चाचा a *younger* one, so
+without birth years the app gives the descriptive term and offers to sharpen it. Guessing would be
+wrong half the time, in a way a family notices at once.
+
+### Can you add my language?
+
+Very likely, and this is the contribution the project most wants. Bengali, Marathi, Gujarati,
+Punjabi, Tamil and Telugu are already covered structurally — each is a word list plus a small rules
+file. It needs a **native speaker** more than a developer.
+
+[Open an issue and say which language.](https://github.com/thisisankit27/f-tree/issues/new/choose)
+
+---
+
+## Sharing and merging
+
+### How do two people combine their family trees?
+
+One exports, the other imports. **An import adds; it never replaces.** Nothing already in the tree
+is deleted and no existing value is overwritten — the worst an import can do is add people who turn
+out to be duplicates, which can then be merged. The opposite mistake, silently collapsing two real
+people into one, cannot be undone, and every default follows from that asymmetry.
+
+To join two families: import the other person's file, then create **one relationship** between
+somebody in it and somebody in yours. There is no special "merge two trees" mode because there does
+not need to be — a tree is a graph and a marriage is an edge.
+
+### Can I send just part of my tree?
+
+Yes. Tap somebody and share their household — the person, everyone descended from them, and the
+partners of all of them. Everything *above* and *beside* them stays behind, so sending somebody a
+branch does not quietly hand over the rest of your family.
+
+### What if I import the same file twice?
+
+Nothing happens. Every record carries where it came from, so the second import recognises those
+people outright rather than proposing them as duplicates.
+
+### Will importing overwrite what I have already written?
+
+No. Merging **fills gaps only** — an empty field takes the imported value, a field that already
+says something keeps saying it, and the disagreement is reported to you. A backup is also written
+before every import, to `files/backups/`, and the three most recent are kept.
+
+### Does it import GEDCOM?
+
+No, and [deliberately so](../README.md#deliberately-not-built): it is a large format for a
+lightweight app, and the documented `.ftree` schema covers sharing between users of this app.
+
+---
+
+## Updating
+
+### Will I lose my tree when I update?
+
+No. Installing a new APK over the old one keeps the app's data directory — that is ordinary Android
+behaviour, and it is why the in-place updater exists at all. Without it, moving to a new version
+would mean exporting, uninstalling, reinstalling and importing: four steps in which a family can be
+lost.
+
+### How do in-app updates work?
+
+Off until you switch them on in Settings. When on, f-tree checks GitHub for a newer release and,
+before installing anything, verifies three things in order:
+
+1. the download's SHA-256 against the digest GitHub publishes for the asset,
+2. that the archive's package name is this app,
+3. that its signing certificate matches the copy already installed.
+
+The third is the one that protects your tree: an APK signed with a different key *cannot* update
+this one — Android refuses it — and the only way to install it would be to uninstall first, taking
+the family with it.
+
+### What is the beta channel?
+
+An opt-in setting at the very bottom of Settings that offers pre-releases. Most people should leave
+it alone: a beta is an unfinished build of an app you keep your family in.
+
+Note that turning it back **off does not move you off a beta** — Android will not install an older
+version over a newer one. The next stable release does. Export your tree before installing a beta.
+
+---
+
+## The project
+
+### Who makes this?
+
+[Ankit Srivastava](https://github.com/thisisankit27). It is MIT-licensed and contributions are
+welcome — see [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+### How can I help?
+
+The two most useful contributions need no Android experience: **kinship terms in another language**
+(native speakers especially), and **real families that break the layout**. Accessibility testing
+with TalkBack and documentation are next. And starring the repository genuinely does help other
+families find it.
+
+### I found a security problem.
+
+Please do not open a public issue. Report it through the [private advisory
+form](https://github.com/thisisankit27/f-tree/security/advisories/new); scope and expectations are
+in [SECURITY.md](../SECURITY.md).

--- a/docs/ftree-format.md
+++ b/docs/ftree-format.md
@@ -1,0 +1,189 @@
+# The `.ftree` format, sharing, and merging
+
+An f-tree export is an ordinary ZIP with a documented JSON document inside it. It is the only way
+a tree leaves the phone, and it is designed so that **importing one adds to your tree rather than
+replacing it**.
+
+This page covers the file format, what travels when you share a single branch, and the rules the
+merge follows.
+
+**Contents**
+
+- [The `.ftree` format](#the-ftree-format)
+- [Sharing one branch](#sharing-one-branch)
+- [Joining a shared branch to your own tree](#joining-a-shared-branch-to-your-own-tree)
+- [Merge behaviour](#merge-behaviour)
+
+---
+
+## The `.ftree` format
+
+A ZIP. Version 1:
+
+```
+tree.json
+photos/<photoId>.jpg
+```
+
+```json
+{
+  "format": "f-tree",
+  "version": 1,
+  "exportedAt": "2026-08-31T00:00:00Z",
+  "sourceTreeId": "<uuid, stable for the life of an installation>",
+  "people": [
+    {
+      "id": "…", "name": "Ankit Kumar", "gender": "MALE",
+      "birthDate": "1990-05-01", "deathDate": null, "deceased": false,
+      "photo": "photos/….jpg", "notes": "…",
+      "origins": [{ "treeId": "…", "personId": "…" }]
+    }
+  ],
+  "relationships": [
+    { "id": "…", "from": "<parent>", "to": "<child>", "type": "PARENT", "subtype": null }
+  ]
+}
+```
+
+ZIP rather than one large JSON: base64-encoding a few hundred photographs would inflate them by a
+third and force the whole tree through memory to read one person's name.
+
+**Compatibility.** Every field but `format` and `version` is optional, and unknown keys are ignored
+on read, so a file written by a future release still opens. Those two are always written even though
+they equal their defaults, because they are how a reader knows what it is holding. A file claiming a
+*higher* version is refused rather than partly understood.
+
+`sourceTreeId` identifies the installation that wrote the file. With a person's id it forms a stable
+identity across exports; each person also carries the `origins` they were imported with, so a tree
+that has already been merged once still matches exactly on a later import.
+
+## Sharing one branch
+
+Export writes the whole archive, because it is the user's archive and they are keeping it. Sharing
+is a different act with a different shape: it is a message, it goes to somebody who may not have the
+app, and it should carry a part of the family rather than all of it.
+
+**What travels is a household and the households under it** — the person, everyone descended from
+them, and the partners of all of them. Sandeep's share is Sandeep, his wife, his children and their
+partners, and so on down. What stays behind is everything *above* and *beside* him: his parents, his
+siblings, their children. Sending somebody a branch should not quietly hand over the rest of the
+sharer's family, and a recipient starting their own tree from a relative's file wants the people
+below that relative, not the archive they came from.
+
+Partners come along at every level, because a couple is how a family is read and a child arriving
+without the parent they married is a hole in the story. Their *parents* do not: they are the doorway
+back into another whole family, which is exactly what this is not.
+
+A relationship travels only when **both** ends do. A shared branch therefore never carries an edge
+pointing at somebody who is not in the file — the reader could not resolve it, and it would leak the
+existence of a person deliberately left behind.
+
+The rule is [`FamilyGraph.branchFrom`](../app/src/main/java/com/vibethroughcode/ftree/graph/FamilyGraph.kt),
+which is an ordinary function over adjacency lookups and is tested as one.
+
+### The file, and the message with it
+
+The whole-tree export asks where to put the file. A share does not: nobody wants to name a message.
+It is written to the cache as `Sandeep-Kumar-family.ftree`, handed over as a content URI for the
+length of one intent, and the previous one is deleted on the next share rather than leaving copies of
+a family in a temporary directory. It has its own `FileProvider` — a subclass, because two
+`<provider>` entries naming the same class are one component to Android, and the first version of
+this shipped URIs that arrived at the updater's provider and were refused.
+
+The message that goes with it has to work for somebody looking at an attachment in a chat who has
+never heard of this app: whose family it is, how many people, where to get the app, and that
+importing will not overwrite anything they already have. Whether a given chat app *shows* that
+message beside the document is that app's decision — which is why the file is named after whose
+family it is. The name is the part that always arrives.
+
+### Sharing a relationship as a picture
+
+Sending a `.ftree` taught us something: **a chat app handed a document quietly drops the message
+that came with it.** The file arrives, the sentence explaining it does not. Handed an `image/png`,
+the same app shows the text beside the picture — Android's own share sheet does it too, which is how
+this was confirmed rather than assumed.
+
+So a relationship can also be sent as a card. Not a screenshot: a screenshot carries a status bar, a
+navigation bar and whatever font size the sender happens to use, none of which is the answer. The
+card is the app's own sentence and its own notation, laid out for the purpose, in two drawings of
+the same line — **Tree**, cards down a spine with each step named on the rule that makes it, and
+**List**, a register with a rail through the faces. The reader sees it before sending and picks.
+
+The preview *is* the card. The same composable is drawn on screen and recorded into the file through
+a `GraphicsLayer`, so there is no second rendering that could disagree with what was shown. Its
+density is pinned at three pixels to the point rather than read from the device, which is what makes
+the picture 1080 x 1350 from every phone; the preview scales that to fit after layout, so nothing is
+re-measured. The ground is painted opaque, because a PNG with transparent corners is at the mercy of
+whatever it lands on.
+
+A line of any length fits, because both ends are always shown and a middle that will not fit is
+counted rather than cut — "+4 more" is true where a silently shortened chain is not.
+
+## Joining a shared branch to your own tree
+
+This is the other half of why it exists. Import the branch, then create one relationship between
+somebody in it and somebody in yours, and the two families are one graph: your wife's father is your
+father-in-law, her brother your brother-in-law, and the relation finder can walk between them. There
+is no special "merge two trees" mode, because there does not need to be — a tree is a graph and a
+marriage is an edge.
+
+Re-importing the same file is a no-op. Every record carries where it came from, so the second import
+recognises those people outright rather than proposing them as duplicates.
+
+## Merge behaviour
+
+**An import adds; it never replaces.** Nothing already in the tree is deleted, and no existing value
+is overwritten. The worst an import can do is add people who turn out to be duplicates — which can
+then be merged. The opposite mistake, silently collapsing two real people into one, cannot be undone.
+Every default follows from that asymmetry.
+
+Reading and judging a file **writes nothing**; only a plan the user has confirmed is applied, in one
+transaction.
+
+| Evidence | Default |
+|---|---|
+| Provable — the file's origins name someone already held | merge, without asking |
+| Same name **and a relative already matched** | proposed **merge** |
+| Same name alone | proposed **keep separate** |
+| Dates that cannot both be true, or an unnamed person | no match at all |
+
+Matching runs in passes, so confirmed matches become evidence for their relatives: two people with
+the same name are far likelier to be the same once their father has already matched. Names are
+compared past accents, punctuation and spacing, but never abbreviations — guessing that "R. Kumar"
+is "Raj Kumar" is how a merge quietly destroys data.
+
+Applying:
+
+- Imported ids are **always remapped** to fresh local ones; an id in someone else's file may belong
+  to a different person here.
+- Merging **fills gaps only**. An empty field takes the imported value; a field that already says
+  something keeps saying it, and the disagreement is reported.
+- Existing relationships are skipped, not duplicated.
+- A **backup is written first**, to `files/backups/`, and the three most recent are kept.
+
+Re-importing the same file, or the app's own export, is a no-op.
+
+
+---
+
+## Reading a `.ftree` yourself
+
+The format is deliberately boring so that anything can read it: unzip the file and parse
+`tree.json`. There is no proprietary container, no encryption and no server involved, which is the
+point — a family record that only one program can open is a family record with an expiry date.
+
+The [browser viewer](https://ftree.vibethroughcode.com/playground/) is a working reference reader
+in about a thousand lines of dependency-free JavaScript. Its `archive.js` is the part that reads
+the ZIP, and it documents the one real trap: **read the central directory, never the local file
+headers** — see [the site notes](site.md#the-viewer).
+
+```bash
+unzip -l family.ftree
+unzip -p family.ftree tree.json | python3 -m json.tool | head -40
+```
+
+## Where to go next
+
+- [Architecture](architecture.md)
+- [The data model, field by field](data-model.md)
+- [The website and the browser viewer](site.md)

--- a/docs/site.md
+++ b/docs/site.md
@@ -1,0 +1,104 @@
+# The website and the browser viewer
+
+[ftree.vibethroughcode.com](https://ftree.vibethroughcode.com/) is the landing page and install
+guide. [ftree.vibethroughcode.com/playground/](https://ftree.vibethroughcode.com/playground/) is a
+browser-only reader for an exported `.ftree` — it draws the whole archive at once, including the
+people no relationship reaches.
+
+Neither page has an analytics script. The viewer never uploads the file you open.
+
+---
+
+## The landing page
+
+`site/` is the public landing page and install guide, deployed to GitHub Pages by
+`.github/workflows/pages.yml` on any push to `main` that touches it. There is no build step —
+edit the HTML and push.
+
+It reads version, size, release date, SHA-256 and the download count from the GitHub Releases API
+at run time, so cutting a release updates the site with no edit here, and the download count is
+real asset downloads rather than a third-party tracker. There is no analytics script on either
+page. Asset paths are relative, so the site works both at `thisisankit27.github.io/f-tree/` and at
+a custom domain.
+
+## The viewer
+
+`site/playground/` is a browser-only reader for an exported `.ftree`. Where the app draws the
+family *around one person* a few relationships deep — the right answer on a phone — the viewer
+draws the whole archive at once, on a tablet or a television, **including the people no
+relationship reaches**, who the app has nowhere to put at all.
+
+It is plain ES modules, no build, no dependencies:
+
+| | |
+|---|---|
+| `archive.js` | reads the ZIP and validates the document |
+| `model.js` | derives siblings, family units, components, kinship terms |
+| `layout.js` | generations, crossing reduction, coordinates, packing |
+| `chart.js` | the canvas renderer |
+| `main.js` | the interface |
+
+Three decisions in there are load-bearing:
+
+**The ZIP is read through its central directory, never the local file headers.** The app writes
+the archive with `java.util.zip.ZipOutputStream`, which for DEFLATED entries emits a local header
+with the CRC and both sizes zeroed and puts the real values in a trailing data descriptor. A reader
+that trusts the local header sees a length of zero for every entry.
+`tools/make_sample_tree.py` therefore emits one fixture through an unseekable stream so CI keeps
+testing that path.
+
+**Semantic zoom is what makes a large archive readable.** Drawing every name at every scale gives a
+grey wash the moment a whole family is on screen, so the chart draws less as it pulls back: at a
+distance the cards are plain shapes and what you read is the shape of the family — how many
+generations, how wide each got, and where the record has holes, because an unknown person keeps
+their brass dashed edge at every scale.
+
+**A generation is a relative fact, not a depth.** A child sits exactly one row below each parent,
+and spouses — and siblings whose parents nobody recorded — sit on the same row; those offsets are
+propagated out from one seed per connected family, which fixes every row exactly, because the offset
+between two people is the same along every route between them.
+
+The textbook alternative, ranking people by their longest path down from the oldest ancestor on
+record, is wrong in a way that takes a real family to notice: it makes a person's row depend on how
+far back *their* ancestry happens to be written down. A maternal grandfather whose own parents are
+unknown lands on the top row beside a great-great-grandfather from the other side of the family, and
+his children scatter across rows, each dragged down by however deep their own spouse's ancestry ran.
+
+Everything happens in the tab. The file is never uploaded, there is no analytics on the page, and
+the only thing stored is four display preferences in `localStorage`.
+
+```bash
+python3 tools/make_sample_tree.py /tmp/fixtures   # .ftree files, including odd ones
+node tools/check_layout.mjs /tmp/fixtures         # layout invariants, run in CI
+```
+
+To preview it locally:
+
+```bash
+python3 -m http.server 8731 --directory site
+```
+
+## Custom domain
+
+The site is served at **[ftree.vibethroughcode.com](https://ftree.vibethroughcode.com/)**, with
+`thisisankit27.github.io/f-tree/` still working. Asset paths are relative so that both do.
+
+The domain is held in the repository's **Pages settings**, not in a `site/CNAME` file — this
+deployment builds the pages as a workflow artifact rather than serving a branch, so GitHub keeps
+the custom domain as a repository setting and there is nothing to commit. Check it with:
+
+```bash
+gh api repos/thisisankit27/f-tree/pages --jq '.cname'
+```
+
+If you are pointing a *new* subdomain at this repository, order matters: add the `CNAME` record
+first, wait for it to resolve, and only then set the custom domain. Claiming a hostname that does
+not yet answer redirects the working `github.io` URL to one that is dead.
+
+
+---
+
+## Where to go next
+
+- [The `.ftree` format](ftree-format.md)
+- [Architecture](architecture.md)


### PR DESCRIPTION
The README was a 696-line engineering design document. It was the best writing in the project and the wrong first screen: somebody arriving from a search had to read past the data model to find out that the app is free, offline, and downloadable.

**Split rather than cut.** Every paragraph of the old README survives, moved into `docs/` where it is easier to find than it was buried mid-page.

## The README

A front door: what it is, screenshots, badges carrying a live download count, install, features, a privacy table, and where the documentation lives. The `site/shots/*.webp` screenshots were already excellent and were doing nothing for the repo — they are now the hero row.

Privacy is the strongest differentiator against every other family-tree app, so it is a badge and a table rather than a paragraph.

## New documentation

| | |
|---|---|
| `docs/architecture.md` | the graph, chart layout, kinship rules, photos, accessibility, and the design decisions table |
| `docs/ftree-format.md` | the file spec, sharing a branch, merge rules |
| `docs/building.md` | build, run, seed, test, sign, tag, ship |
| `docs/site.md` | the landing page and the browser viewer |
| `docs/faq.md` | **new** — the questions a prospective user actually asks |
| `docs/README.md` | **new** — an index |

## Community files, none of which existed

- **`CONTRIBUTING.md`** leads with the two contributions that need no Android experience — kinship terms in another language, and real families that break the layout.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, plus a note that a family shape you have not met is not one to correct.
- **`SECURITY.md`** — scope is the updater, import, file sharing, and the viewer.
- **`CHANGELOG.md`** — every stable release, written from the published release notes rather than invented.
- **Issue and PR templates**, including one for offering a language, labelled `good first issue`.

## Two corrections

- The custom-domain section described a `site/CNAME` file that does not exist. The domain is held in the Pages settings, because this deployment builds an artifact rather than serving a branch.
- *"Not built: a whole-graph chart"* contradicted the **Everyone** view, which draws exactly that.

## Also done outside this PR

The repository had no description, no website and no topics, so it was effectively invisible to GitHub search. All three are now set, Discussions is enabled, and a `kinship` label was created for the new template.

## Verification

- Every relative link, anchor and image resolves.
- All four issue-template YAMLs parse.
- **No application code is touched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)