### PR TITLE
The app icon is the mark the website uses

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 22
-        versionName = "0.7.0"
+        versionCode = 23
+        versionName = "0.7.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
@@ -130,7 +130,6 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     androidTestImplementation(libs.androidx.room.testing)

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/ChartPanningTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/ChartPanningTest.kt
@@ -1,10 +1,10 @@
 package com.vibethroughcode.ftree.ui
 
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -14,7 +14,6 @@ import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipe
 import androidx.compose.ui.unit.dp
-import androidx.test.espresso.Espresso
 import androidx.test.platform.app.InstrumentationRegistry
 import com.vibethroughcode.ftree.FTreeApplication
 import com.vibethroughcode.ftree.MainActivity
@@ -80,6 +79,21 @@ class ChartPanningTest {
         }
     }
 
+    /**
+     * Waits for the chart to be the one asked for, rather than for Compose to merely look idle.
+     *
+     * Re-centring goes out through the graph and comes back as a new layout, and the framing that
+     * follows is an effect of its own; `waitForIdle` returns before either. The chart says who it
+     * is centred on in its own description, so that is what to wait on.
+     */
+    private fun centredOn(name: String) {
+        rule.waitUntil(10_000) {
+            rule.onAllNodesWithContentDescription("centred on $name", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+        rule.waitForIdle()
+    }
+
     @Test
     fun aSmallDragDoesNotThrowARecentredChartOffTheScreen() {
         // The chart is built showing Padma, whose family is her husband and nobody else.
@@ -88,9 +102,7 @@ class ChartPanningTest {
         rule.onNodeWithText("Padma").performScrollTo().performClick()
         rule.waitForIdle()
         rule.onNodeWithContentDescription("Show on the tree").performClick()
-        rule.waitUntil(10_000) {
-            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
-        }
+        centredOn("Padma")
 
         /*
          * Her husband is stacked directly under her, a couple's spacing away, and the pair are
@@ -102,20 +114,14 @@ class ChartPanningTest {
         }
         rule.waitForIdle()
         rule.onNodeWithText("Centre the tree here").performClick()
-        rule.waitForIdle()
+        centredOn(middleSibling)
 
-        // Re-centred, in place, on a chart thirty-one people tall. He is at the middle of it.
-        rule.onNodeWithTag(FamilyChartTag).performTouchInput { click(center) }
-        rule.waitForIdle()
-        rule.onNodeWithText("Open $middleSibling").assertIsDisplayed()
-
-        // Put the sheet away and make sure it is gone: left open, its text would still be on
-        // screen at the end and the assertion below would pass without the chart being asked
-        // anything at all.
-        Espresso.pressBack()
-        rule.waitUntil(5_000) {
-            rule.onAllNodesWithText("Open $middleSibling").fetchSemanticsNodes().isEmpty()
-        }
+        /*
+         * Re-centred, in place, on a chart thirty-one people tall, with him at the middle of it.
+         * Choosing the action closed the sheet, so nothing is left over the chart — worth saying,
+         * because an earlier version of this test dismissed the sheet by hand and passed without
+         * the chart being asked anything: the sheet it read at the end was the one still open.
+         */
 
         // A drag of twenty points is a third of a card. Whoever was under the middle of the screen
         // must still be under it.

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -3,16 +3,45 @@
     android:height="108dp"
     android:viewportWidth="108"
     android:viewportHeight="108">
-    <!-- Three-generation glyph: one ancestor, a couple, two children. -->
-    <group android:translateX="0" android:translateY="0">
-        <path
-            android:strokeColor="#F2E8D5"
-            android:strokeWidth="2.6"
-            android:strokeLineCap="round"
-            android:strokeLineJoin="round"
-            android:pathData="M54,36 L54,46 M40,58 L68,58 M40,58 L40,52 M68,58 L68,52 M54,46 L54,52 M40,52 L68,52" />
-        <path android:fillColor="#F2E8D5" android:pathData="M54,26m-6,0a6,6 0,1 1,12 0a6,6 0,1 1,-12 0" />
-        <path android:fillColor="#8FC7A1" android:pathData="M40,66m-6,0a6,6 0,1 1,12 0a6,6 0,1 1,-12 0" />
-        <path android:fillColor="#8FC7A1" android:pathData="M68,66m-6,0a6,6 0,1 1,12 0a6,6 0,1 1,-12 0" />
-    </group>
+
+    <!--
+        The mark the website uses, at the size an adaptive icon can show.
+
+        A couple joined by a rule, descending to two children, one of whom is drawn in dashed brass
+        because nobody recorded their name. That last circle is the app's own notation for a gap in
+        a family record, and it is why this mark is worth keeping rather than a generic tree: the
+        icon states what the app is *for* — holding what a family remembers, holes included.
+
+        Scaled to sit inside the 66dp circle every launcher mask is guaranteed to show, so no part
+        of it is trimmed on a round mask.
+    -->
+
+    <!-- The lines, and the two people whose names are known. -->
+    <path
+        android:strokeColor="#CDE6D5"
+        android:strokeWidth="4.17"
+        android:strokeLineCap="round"
+        android:pathData="M49.34,38.69L58.65,38.69 M54,46.28L54,54.61 M36.85,54.61L71.15,54.61 M36.85,54.61L36.85,60.98 M71.15,54.61L71.15,60.98" />
+    <path
+        android:strokeColor="#CDE6D5"
+        android:strokeWidth="4.17"
+        android:pathData="M41.75,31.09a7.6,7.6 0 1,0 0,15.2a7.6,7.6 0 1,0 0,-15.2" />
+    <path
+        android:strokeColor="#CDE6D5"
+        android:strokeWidth="4.17"
+        android:pathData="M66.25,31.09a7.6,7.6 0 1,0 0,15.2a7.6,7.6 0 1,0 0,-15.2" />
+    <path
+        android:strokeColor="#CDE6D5"
+        android:strokeWidth="4.17"
+        android:pathData="M36.85,61.71a7.6,7.6 0 1,0 0,15.2a7.6,7.6 0 1,0 0,-15.2" />
+
+    <!--
+        The one nobody named. Drawn as five arcs rather than a dashed stroke: a VectorDrawable has
+        no dash array, so the pattern has to be the path.
+    -->
+    <path
+        android:strokeColor="#E3C38C"
+        android:strokeWidth="4.17"
+        android:strokeLineCap="round"
+        android:pathData="M78.29,66.71A7.6,7.6 0 0,1 78.29,71.91 M75.83,75.30A7.6,7.6 0 0,1 70.88,76.91 M66.90,75.61A7.6,7.6 0 0,1 63.84,71.40 M63.84,67.22A7.6,7.6 0 0,1 66.90,63.01 M70.88,61.71A7.6,7.6 0 0,1 75.83,63.32" />
 </vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="ic_launcher_background">#1F3D2B</color>
+    <color name="ic_launcher_background">#2A5138</color>
 </resources>


### PR DESCRIPTION
`versionCode` 23, `versionName` 0.7.1 — a **stable** release, so `releases/latest` moves.

The site and the app were showing different logos. The site's is the better one and the one people meet first, so the app takes it.

## The mark

A couple joined by a rule, descending to two children — one drawn in **dashed brass because nobody recorded their name**. That last circle is why this is worth having over a generic tree: dashed brass is the app's own notation for a gap in a family record. It means the same thing on the chart, on a shared card, and now on the home screen.

## Two things the translation had to deal with

**A VectorDrawable has no dash array.** `stroke-dasharray` is an SVG feature Android's vector format does not implement, so the brass circle is drawn as five arcs at the same duty cycle as the original (55% against the site's 52%).

**Launcher masks.** The mark is scaled to sit inside the **66dp circle** every mask is guaranteed to show — measured at 65.3dp — so a round mask trims none of it. Checked on a device, not assumed: the app-info screen renders the icon under a circular mask and nothing is clipped.

Background moves from `#1F3D2B` to the site's `#2A5138`. `minSdk` is 26 so the adaptive icon covers every supported device; there are no PNG fallbacks to regenerate. The same drawable serves the monochrome/themed layer, where the dash pattern survives tinting.

## Also: ChartPanningTest made deterministic

The test added in [#73](https://github.com/thisisankit27/f-tree/pull/73) was flaky, and the full suite caught it here.

- It waited for Compose to look idle after re-centring, but re-centring goes out through the graph and comes back as a new layout, with the framing after it an effect of its own. It now waits for the chart to *say* it is centred on the person asked for.
- It dismissed the actions sheet by hand. Espresso's `pressBack()` timed out about one run in three waiting for a chart that was still laying itself out, and the activity's own back dispatcher **finished the activity** whenever the sheet had already closed. Neither is needed: choosing "Centre the tree here" closes the sheet itself.

Confirmed again to fail without the pan fix (with the intended message) and pass with it.

213 unit, 156 instrumented, lint unchanged at 82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)