### PR TITLE
fix: use the whole window instead of one column and a void

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 24
-        versionName = "0.8.0-beta.1"
+        versionCode = 25
+        versionName = "0.8.0-beta.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/androidTest/java/com/vibethroughcode/ftree/ui/WideWindowLayoutTest.kt
+++ b/app/src/androidTest/java/com/vibethroughcode/ftree/ui/WideWindowLayoutTest.kt
@@ -1,0 +1,135 @@
+package com.vibethroughcode.ftree.ui
+
+import androidx.compose.ui.test.DeviceConfigurationOverride
+import androidx.compose.ui.test.ForcedSize
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.vibethroughcode.ftree.FTreeApplication
+import com.vibethroughcode.ftree.data.Person
+import com.vibethroughcode.ftree.ui.people.PeopleCountTag
+import com.vibethroughcode.ftree.ui.people.PeopleScreen
+import com.vibethroughcode.ftree.ui.settings.SettingsScreen
+import com.vibethroughcode.ftree.ui.theme.FTreeTheme
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.math.abs
+
+/**
+ * That a window wider than one column of reading matter is used rather than left half empty.
+ *
+ * This is the shape of a bug that has been reported twice: a landscape phone showing three names
+ * beside two hundred points of nothing, and a tablet that would show the same thing worse. Both
+ * screens are laid out at a *forced* size rather than by rotating the device, so the test says the
+ * same thing on a phone, on a tablet and on whatever the emulator happens to be.
+ */
+@RunWith(AndroidJUnit4::class)
+class WideWindowLayoutTest {
+
+    @get:Rule
+    val rule = createComposeRule()
+
+    private val app: FTreeApplication
+        get() = InstrumentationRegistry.getInstrumentation()
+            .targetContext.applicationContext as FTreeApplication
+
+    @Before
+    fun seedFourPeople() {
+        app.container.updatePreferences.setEnabled(false)
+        app.container.database.clearAllTables()
+        runBlocking {
+            listOf("Aarav Verma", "Bhavna Verma", "Chandra Verma", "Devika Verma").forEach {
+                app.container.familyRepository.addPerson(Person(name = it, birthDate = "1960"))
+            }
+        }
+    }
+
+    private fun people(width: Int, height: Int = 420) = rule.setContent {
+        DeviceConfigurationOverride(
+            DeviceConfigurationOverride.ForcedSize(DpSize(width.dp, height.dp))
+        ) {
+            FTreeTheme { PeopleScreen(onOpenPerson = {}, onAddPerson = {}) }
+        }
+    }
+
+    @Test
+    fun a_landscape_phone_reads_the_list_in_two_columns() {
+        people(width = 750)
+
+        val first = rule.onNodeWithText("Aarav Verma").getBoundsInRoot()
+        val second = rule.onNodeWithText("Bhavna Verma").getBoundsInRoot()
+
+        assertTrue(
+            "the second name is below the first rather than beside it",
+            abs((first.top - second.top).value) < 1f,
+        )
+        assertTrue("the second name is not to the right of the first", second.left > first.left)
+    }
+
+    @Test
+    fun an_upright_phone_still_reads_the_list_in_one() {
+        people(width = 411, height = 900)
+
+        val first = rule.onNodeWithText("Aarav Verma").getBoundsInRoot()
+        val second = rule.onNodeWithText("Bhavna Verma").getBoundsInRoot()
+
+        assertEquals("the names are side by side on a narrow window", first.left, second.left)
+        assertTrue("the second name is not under the first", second.top > first.top)
+    }
+
+    /**
+     * The failure the whole change is about: not *how* the width is divided, but that all of it is
+     * used. A column stopping short of the far edge is the band of nothing that was reported.
+     */
+    @Test
+    fun the_columns_reach_the_far_edge_of_a_tablet() {
+        people(width = 1280, height = 800)
+
+        // The count belongs to the whole list, so it spans every column: its right edge is where
+        // the columns end, and the band of nothing that was reported is the gap after it. It sets
+        // its own twenty points of padding, so that much short of the edge is the text, not a gap.
+        val underneath = rule.onNodeWithTag(PeopleCountTag).getBoundsInRoot()
+        val short = 1280 - underneath.right.value
+        assertTrue("the list stops $short points short of the far edge", short <= 21f)
+
+        // And it really is more than two columns: the third name starts past two thirds across.
+        val third = rule.onNodeWithText("Chandra Verma").getBoundsInRoot()
+        assertTrue("there is no third column", third.left.value > 1280 * 2 / 3f - 60f)
+    }
+
+    @Test
+    fun settings_sections_stand_beside_each_other_on_a_wide_window() {
+        rule.setContent {
+            DeviceConfigurationOverride(
+                DeviceConfigurationOverride.ForcedSize(DpSize(900.dp, 500.dp))
+            ) {
+                FTreeTheme {
+                    SettingsScreen(
+                        onExport = {},
+                        onImport = {},
+                        viewModel = viewModel(factory = FTreeViewModels.Factory),
+                    )
+                }
+            }
+        }
+
+        val words = rule.onNodeWithText("FAMILY WORDS").getBoundsInRoot()
+        val chart = rule.onNodeWithText("CHART").getBoundsInRoot()
+
+        assertTrue("the chart section is below the words section, not beside it",
+            abs((words.top - chart.top).value) < 1f)
+        assertTrue("the chart section is not to the right of the words section",
+            chart.left > words.left)
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/FTreeApp.kt
@@ -50,7 +50,6 @@ import com.vibethroughcode.ftree.FTreeApplication
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.transfer.TreeDocument
 import com.vibethroughcode.ftree.transfer.sendBranchIntent
-import com.vibethroughcode.ftree.ui.common.LocalHasNavigationRail
 import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.isShortWindow
 import com.vibethroughcode.ftree.ui.people.PeopleScreen
@@ -187,17 +186,7 @@ fun FTreeApp(
      */
     val useRail = onTopLevel && isShortWindow()
 
-    /*
-     * The rail is announced rather than re-derived.
-     *
-     * Every screen beside it lays its own reading column against it, and a screen working that out
-     * from the window size would be guessing at a decision made here — and would guess wrongly the
-     * moment the rail appears or disappears for a reason other than the height.
-     */
-    CompositionLocalProvider(
-        LocalKinshipLanguage provides kinshipLanguage,
-        LocalHasNavigationRail provides useRail,
-    ) {
+    CompositionLocalProvider(LocalKinshipLanguage provides kinshipLanguage) {
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) },
             bottomBar = {

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/ReadingColumns.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/ReadingColumns.kt
@@ -1,0 +1,68 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.unit.Constraints
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Lays a handful of self-contained blocks out in as many columns as the width deserves.
+ *
+ * A settings page and a person's relatives are not one long thing; they are six or seven short
+ * ones stacked because a phone is narrow. Given a landscape phone or a tablet they should stand
+ * beside each other rather than leave half the glass empty and make the reader scroll past it.
+ *
+ * How many columns is [readableColumns]' decision, so every screen in the app breaks at the same
+ * widths. Each block is then given a whole column and dropped into whichever column is currently
+ * shortest, which is what keeps two columns of unequal blocks ending at roughly the same place —
+ * a plain half-and-half split would put the tall one on one side and leave the other stranded.
+ * With everything the same height, or with one column, that rule degenerates to the obvious
+ * answer: straight down the page, in the order written.
+ *
+ * Not lazy, deliberately. There are six sections, not six hundred; laziness would buy nothing and
+ * would cost the page its ability to be scrolled to by anything that is not currently on screen —
+ * which is how the whole app is tested.
+ *
+ * Each direct child must emit exactly one layout node. Wrap a run of them in a `Column`.
+ */
+@Composable
+fun ReadingColumns(
+    modifier: Modifier = Modifier,
+    gutter: Dp = 32.dp,
+    content: @Composable () -> Unit,
+) {
+    Layout(modifier = modifier, content = content) { measurables, constraints ->
+        val available = constraints.maxWidth
+        val count = readableColumns(available.toDp())
+        val gutterPx = gutter.roundToPx()
+        val columnWidth = (available - gutterPx * (count - 1)) / count
+
+        val placeables = measurables.map {
+            it.measure(
+                Constraints(
+                    minWidth = columnWidth,
+                    maxWidth = columnWidth,
+                    minHeight = 0,
+                    maxHeight = Constraints.Infinity,
+                )
+            )
+        }
+
+        val filled = IntArray(count)
+        val offsets = placeables.map { placeable ->
+            val column = (0 until count).minBy { filled[it] }
+            val offset = column * (columnWidth + gutterPx) to filled[column]
+            filled[column] += placeable.height
+            offset
+        }
+
+        layout(available, filled.maxOrNull() ?: 0) {
+            placeables.forEachIndexed { index, placeable ->
+                val (x, y) = offsets[index]
+                placeable.place(x, y)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/common/Windowing.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/common/Windowing.kt
@@ -4,13 +4,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import kotlin.math.ceil
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Whether the window is short enough that horizontal chrome has to give way.
@@ -31,40 +32,53 @@ fun isShortWindow(): Boolean {
 private val SHORT_WINDOW = 500.dp
 
 /**
- * Whether a navigation rail stands along the start edge of whatever is being laid out.
+ * The widest a single column of reading matter is allowed to get, and the narrowest worth having.
  *
- * Provided once by the app shell, which is the only thing that knows. A screen has no business
- * asking about the orientation to work this out — the rail appears for reasons of its own — and
- * it needs the answer because a column of reading matter is positioned relative to the edge it
- * sits beside, not relative to the glass.
+ * A list of names stretched across a landscape phone puts the name at one edge and the date at the
+ * other, with a hand's width of nothing between them — the eye loses the row on the way across.
+ * Typographers have known the answer for five hundred years and it is not "wider".
  */
-val LocalHasNavigationRail = staticCompositionLocalOf { false }
+val READABLE_MEASURE = 560.dp
+private val LEAST_MEASURE = 320.dp
 
 /**
- * Holds a column of reading matter to a sensible measure, against whatever edge it belongs to.
+ * How many columns a pane this wide should be read in.
  *
- * A list of names stretched across a landscape phone puts the name at one edge of the screen and
- * the date at the other, with a hand's width of nothing between them — the eye loses the row on the
- * way across. Typographers have known the answer for five hundred years and it is not "wider": a
- * line has a comfortable length, and past it you add margins rather than words.
+ * The answer a typesetter gives to a page too wide for one column is *another column*, and this is
+ * that answer: no column wider than the measure, as few columns as that allows, and the width
+ * shared out between them so none of it is left over. A landscape phone reads in two, a tablet in
+ * three, an upright phone in one — and in every case the content reaches both edges of the pane.
  *
- * Where the column *sits* is the other half of it, and the answer is not "the middle" whatever the
- * screen. Centred beside a navigation rail, a column leaves a band of nothing between the rail and
- * the first word, bounded by furniture on both sides — a gap that reads as a mistake rather than as
- * a margin, and one the eye keeps trying to fill. So the column anchors to the rail when there is
- * one and centres when there is not, which in both cases puts its start edge against the nearest
- * real edge.
+ * The floor matters as much as the ceiling. Between one measure and two there is a stretch where
+ * splitting would buy two columns too cramped to hold a name and a date, so a pane in that band
+ * takes the extra width as a slightly long line rather than as a bad break. That is the only place
+ * a column is allowed past [READABLE_MEASURE], and it tops out around the width of an upright
+ * tablet, where one column is the right answer anyway.
  *
- * Applied to a whole screen rather than to its body: a top bar and a floating button laid out to
- * the full width, above a column that is not, leave a search icon and an "add" button stranded out
- * in the margin with nothing to line up against. One measure for the screen means everything on it
- * shares the same two edges.
- *
- * The charts are exempt, deliberately. They are pictures, not prose, and they want every pixel.
+ * A pure function of a width rather than something that reads the window, because the pane is not
+ * the window: a navigation rail and the display cutout beside it can take two hundred points off
+ * the front before a screen sees any of it.
  */
-@Composable
-fun Modifier.readableMeasure(max: Dp = 560.dp): Modifier {
-    val alignment =
-        if (LocalHasNavigationRail.current) Alignment.Start else Alignment.CenterHorizontally
-    return fillMaxWidth().wrapContentWidth(alignment).widthIn(max = max)
+fun readableColumns(
+    width: Dp,
+    measure: Dp = READABLE_MEASURE,
+    least: Dp = LEAST_MEASURE,
+): Int {
+    if (width <= measure) return 1
+    val fewestWithinTheMeasure = ceil(width / measure).toInt()
+    val mostStillLegible = (width / least).toInt()
+    return max(1, min(fewestWithinTheMeasure, mostStillLegible))
 }
+
+/**
+ * Holds a column of reading matter to a sensible measure, centred in whatever it is given.
+ *
+ * This is for the screens that genuinely are one column and could not be any other number: a form
+ * to fill in, a question to answer. Splitting a form into two columns makes the eye hunt for the
+ * next field, so these take the measure and let the rest be margin, the way a page of a book does.
+ *
+ * Screens made of *parts* — a list of people, a stack of settings, a person's relatives — do not
+ * use this. They use [readableColumns] and fill the pane. See `ReadingColumns`.
+ */
+fun Modifier.readableMeasure(max: Dp = READABLE_MEASURE): Modifier =
+    fillMaxWidth().wrapContentWidth().widthIn(max = max)

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/people/PeopleScreen.kt
@@ -1,6 +1,6 @@
 package com.vibethroughcode.ftree.ui.people
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.material3.FilterChip
 import androidx.compose.foundation.layout.Arrangement
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -49,7 +51,7 @@ import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.ui.FTreeViewModels
 import com.vibethroughcode.ftree.ui.common.EmptyState
 import com.vibethroughcode.ftree.ui.common.PersonRow
-import com.vibethroughcode.ftree.ui.common.readableMeasure
+import com.vibethroughcode.ftree.ui.common.readableColumns
 import com.vibethroughcode.ftree.ui.common.peopleCount
 import com.vibethroughcode.ftree.ui.common.TreeGlyph
 import com.vibethroughcode.ftree.ui.theme.FTreeText
@@ -79,15 +81,15 @@ fun PeopleScreen(
     }
 
     /*
-     * The measure is put on the whole screen rather than on the list inside it.
+     * The screen takes the whole pane; the reading measure is kept by the columns inside it.
      *
-     * The top bar, the search icon and the "add a person" button are laid out by the scaffold, so
-     * insetting only the body left them out in the margin: a search icon against the far bezel
-     * above a list that stopped a hundred points short of it, and nothing on the screen sharing an
-     * edge with anything else.
+     * Holding the screen itself to one column's width was the earlier answer, and on anything
+     * wider than a phone it left a band of nothing down one side with the top bar and the "add a
+     * person" button stranded in it. A list of names does not need a wider line — it needs more
+     * lines, and a landscape phone has room for two of them side by side.
      */
     Scaffold(
-        modifier = modifier.readableMeasure(),
+        modifier = modifier,
         topBar = {
             if (searching) {
                 OutlinedTextField(
@@ -150,7 +152,7 @@ fun PeopleScreen(
                     onFilterChange = viewModel::onFilterChange,
                 )
             }
-            Box(Modifier.fillMaxSize()) {
+            BoxWithConstraints(Modifier.fillMaxSize()) {
             when {
                 state.isEmptyTree -> EmptyState(
                     title = stringResource(R.string.empty_title),
@@ -176,7 +178,8 @@ fun PeopleScreen(
                     modifier = Modifier.align(Alignment.TopCenter).padding(32.dp),
                 )
 
-                else -> LazyColumn(
+                else -> LazyVerticalGrid(
+                    columns = GridCells.Fixed(readableColumns(maxWidth)),
                     modifier = Modifier.fillMaxSize().testTag(PeopleListTag),
                     // Room for the extended FAB to sit over without covering the last row.
                     contentPadding = PaddingValues(bottom = 96.dp),
@@ -184,7 +187,9 @@ fun PeopleScreen(
                     items(state.people, key = { it.id }) { person ->
                         PersonRow(person = person, onClick = { onOpenPerson(person.id) })
                     }
-                    item {
+                    // The count is about the whole list, so it sits under all of it rather than
+                    // under one column of it.
+                    item(span = { GridItemSpan(maxLineSpan) }) {
                         Text(
                             text = countLine(state),
                             style = FTreeText.recordSmall,

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/person/PersonDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -59,7 +60,8 @@ import com.vibethroughcode.ftree.ui.common.SectionRule
 import com.vibethroughcode.ftree.ui.common.PersonRow
 import com.vibethroughcode.ftree.ui.common.addRelativeLabel
 import com.vibethroughcode.ftree.ui.common.displayName
-import com.vibethroughcode.ftree.ui.common.readableMeasure
+import com.vibethroughcode.ftree.ui.common.READABLE_MEASURE
+import com.vibethroughcode.ftree.ui.common.ReadingColumns
 import com.vibethroughcode.ftree.ui.common.LocalKinshipLanguage
 import com.vibethroughcode.ftree.ui.common.relativeRoleLabel
 import com.vibethroughcode.ftree.ui.common.sectionTitle
@@ -187,31 +189,45 @@ fun PersonDetailScreen(
             modifier = Modifier
                 .fillMaxHeight()
                 .padding(padding)
-                .readableMeasure()
                 .verticalScroll(rememberScrollState()),
         ) {
-            PersonHeader(person, Modifier.padding(horizontal = 20.dp))
+            // Who the page is about, across the top of it: one person, so one column, however
+            // wide the glass. The sections below are four separate lists and can stand abreast.
+            PersonHeader(
+                person,
+                Modifier.widthIn(max = READABLE_MEASURE).padding(horizontal = 20.dp),
+            )
 
-            RelativeKind.entries.forEach { kind ->
-                RelativeSection(
-                    kind = kind,
-                    relatives = state.of(kind),
-                    onOpen = onOpenPerson,
-                    onAdd = { onAddRelative(viewModel.personId, kind) },
-                    onRemove = { other -> pendingRemoval = other },
-                )
-            }
+            // No gutter: each section already holds its rows twenty points off its own edges, so
+            // two of them side by side keep forty points between the names, which is enough.
+            ReadingColumns(gutter = 0.dp) {
+                RelativeKind.entries.forEach { kind ->
+                    Column {
+                        RelativeSection(
+                            kind = kind,
+                            relatives = state.of(kind),
+                            onOpen = onOpenPerson,
+                            onAdd = { onAddRelative(viewModel.personId, kind) },
+                            onRemove = { other -> pendingRemoval = other },
+                        )
+                    }
+                }
 
-            if (!person.notes.isNullOrBlank()) {
-                SectionRule(
-                    label = stringResource(R.string.person_notes),
-                    modifier = Modifier.padding(horizontal = 20.dp),
-                )
-                Text(
-                    text = person.notes!!,
-                    style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 4.dp),
-                )
+                if (!person.notes.isNullOrBlank()) {
+                    Column {
+                        SectionRule(
+                            label = stringResource(R.string.person_notes),
+                            modifier = Modifier.padding(horizontal = 20.dp),
+                        )
+                        Text(
+                            text = person.notes!!,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp, vertical = 4.dp),
+                        )
+                    }
+                }
             }
 
             Spacer(Modifier.height(40.dp))

--- a/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/vibethroughcode/ftree/ui/settings/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.verticalScroll
@@ -57,7 +58,8 @@ import com.vibethroughcode.ftree.BuildConfig
 import com.vibethroughcode.ftree.R
 import com.vibethroughcode.ftree.data.KinshipLanguage
 import com.vibethroughcode.ftree.ui.common.SectionRule
-import com.vibethroughcode.ftree.ui.common.readableMeasure
+import com.vibethroughcode.ftree.ui.common.READABLE_MEASURE
+import com.vibethroughcode.ftree.ui.common.ReadingColumns
 import com.vibethroughcode.ftree.ui.theme.FTreeText
 import com.vibethroughcode.ftree.ui.theme.FTreeTheme
 import com.vibethroughcode.ftree.update.AvailableUpdate
@@ -97,14 +99,18 @@ fun SettingsScreen(
     val betaChannel by viewModel.betaChannel.collectAsStateWithLifecycle()
     var confirmingBeta by remember { mutableStateOf(false) }
 
-    // One measure for the screen, so the title above the settings sits over the settings rather
-    // than over the middle of the glass. See `readableMeasure`.
     Scaffold(
-        modifier = modifier.readableMeasure(),
+        modifier = modifier,
         topBar = {
             CenterAlignedTopAppBar(title = { Text(stringResource(R.string.settings_title)) })
         },
     ) { padding ->
+    /*
+     * Settings are not one long thing; they are six short ones, and on a window wide enough for
+     * two they stand beside each other rather than leave half of it empty and make the reader
+     * scroll past the emptiness. The scroll stays outside the columns, so however many there are
+     * the page is still one thing that scrolls.
+     */
     Column(
         modifier = Modifier
             .fillMaxHeight()
@@ -112,154 +118,170 @@ fun SettingsScreen(
             .verticalScroll(rememberScrollState())
             .padding(horizontal = 24.dp),
     ) {
-        SectionRule(stringResource(R.string.settings_section_words))
+        ReadingColumns {
+            Column {
+                SectionRule(stringResource(R.string.settings_section_words))
 
-        Text(
-            stringResource(R.string.settings_words_body),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 4.dp, bottom = 12.dp),
-        )
-        SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
-            SegmentedButton(
-                selected = kinshipLanguage == KinshipLanguage.ENGLISH,
-                onClick = { viewModel.setKinshipLanguage(KinshipLanguage.ENGLISH) },
-                shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
-                modifier = Modifier.testTag(SettingsWordsEnglishTag),
-            ) { Text(stringResource(R.string.settings_words_english)) }
-
-            SegmentedButton(
-                selected = kinshipLanguage == KinshipLanguage.HINDI,
-                onClick = { viewModel.setKinshipLanguage(KinshipLanguage.HINDI) },
-                shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
-                modifier = Modifier.testTag(SettingsWordsHindiTag),
-            ) { Text(stringResource(R.string.settings_words_hindi)) }
-        }
-
-        SectionRule(stringResource(R.string.settings_section_chart))
-
-        SettingsSwitch(
-            title = stringResource(R.string.settings_photos_toggle),
-            body = stringResource(R.string.settings_photos_explainer),
-            checked = photosInChart,
-            onCheckedChange = viewModel::setPhotosInChart,
-            tag = SettingsPhotosToggleTag,
-        )
-
-        SectionRule(stringResource(R.string.settings_section_updates))
-
-        SettingsSwitch(
-            title = stringResource(R.string.settings_updates_toggle),
-            body = stringResource(R.string.settings_updates_explainer),
-            checked = enabled,
-            onCheckedChange = viewModel::setUpdatesEnabled,
-            tag = SettingsUpdatesToggleTag,
-        )
-
-        AnimatedVisibility(visible = enabled) {
-            UpdatePanel(
-                state = state,
-                onCheck = viewModel::check,
-                onDownload = viewModel::download,
-                onCancel = viewModel::cancel,
-                onInstall = { file ->
-                    if (viewModel.canInstall()) {
-                        viewModel.install(file)
-                    } else {
-                        context.startActivity(viewModel.permissionIntent())
-                    }
-                },
-                onSkip = viewModel::skip,
-                onDismiss = viewModel::dismissFailure,
-            )
-        }
-
-        SectionRule(stringResource(R.string.settings_section_data))
-
-        SettingsAction(
-            icon = { Icon(Icons.Default.Upload, contentDescription = null) },
-            title = stringResource(R.string.settings_export),
-            body = stringResource(R.string.settings_export_body),
-            onClick = onExport,
-            modifier = Modifier.testTag(SettingsExportTag),
-        )
-        SettingsAction(
-            icon = { Icon(Icons.Default.Download, contentDescription = null) },
-            title = stringResource(R.string.settings_import),
-            body = stringResource(R.string.settings_import_body),
-            onClick = onImport,
-            modifier = Modifier.testTag(SettingsImportTag),
-        )
-
-        SectionRule(stringResource(R.string.settings_section_about))
-
-        Text(
-            stringResource(R.string.about_body),
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Text(
-            stringResource(R.string.settings_version, BuildConfig.VERSION_NAME),
-            style = FTreeText.record,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 12.dp),
-        )
-
-        TextButton(
-            onClick = {
-                context.startActivity(
-                    Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.RELEASES_PAGE_URL))
+                Text(
+                    stringResource(R.string.settings_words_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp, bottom = 12.dp),
                 )
-            },
-            modifier = Modifier.padding(top = 4.dp),
-        ) {
-            Text(stringResource(R.string.settings_source))
-            Spacer(Modifier.size(6.dp))
-            Icon(Icons.Default.OpenInNew, contentDescription = null, modifier = Modifier.size(16.dp))
-        }
+                SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
+                    SegmentedButton(
+                        selected = kinshipLanguage == KinshipLanguage.ENGLISH,
+                        onClick = { viewModel.setKinshipLanguage(KinshipLanguage.ENGLISH) },
+                        shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                        modifier = Modifier.testTag(SettingsWordsEnglishTag),
+                    ) { Text(stringResource(R.string.settings_words_english)) }
 
-        Text(
-            stringResource(R.string.settings_permissions_title).uppercase(),
-            style = FTreeText.sectionLabel,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 16.dp),
-        )
-        Text(
-            stringResource(R.string.settings_permissions_body),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 4.dp),
-        )
-        Text(
-            stringResource(R.string.about_fonts),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(top = 16.dp),
-        )
+                    SegmentedButton(
+                        selected = kinshipLanguage == KinshipLanguage.HINDI,
+                        onClick = { viewModel.setKinshipLanguage(KinshipLanguage.HINDI) },
+                        shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                        modifier = Modifier.testTag(SettingsWordsHindiTag),
+                    ) { Text(stringResource(R.string.settings_words_hindi)) }
+                }
+            }
+
+            Column {
+                SectionRule(stringResource(R.string.settings_section_chart))
+
+                SettingsSwitch(
+                    title = stringResource(R.string.settings_photos_toggle),
+                    body = stringResource(R.string.settings_photos_explainer),
+                    checked = photosInChart,
+                    onCheckedChange = viewModel::setPhotosInChart,
+                    tag = SettingsPhotosToggleTag,
+                )
+            }
+
+            Column {
+                SectionRule(stringResource(R.string.settings_section_updates))
+
+                SettingsSwitch(
+                    title = stringResource(R.string.settings_updates_toggle),
+                    body = stringResource(R.string.settings_updates_explainer),
+                    checked = enabled,
+                    onCheckedChange = viewModel::setUpdatesEnabled,
+                    tag = SettingsUpdatesToggleTag,
+                )
+
+                AnimatedVisibility(visible = enabled) {
+                    UpdatePanel(
+                        state = state,
+                        onCheck = viewModel::check,
+                        onDownload = viewModel::download,
+                        onCancel = viewModel::cancel,
+                        onInstall = { file ->
+                            if (viewModel.canInstall()) {
+                                viewModel.install(file)
+                            } else {
+                                context.startActivity(viewModel.permissionIntent())
+                            }
+                        },
+                        onSkip = viewModel::skip,
+                        onDismiss = viewModel::dismissFailure,
+                    )
+                }
+            }
+
+            Column {
+                SectionRule(stringResource(R.string.settings_section_data))
+
+                SettingsAction(
+                    icon = { Icon(Icons.Default.Upload, contentDescription = null) },
+                    title = stringResource(R.string.settings_export),
+                    body = stringResource(R.string.settings_export_body),
+                    onClick = onExport,
+                    modifier = Modifier.testTag(SettingsExportTag),
+                )
+                SettingsAction(
+                    icon = { Icon(Icons.Default.Download, contentDescription = null) },
+                    title = stringResource(R.string.settings_import),
+                    body = stringResource(R.string.settings_import_body),
+                    onClick = onImport,
+                    modifier = Modifier.testTag(SettingsImportTag),
+                )
+            }
+
+            Column {
+                SectionRule(stringResource(R.string.settings_section_about))
+
+                Text(
+                    stringResource(R.string.about_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    stringResource(R.string.settings_version, BuildConfig.VERSION_NAME),
+                    style = FTreeText.record,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 12.dp),
+                )
+
+                TextButton(
+                    onClick = {
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW, Uri.parse(BuildConfig.RELEASES_PAGE_URL))
+                        )
+                    },
+                    modifier = Modifier.padding(top = 4.dp),
+                ) {
+                    Text(stringResource(R.string.settings_source))
+                    Spacer(Modifier.size(6.dp))
+                    Icon(Icons.Default.OpenInNew, contentDescription = null, modifier = Modifier.size(16.dp))
+                }
+
+                Text(
+                    stringResource(R.string.settings_permissions_title).uppercase(),
+                    style = FTreeText.sectionLabel,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 16.dp),
+                )
+                Text(
+                    stringResource(R.string.settings_permissions_body),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+                Text(
+                    stringResource(R.string.about_fonts),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 16.dp),
+                )
+            }
+        }
 
         /*
-         * Last on the page, and meant to be.
+         * Last on the page, and meant to be — which is why it is not one of the columns.
          *
          * A beta is an unfinished build of an app somebody keeps their family in. Putting it under
          * the licence notice rather than beside "Check for updates" is the honest placement: it is
          * for people who came looking for it, and nobody should meet it while turning ordinary
-         * updates on.
+         * updates on. Inside the columns it would go wherever there was room, and on a wide window
+         * that could be directly beside the updates switch, so it sits below them all instead and
+         * keeps its own measure.
          */
-        SectionRule(stringResource(R.string.settings_section_beta))
-        SettingsSwitch(
-            title = stringResource(R.string.settings_beta_toggle),
-            body = stringResource(
-                if (enabled) R.string.settings_beta_explainer
-                else R.string.settings_beta_explainer_updates_off
-            ),
-            checked = betaChannel,
-            enabled = enabled,
-            onCheckedChange = { wanted ->
-                // Turning it off is not a decision worth interrupting; turning it on is.
-                if (wanted) confirmingBeta = true else viewModel.setBetaChannel(false)
-            },
-            tag = SettingsBetaToggleTag,
-        )
+        Column(Modifier.widthIn(max = READABLE_MEASURE)) {
+            SectionRule(stringResource(R.string.settings_section_beta))
+            SettingsSwitch(
+                title = stringResource(R.string.settings_beta_toggle),
+                body = stringResource(
+                    if (enabled) R.string.settings_beta_explainer
+                    else R.string.settings_beta_explainer_updates_off
+                ),
+                checked = betaChannel,
+                enabled = enabled,
+                onCheckedChange = { wanted ->
+                    // Turning it off is not a decision worth interrupting; turning it on is.
+                    if (wanted) confirmingBeta = true else viewModel.setBetaChannel(false)
+                },
+                tag = SettingsBetaToggleTag,
+            )
+        }
 
         Spacer(Modifier.height(40.dp))
     }

--- a/app/src/test/java/com/vibethroughcode/ftree/ui/common/ReadableColumnsTest.kt
+++ b/app/src/test/java/com/vibethroughcode/ftree/ui/common/ReadableColumnsTest.kt
@@ -1,0 +1,76 @@
+package com.vibethroughcode.ftree.ui.common
+
+import androidx.compose.ui.unit.dp
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The rule that decides how many columns a pane is read in.
+ *
+ * Written against real widths rather than round numbers, because the widths are the point: these
+ * are the panes the app is actually handed once a navigation rail and a display cutout have taken
+ * their share, and the bug this rule fixes was a landscape phone showing a column of names beside
+ * two hundred points of nothing.
+ */
+class ReadableColumnsTest {
+
+    @Test
+    fun `an upright phone reads in one column`() {
+        assertEquals(1, readableColumns(411.dp))
+        assertEquals(1, readableColumns(360.dp))
+    }
+
+    @Test
+    fun `a landscape phone reads in two`() {
+        // A 914dp window less the rail and the cutout beside it: what the emulator actually gives.
+        assertEquals(2, readableColumns(750.dp))
+        // A narrower phone, where the pane is only just wide enough to be worth splitting.
+        assertEquals(2, readableColumns(644.dp))
+    }
+
+    @Test
+    fun `a tablet reads in three`() {
+        assertEquals(3, readableColumns(1280.dp))
+        assertEquals(3, readableColumns(1600.dp))
+    }
+
+    @Test
+    fun `no column is ever wider than the measure once there is room for two`() {
+        var width = 640
+        while (width <= 2400) {
+            val columns = readableColumns(width.dp)
+            val each = width.toFloat() / columns
+            assertTrue("$width dp in $columns columns is ${each}dp each", each <= 560f)
+            width += 1
+        }
+    }
+
+    @Test
+    fun `no column is ever narrower than a name and a date`() {
+        var width = 1
+        while (width <= 2400) {
+            val columns = readableColumns(width.dp)
+            val each = width.toFloat() / columns
+            assertTrue("$width dp in $columns columns is ${each}dp each", columns == 1 || each >= 320f)
+            width += 1
+        }
+    }
+
+    /**
+     * Just past one measure, splitting would buy two columns too cramped to hold a name and a
+     * date, so the width is taken as a slightly long line instead. This is the only place a column
+     * is allowed past the measure, and it ends where two real columns become possible.
+     */
+    @Test
+    fun `the band above one measure stays a single column`() {
+        assertEquals(1, readableColumns(561.dp))
+        assertEquals(1, readableColumns(639.dp))
+        assertEquals(2, readableColumns(640.dp))
+    }
+
+    @Test
+    fun `a pane with no width still asks for one column`() {
+        assertEquals(1, readableColumns(0.dp))
+    }
+}


### PR DESCRIPTION
Reported twice now: in landscape, People and Settings sit in a column with a wide band of nothing beside them. The alignment was not the problem — I measured it, and the column was anchored exactly where the last fix put it. The **measure** was the problem: 560dp on a pane nearly twice that wide.

### The rule

A line of text has a comfortable length; a screen does not. The answer a typesetter gives to a page too wide for one column is another column, and that is now the rule the whole app shares:

> No column wider than the measure, as few columns as that allows, and the width shared out so none of it is left over.

| pane | columns | each |
|---|---|---|
| 411dp (upright phone) | 1 | 411dp |
| 750dp (landscape phone, after the rail and the cutout) | 2 | 375dp |
| 1280dp (tablet) | 3 | 427dp |

Just above one measure there is a band where splitting would buy two columns too cramped for a name and a date, so a pane there takes the width as a slightly long line instead. That is the only place a column runs past 560dp, and it ends around the width of an upright tablet.

### What changed

- **People** is a grid on that rule. A landscape phone shows six names where it showed three; a tablet shows twenty-one.
- **Settings** and **a person's relatives** use `ReadingColumns`, which gives each section a whole column and drops it into whichever is shortest, so two columns of unequal blocks end level.
- **Beta releases** stays out of the columns. It is meant to be last on the page, and inside them it could have landed beside the updates switch.
- `LocalHasNavigationRail` is deleted. It existed only to anchor the old single column against the rail; nothing that fills its pane needs to know what is beside it.
- Forms — editing a person, adding a relative — keep the single centred measure. Two columns of a form makes the eye hunt for the next field.

### Verification

- 220 unit tests (7 new on the rule itself), 163 instrumented (4 new), lint unchanged at 82.
- Checked on the emulator at three window sizes: upright phone (unchanged), landscape phone, and a 1280×800dp tablet.
- **The new tests were run against a reverted fix**: three of the four fail, one of them reporting that the list "stops 379 points short of the far edge".

🤖 Generated with [Claude Code](https://claude.com/claude-code)