### PR TITLE
chore: version 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ betas leading up to a stable release are folded into that release's entry here.
 
 ---
 
+## [0.8.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.8.0) — 2026-09-09
+
+**See the photograph you saved, and get the whole screen back on a phone held sideways.**
+
+- **Tap somebody's photograph to see it.** It opens whole rather than as a circle — the circle is a
+  display decision and the file was never round, so for a photo that arrived in somebody else's tree
+  this is the first time anyone sees what the circle was cutting off. There is deliberately no
+  pinch-zoom: photos are stored at 512px on the long edge to keep a large family and its `.ftree`
+  small, and offering the gesture would promise detail the file does not hold.
+- **A wide window is used rather than left half empty.** People, Settings and a person's relatives
+  now break into as many columns as the width deserves — one on an upright phone, two on a phone
+  held sideways, three on a tablet — instead of one column of reading matter beside a band of
+  nothing. A landscape phone shows six names where it showed three; a tablet shows twenty-one. The
+  rule is that no column runs past a comfortable line length and none of the width is left over,
+  which is the answer a typesetter gives to a page too wide for one column.
+
+Everything from 0.8.0-beta.1 and beta.2, promoted unchanged.
+
+## [0.7.1](https://github.com/thisisankit27/f-tree/releases/tag/v0.7.1) — 2026-09-07
+
+- **The app icon is the mark from the website.** The launcher showed something different from the
+  site's logo; they are now one mark.
+- The README is a front door rather than a set of build notes, and the site's calls to action look
+  like buttons.
+
 ## [0.7.0](https://github.com/thisisankit27/f-tree/releases/tag/v0.7.0) — 2026-09-07
 
 **Ask how two people are related from the chart that answers it, and turn the whole thing sideways.**

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,8 +21,8 @@ android {
         applicationId = "com.vibethroughcode.ftree"
         minSdk = 26
         targetSdk = 36
-        versionCode = 25
-        versionName = "0.8.0-beta.2"
+        versionCode = 26
+        versionName = "0.8.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
Promotes **0.8.0-beta.1** and **0.8.0-beta.2** to a stable release. No code changes — this is the version bump and the changelog.

`versionCode` 25 → **26**, `versionName` → **0.8.0**.

### What ships

- **Tap somebody's photograph to see it.** Opens whole rather than as a circle; no pinch-zoom, deliberately, because 512px on the long edge is what keeps a large family's `.ftree` small and the gesture would promise detail the file doesn't hold.
- **A wide window is used rather than left half empty.** People, Settings and a person's relatives break into as many columns as the width deserves — one upright, two in landscape, three on a tablet. A landscape phone shows six names where it showed three; a tablet twenty-one.

### Also

Backfills the **0.7.1** changelog entry. It was never written, so a file that opens with "all notable changes to f-tree" skipped a released version and jumped 0.7.0 → 0.8.0.

### Verified

`./gradlew testDebugUnitTest lintDebug` — the same checks the release workflow gates on — pass locally: 220 unit tests, lint clean at its usual 82. The app code is byte-identical to what was already tested on device as beta.2 (163 instrumented tests), so this promotes something already exercised rather than something new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)