### PR TITLE
Open somebody's photograph by tapping it

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 23
-        versionName = "0.7.1"
+        versionCode = 24
+        versionName = "0.8.0-beta.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PhotoViewerTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/PhotoViewerTest.kt
@@ -1,0 +1,125 @@
+package com.vibethroughcode.ftree.ui
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.MainActivity
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.ui.person.PersonAvatarTag
+import com.vibethroughcode.ftree.ui.person.PersonPhotoCloseTag
+import com.vibethroughcode.ftree.ui.person.PersonPhotoDialogTag
+import com.vibethroughcode.ftree.ui.person.PersonPhotoImageTag
+import com.vibethroughcode.ftree.ui.tree.FamilyChartTag
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayOutputStream
+
+/** Opening the photograph on somebody's page, and putting it away again. */
+@RunWith(AndroidJUnit4::class)
+class PhotoViewerTest {
+
+    @get:Rule
+    val rule = createAndroidComposeRule<MainActivity>()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    @Before
+    fun seedOneFaceAndOneInitial() {
+        app.container.updatePreferences.setEnabled(false)
+        app.container.database.clearAllTables()
+
+        runBlocking {
+            // A real JPEG through the real store, so the id and the file agree the way they do
+            // when somebody picks a photograph.
+            val bitmap = Bitmap.createBitmap(300, 300, Bitmap.Config.ARGB_8888).apply {
+                eraseColor(Color.rgb(120, 80, 60))
+            }
+            val bytes = ByteArrayOutputStream()
+                .also { bitmap.compress(Bitmap.CompressFormat.JPEG, 85, it) }
+                .toByteArray()
+            val photoId = app.container.photoStore.saveBytes(bytes)
+            assertTrue("the store did not keep the photograph", photoId != null)
+
+            app.container.familyRepository.addPerson(
+                Person(name = "Neeru Verma", birthDate = "1966", photoId = photoId)
+            )
+            app.container.familyRepository.addPerson(Person(name = "Arun Verma", birthDate = "1962"))
+        }
+        rule.waitUntil(10_000) {
+            rule.onAllNodesWithTag(FamilyChartTag).fetchSemanticsNodes().isNotEmpty()
+        }
+    }
+
+    private fun openPerson(name: String) {
+        rule.onNodeWithTag(NavPeopleTag).performClick()
+        rule.waitForIdle()
+        rule.onNodeWithText(name).performScrollTo().performClick()
+        rule.waitForIdle()
+    }
+
+    @Test
+    fun aPhotographOpensWhenItIsTappedAndCloses() {
+        openPerson("Neeru Verma")
+
+        rule.onNodeWithTag(PersonAvatarTag).assertIsDisplayed().performClick()
+        rule.waitForIdle()
+        rule.onNodeWithTag(PersonPhotoDialogTag).assertIsDisplayed()
+        // The picture itself, not merely the scrim it sits on. By tag, because the avatar on the
+        // page behind carries the same description — which is right, and is why matching on the
+        // description alone found two.
+        // Through the unmerged tree: the scrim is clickable, so it merges the picture's semantics
+        // into itself — which is what makes a screen reader announce one thing, "photo of Neeru
+        // Verma", with one way out, rather than two nodes to hunt through.
+        rule.onNodeWithTag(PersonPhotoImageTag, useUnmergedTree = true).assertIsDisplayed()
+
+        rule.onNodeWithTag(PersonPhotoCloseTag).performClick()
+        rule.waitForIdle()
+        assertTrue(
+            "the photograph stayed open after Close",
+            rule.onAllNodesWithTag(PersonPhotoDialogTag).fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    @Test
+    fun tappingThePictureItselfPutsItAway() {
+        openPerson("Neeru Verma")
+        rule.onNodeWithTag(PersonAvatarTag).performClick()
+        rule.waitForIdle()
+
+        rule.onNodeWithTag(PersonPhotoDialogTag).performClick()
+        rule.waitForIdle()
+        assertTrue(
+            "a tap on the picture should put it away, as it does anywhere else",
+            rule.onAllNodesWithTag(PersonPhotoDialogTag).fetchSemanticsNodes().isEmpty(),
+        )
+    }
+
+    /**
+     * Somebody with no photograph has a lettered circle, and it must not offer a gesture that
+     * leads to a blank screen.
+     */
+    @Test
+    fun anInitialIsNotSomethingToOpen() {
+        openPerson("Arun Verma")
+
+        assertTrue(
+            "the lettered circle should not be tappable",
+            rule.onAllNodesWithTag(PersonAvatarTag).fetchSemanticsNodes().isEmpty(),
+        )
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -65,6 +65,9 @@ import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.common.sectionTitle
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.draw.clip
 
 const val PersonNameTag = "person-name"
 const val PersonDeleteTag = "person-delete"
@@ -72,6 +75,7 @@ const val PersonMenuTag = "person-menu"
 const val PersonRelateTag = "person-relate"
 const val PersonShareTag = "person-share"
 const val PersonEditTag = "person-edit"
+const val PersonAvatarTag = "person-avatar"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -253,12 +257,31 @@ fun PersonDetailScreen(
 @Composable
 private fun PersonHeader(person: Person, modifier: Modifier = Modifier) {
     val accents = FTreeTheme.accents
+    var showingPhoto by rememberSaveable { mutableStateOf(false) }
+
     Row(
         modifier = modifier.fillMaxWidth().padding(top = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(20.dp),
     ) {
-        PersonAvatar(person, diameter = 72.dp)
+        /*
+         * A photograph opens; an initial does not.
+         *
+         * Only a face is worth a second look, and making the lettered circle tappable would offer
+         * a gesture that leads to a blank screen. The ripple is the whole affordance: nothing here
+         * announces itself as a button, because a photograph on a person's page is the one thing a
+         * reader already expects to be able to tap.
+         */
+        val hasPhoto = person.photoId != null
+        val viewLabel = stringResource(R.string.photo_view)
+        PersonAvatar(
+            person = person,
+            diameter = 72.dp,
+            modifier = if (!hasPhoto) Modifier else Modifier
+                .clip(CircleShape)
+                .clickable(onClickLabel = viewLabel) { showingPhoto = true }
+                .testTag(PersonAvatarTag),
+        )
         Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
             Text(
                 text = person.displayName(),
@@ -269,6 +292,10 @@ private fun PersonHeader(person: Person, modifier: Modifier = Modifier) {
             )
             LifeLine(person)
         }
+    }
+
+    if (showingPhoto) {
+        PersonPhotoDialog(person = person, onDismiss = { showingPhoto = false })
     }
 }
 

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonPhotoDialog.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonPhotoDialog.kt
@@ -1,0 +1,109 @@
+package com.vibethroughcode.ftree.ui.person
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import coil3.compose.AsyncImage
+import com.vibethroughcode.ftree.R
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.data.PhotoStore
+import com.vibethroughcode.ftree.ui.common.displayName
+import com.vibethroughcode.ftree.ui.common.photoFile
+
+const val PersonPhotoDialogTag = "person-photo-dialog"
+const val PersonPhotoCloseTag = "person-photo-close"
+const val PersonPhotoImageTag = "person-photo-image"
+
+/**
+ * Somebody's photograph, as large as the screen will show it.
+ *
+ * Everywhere else in the app a face is a circle — in a list row, on a person's page, on a chart
+ * card — because a circle is what a face has to be when it sits beside a name. That is a decision
+ * about *display*, though, and the file on disk was never round: it is the square the reader framed,
+ * or, for a photograph that arrived in somebody else's tree, the whole picture exactly as they sent
+ * it. So this shows the picture whole and uncropped, which for an imported photograph is generally
+ * more than any circle in the app has ever shown of it.
+ *
+ * Deliberately without pinch and zoom. A photograph is stored at [PhotoStore.STORED_EDGE] on its
+ * long edge — small on purpose, so that a family of a thousand costs tens of megabytes and a
+ * `.ftree` file is something you can send in a chat — and there is nothing underneath that size to
+ * zoom into. Offering the gesture would promise detail the file does not contain.
+ */
+@Composable
+fun PersonPhotoDialog(person: Person, onDismiss: () -> Unit) {
+    val photoId = person.photoId ?: return
+    val description = stringResource(R.string.a11y_person_avatar, person.displayName())
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            // Fills the screen properly rather than leaving the scrim short of the status and
+            // navigation bars, which on a dark ground reads as a bug rather than as a frame.
+            decorFitsSystemWindows = false,
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.94f))
+                /*
+                 * A tap anywhere puts it away, which is what a picture opened full screen has
+                 * meant for as long as phones have had pictures. No ripple: this is a way out,
+                 * not a control, and a flash of ink across a photograph looks like a fault.
+                 */
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = onDismiss,
+                )
+                .testTag(PersonPhotoDialogTag),
+            contentAlignment = Alignment.Center,
+        ) {
+            AsyncImage(
+                model = LocalContext.current.photoFile(photoId),
+                contentDescription = description,
+                // Fit, not Crop: the point of opening it is to see the parts a circle cuts off.
+                contentScale = ContentScale.Fit,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .safeDrawingPadding()
+                    .padding(16.dp)
+                    .testTag(PersonPhotoImageTag),
+            )
+
+            IconButton(
+                onClick = onDismiss,
+                colors = IconButtonDefaults.iconButtonColors(contentColor = Color.White),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .safeDrawingPadding()
+                    .padding(8.dp)
+                    .testTag(PersonPhotoCloseTag),
+            ) {
+                Icon(Icons.Default.Close, contentDescription = stringResource(R.string.photo_close))
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -145,6 +145,8 @@
     <string name="photo_add">Add a photo</string>
     <string name="photo_change">Change photo</string>
     <string name="photo_remove">Remove photo</string>
+    <string name="photo_view">View photo</string>
+    <string name="photo_close">Close photo</string>
     <string name="photo_crop_title">Frame the photo</string>
     <string name="photo_crop_hint">Drag to move, pinch to zoom. A photo is always shown as a circle.</string>
     <string name="photo_crop_use">Use photo</string>


### PR DESCRIPTION
A face on a person's page now opens full screen.

## What it does

Tap the photograph in the page header and it fills the screen. Tap anywhere, or the close button, to put it away.

**Only a face is tappable.** A lettered circle stays inert — making it tappable would offer a gesture that leads to a blank screen. The ripple is the whole affordance; nothing is labelled as a button, because a photograph on somebody's page is the one thing a reader already expects to be able to tap.

## Two decisions worth stating

**It is shown whole, not as a circle.** Everywhere else a face is round because that is what it has to be beside a name — but that is a decision about *display*, and the file was never round. `PhotoStore` says as much: the stored JPEG is the square the reader framed, or, for a photograph imported with somebody else's tree, the picture exactly as they sent it (imports are not cropped, since nobody is at the phone to frame a stranger's photo). So opening it is generally the first time anyone sees the parts the circle has been cutting off.

**No pinch and zoom.** A photograph is kept at `STORED_EDGE` = 512px — small on purpose, so a family of a thousand costs tens of megabytes and a `.ftree` is something you can send in a chat. There is no detail under that to zoom into, and offering the gesture would promise what the file does not hold. At 512px filling a 1080px screen it is a ~2x upscale: soft, and entirely legible.

## Verification

- **Three new instrumented tests**: the photograph opens and closes by the button; a tap on the picture puts it away; and a lettered circle is *not* something to open.
- Confirmed on device with a real photograph from a real tree — the header avatar reports `clickable=true` while the relatives' avatars below it report `clickable=false`, which is the distinction the feature turns on.
- 213 unit, **159 instrumented**, lint unchanged at 82.

One thing the tests taught me: the scrim is `clickable`, so it *merges* the picture's semantics into itself. That is right — a screen reader announces one thing, "Photo of Ankit Srivastava", with one way out — but it means the image is only reachable through the unmerged tree, which the test now says out loud.

`versionCode` 24, `versionName` 0.8.0-beta.1 — a pre-release, so `releases/latest` keeps answering v0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)