### PR TITLE
feat: light and dark on the site, with a toggle in the navbar

### DIFF
--- a/site/app.js
+++ b/site/app.js
@@ -150,6 +150,82 @@
     if (box) box.hidden = true;
   }
 
+  /* ------------------------------------------------------------------ theme */
+  /*
+   * Light and dark. The head script has already put the stored choice on <html> before the
+   * first paint; all this does is flip it and remember it.
+   *
+   * The absence of data-theme is a state, not a missing value: it means "whatever the system
+   * says", which is how the page starts for everyone who has never touched the toggle. So the
+   * toggle asks what is actually on screen — matchMedia, not the attribute — and sets the
+   * opposite. Choosing the mode you are already in is how you get back to following the system,
+   * so picking light on a light system clears the choice rather than pinning it.
+   */
+
+  var DARK_GROUND = '#10150f';
+  var LIGHT_GROUND = '#f7f6f1';
+
+  function systemPrefersDark() {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+
+  function currentTheme() {
+    var set = document.documentElement.getAttribute('data-theme');
+    if (set === 'dark' || set === 'light') return set;
+    return systemPrefersDark() ? 'dark' : 'light';
+  }
+
+  /*
+   * Both metas carry the same value on purpose. The pair in the markup is media-scoped so that
+   * the browser chrome is right with this script switched off; once a choice has been made the
+   * matching one has to give the chosen answer, and the quiet way to guarantee that is for both
+   * to agree.
+   */
+  function paintBrowserChrome(theme) {
+    var ground = theme === 'dark' ? DARK_GROUND : LIGHT_GROUND;
+    document.querySelectorAll('meta[name="theme-color"]').forEach(function (meta) {
+      meta.setAttribute('content', ground);
+    });
+  }
+
+  function describeToggle(btn, theme) {
+    var next = theme === 'dark' ? 'light' : 'dark';
+    btn.setAttribute('aria-label', 'Switch to ' + next + ' mode');
+    btn.setAttribute('title', 'Switch to ' + next + ' mode');
+  }
+
+  function wireTheme() {
+    var btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+
+    var system = window.matchMedia('(prefers-color-scheme: dark)');
+
+    var sync = function () {
+      var theme = currentTheme();
+      describeToggle(btn, theme);
+      paintBrowserChrome(theme);
+    };
+
+    btn.addEventListener('click', function () {
+      var next = currentTheme() === 'dark' ? 'light' : 'dark';
+      if (next === (system.matches ? 'dark' : 'light')) {
+        // Back in step with the system: stop overriding it rather than pinning today's answer.
+        document.documentElement.removeAttribute('data-theme');
+        try { localStorage.removeItem('ftree.theme'); } catch (e) { /* nothing to remember with */ }
+      } else {
+        document.documentElement.setAttribute('data-theme', next);
+        try { localStorage.setItem('ftree.theme', next); } catch (e) { /* a convenience, not a requirement */ }
+      }
+      sync();
+    });
+
+    // Only reaches the page while no explicit choice is stored, which is exactly when it should.
+    if (system.addEventListener) system.addEventListener('change', sync);
+    else if (system.addListener) system.addListener(sync);
+
+    sync();
+  }
+
   /* ------------------------------------------------- the one interactive node */
   /*
    * The hero chart's dashed card is the app's whole argument in one gesture: an unnamed
@@ -267,7 +343,7 @@
     btn.setAttribute('aria-label', 'Play the demo — 17 seconds, no sound');
     btn.innerHTML =
       '<span class="disc" aria-hidden="true">' +
-      '<svg width="24" height="24" viewBox="0 0 24 24" fill="#fff"><path d="M8 5.5v13l11-6.5z"/></svg>' +
+      '<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5.5v13l11-6.5z"/></svg>' +
       '</span>';
 
     btn.addEventListener('click', function () {
@@ -327,6 +403,7 @@
 
   var onThanks = !!document.getElementById('apk-link');
 
+  wireTheme();
   wireNamingSlot();
   wireDemo();
 

--- a/site/index.html
+++ b/site/index.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>f-tree — a private family tree app for Android, with a relationship finder</title>
 <meta name="description" content="A free, offline family tree app for Android. Ask how any two people are related and it names the relationship and shows the line. Record relatives whose names nobody remembers, keep everything on your phone, and share a branch as a file. No account, no server. English and Hindi kinship terms.">
+<meta name="theme-color" content="#f7f6f1" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#10150f" media="(prefers-color-scheme: dark)">
 <link rel="icon" href="favicon.svg" type="image/svg+xml">
 <link rel="canonical" href="https://ftree.vibethroughcode.com/">
 
@@ -51,6 +53,27 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=JetBrains+Mono:wght@400;500&display=swap">
 <link rel="stylesheet" href="style.css">
+
+<!--
+  The theme, decided before the first paint.
+
+  This runs where it sits, in the head, so the ground is already the right colour when the page
+  first draws — pushed to the end of the body it would flash bone at a reader who chose dark.
+  Nothing is stamped when there is no stored choice: the absence of the attribute is what lets
+  the prefers-color-scheme rule in style.css keep following the system, including live, while
+  data-js is what reveals the toggle (see style.css).
+-->
+<script>
+(function () {
+  var root = document.documentElement;
+  root.setAttribute('data-js', '');
+  try {
+    var saved = localStorage.getItem('ftree.theme');
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) { /* private windows and blocked storage both land here; the system decides */ }
+})();
+</script>
+
 </head>
 <body>
 
@@ -58,12 +81,12 @@
   <div class="shell">
     <a class="wordmark" href="./">
       <svg width="26" height="26" viewBox="0 0 32 32" aria-hidden="true">
-        <rect width="32" height="32" rx="7" fill="#2A5138"/>
-        <g fill="none" stroke="#CDE6D5" stroke-width="1.7" stroke-linecap="round">
+        <rect width="32" height="32" rx="7" fill="var(--mark-tile)"/>
+        <g fill="none" stroke="var(--mark-line)" stroke-width="1.7" stroke-linecap="round">
           <circle cx="11" cy="9.5" r="3.1"/><circle cx="21" cy="9.5" r="3.1"/>
           <path d="M14.1 9.5h3.8"/><path d="M16 12.6v3.4M9 16h14M9 16v2.6M23 16v2.6"/>
           <circle cx="9" cy="22" r="3.1"/>
-          <circle cx="23" cy="22" r="3.1" stroke="#E3C38C" stroke-dasharray="2.2 2"/>
+          <circle cx="23" cy="22" r="3.1" stroke="var(--mark-dash)" stroke-dasharray="2.2 2"/>
         </g>
       </svg>
       f-tree
@@ -74,6 +97,15 @@
       <a class="nav-link" href="#merge">Sharing</a>
       <a class="nav-link" href="playground/">Viewer</a>
       <a class="nav-link" href="https://github.com/thisisankit27/f-tree">Source</a>
+      <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Switch theme">
+        <svg class="i-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20.5 14.3A8.5 8.5 0 0 1 9.7 3.5a8.5 8.5 0 1 0 10.8 10.8z"/>
+        </svg>
+        <svg class="i-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4.1"/>
+          <path d="M12 2.6v2.2M12 19.2v2.2M4.35 4.35l1.55 1.55M18.1 18.1l1.55 1.55M2.6 12h2.2M19.2 12h2.2M4.35 19.65 5.9 18.1M18.1 5.9l1.55-1.55"/>
+        </svg>
+      </button>
       <a class="nav-cta" href="thanks/">Download</a>
     </nav>
   </div>
@@ -392,7 +424,7 @@
 <section class="band band-deep">
   <div class="shell split">
     <div>
-      <p class="rule-label" style="color:#8fa694">Local first</p>
+      <p class="rule-label">Local first</p>
       <h2>No account, because there's no server.</h2>
       <p>
         f-tree never asks who you are, because your tree never leaves the phone. That isn't a
@@ -406,8 +438,7 @@
         it only asks.
       </p>
       <p style="margin-top:26px">
-        <a class="btn btn-quiet" style="border-color:#4a6a55;color:#cde6d5"
-           href="https://github.com/thisisankit27/f-tree">Read the source</a>
+        <a class="btn btn-quiet" href="https://github.com/thisisankit27/f-tree">Read the source</a>
       </p>
     </div>
     <ul class="nots">

--- a/site/playground/index.html
+++ b/site/playground/index.html
@@ -2,7 +2,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <title>Viewer — open a whole f-tree on a big screen</title>
 <meta name="description" content="Open an exported .ftree file and see every person in it at once, including the ones no relationship reaches. Runs entirely in your browser; the file never leaves your device.">
-<meta name="theme-color" content="#f7f6f1">
+<meta name="theme-color" content="#f7f6f1" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#10150f" media="(prefers-color-scheme: dark)">
 <link rel="icon" href="../favicon.svg" type="image/svg+xml">
 <link rel="canonical" href="https://ftree.vibethroughcode.com/playground/">
 
@@ -16,7 +17,25 @@
 <link href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400;1,7..72,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="playground.css">
 
-<div class="viewer" id="viewer" data-state="empty" data-theme="light">
+<!--
+  The theme, decided before the first paint. main.js is a module and therefore deferred, so
+  leaving this to it would show a bone-white screen to somebody who asked for dark. Nothing is
+  stamped when no choice has been stored: that absence means "follow the system", and main.js
+  resolves it the same way (see loadPrefs).
+-->
+<script>
+(function () {
+  var theme = null;
+  try { theme = (JSON.parse(localStorage.getItem('ftree.viewer') || '{}') || {}).theme; }
+  catch (e) { /* private windows and blocked storage both land here; the system decides */ }
+  if (theme !== 'dark' && theme !== 'light') {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.setAttribute('data-theme', theme);
+})();
+</script>
+
+<div class="viewer" id="viewer" data-state="empty">
 
   <header class="bar">
     <a class="wordmark" href="../" title="Back to f-tree">
@@ -35,6 +54,17 @@
     </div>
 
     <div class="bar-spacer"></div>
+
+    <!-- Outside .bar-tools on purpose: the opener needs this too, and .bar-tools is loaded-only. -->
+    <button type="button" class="icon theme-btn" id="theme-btn" aria-label="Switch theme">
+      <svg class="i-moon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20.5 14.3A8.5 8.5 0 0 1 9.7 3.5a8.5 8.5 0 1 0 10.8 10.8z"/>
+      </svg>
+      <svg class="i-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4.1"/>
+        <path d="M12 2.6v2.2M12 19.2v2.2M4.35 4.35l1.55 1.55M18.1 18.1l1.55 1.55M2.6 12h2.2M19.2 12h2.2M4.35 19.65 5.9 18.1M18.1 5.9l1.55-1.55"/>
+      </svg>
+    </button>
 
     <div class="bar-tools" data-when="loaded">
       <div class="search" role="search">

--- a/site/playground/main.js
+++ b/site/playground/main.js
@@ -41,8 +41,17 @@ const chart = new Chart($('canvas'), {
 
 /* ------------------------------------------------------------------ preferences */
 
+/*
+ * `theme` is three-valued, not two: 'light', 'dark', or null for "whatever the system says".
+ * Null is the state everyone starts in, and choosing the mode you are already in returns you to
+ * it — so a reader who follows their system at dusk keeps following it, rather than being pinned
+ * to whichever answer was true the first time they opened the page.
+ */
+const systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+const resolvedTheme = () => prefs.theme ?? (systemTheme.matches ? 'dark' : 'light');
+
 function loadPrefs() {
-  const fallback = { theme: 'light', photos: true, big: false, status: true };
+  const fallback = { theme: null, photos: true, big: false, status: true };
   try {
     const saved = JSON.parse(localStorage.getItem('ftree.viewer') ?? '{}');
     return { ...fallback, ...saved };
@@ -58,19 +67,35 @@ function savePrefs() {
 }
 
 function applyPrefs() {
-  viewer.dataset.theme = prefs.theme;
+  const theme = resolvedTheme();
+  // On <html>, not on .viewer: the inline script in the head stamps it there before first paint.
+  document.documentElement.dataset.theme = theme;
   viewer.dataset.big = String(prefs.big);
   viewer.dataset.status = prefs.status ? 'on' : 'off';
-  chart.setTheme(prefs.theme);
+  chart.setTheme(theme);
   chart.showPhotos = prefs.photos;
-  document.querySelector('meta[name="theme-color"]')
-    ?.setAttribute('content', prefs.theme === 'dark' ? '#10150f' : '#f7f6f1');
+  // Both metas are media-scoped so the chrome is right before this runs; giving them the same
+  // value is what makes whichever one matches agree with an explicit choice.
+  for (const meta of document.querySelectorAll('meta[name="theme-color"]')) {
+    meta.setAttribute('content', theme === 'dark' ? '#10150f' : '#f7f6f1');
+  }
+  const next = theme === 'dark' ? 'light' : 'dark';
+  $('theme-btn').setAttribute('aria-label', `Switch to ${next} mode`);
+  $('theme-btn').setAttribute('title', `Switch to ${next} mode`);
   for (const [key, on] of Object.entries({
-    theme: prefs.theme === 'dark', photos: prefs.photos, big: prefs.big, status: prefs.status,
+    theme: theme === 'dark', photos: prefs.photos, big: prefs.big, status: prefs.status,
   })) {
     $('display-menu').querySelector(`[data-toggle="${key}"]`)?.setAttribute('aria-checked', String(on));
   }
   chart.resize();
+}
+
+/** Flips the lights, and drops back to following the system when that is what you picked. */
+function toggleTheme() {
+  const next = resolvedTheme() === 'dark' ? 'light' : 'dark';
+  prefs.theme = next === (systemTheme.matches ? 'dark' : 'light') ? null : next;
+  savePrefs();
+  applyPrefs();
 }
 
 /* ------------------------------------------------------------------ loading a file */
@@ -702,8 +727,8 @@ function wireChrome() {
     const button = e.target.closest('button');
     if (!button) return;
     const toggle = button.dataset.toggle;
-    if (toggle === 'theme') prefs.theme = prefs.theme === 'dark' ? 'light' : 'dark';
-    else if (toggle) prefs[toggle] = !prefs[toggle];
+    if (toggle === 'theme') { toggleTheme(); return; }
+    if (toggle) prefs[toggle] = !prefs[toggle];
     if (button.dataset.action === 'fullscreen') toggleFullscreen();
     if (button.dataset.action === 'shortcuts') { $('shortcuts').hidden = false; menu.hidden = true; }
     if (toggle) { savePrefs(); applyPrefs(); }
@@ -722,6 +747,12 @@ function wireChrome() {
     if (action === 'relate-from') openRelate(state.selected);
   });
 
+  $('theme-btn').addEventListener('click', toggleTheme);
+  // Only moves the page while prefs.theme is null, which is exactly when it should.
+  const followSystem = () => { if (prefs.theme === null) applyPrefs(); };
+  if (systemTheme.addEventListener) systemTheme.addEventListener('change', followSystem);
+  else if (systemTheme.addListener) systemTheme.addListener(followSystem);
+
   window.addEventListener('resize', () => chart.resize());
   document.addEventListener('fullscreenchange', () => chart.resize());
 }
@@ -738,6 +769,11 @@ function wireKeys() {
       return;
     }
     if (typing || e.metaKey || e.ctrlKey || e.altKey) return;
+
+    // Turning the lights down is a property of the page, not of the chart, so it is answered
+    // above the guard: it has to work while somebody is still deciding whether to open a file.
+    if (e.key === 'd' || e.key === 'D') { toggleTheme(); return; }
+
     if (viewer.dataset.state !== 'loaded') return;
 
     switch (e.key) {
@@ -754,11 +790,6 @@ function wireKeys() {
         break;
       case '-': case '_':
         chart.zoomBy(1 / 1.3);
-        break;
-      case 'd': case 'D':
-        prefs.theme = prefs.theme === 'dark' ? 'light' : 'dark';
-        savePrefs();
-        applyPrefs();
         break;
       case 'i': case 'I':
         setView(state.view === 'chart' ? 'index' : 'chart');

--- a/site/playground/playground.css
+++ b/site/playground/playground.css
@@ -31,6 +31,13 @@
   --sage-container: #cde6d5;
   --brass: #8a6420;
   --brass-surface: #f7eedc;
+  /* Roles rather than hues: forest is a dark green carrying white by day, sage a pale green
+     carrying dark green by night, so the controls ask for the job and not the colour. */
+  --forest-hover: var(--forest-deep);
+  --on-forest: #fff;
+  --on-sage: var(--forest-deep);
+  --glyph-moon: block;
+  --glyph-sun: none;
   --rule: #d8d7cd;
   --rule-strong: #b9b8ac;
   /* Matches chart.js's `departed`: the ground for somebody no longer living. */
@@ -59,7 +66,12 @@
   padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 
-.viewer[data-theme="dark"] {
+/*
+ * Night, from the app's own Color.kt. Stamped on <html> rather than on .viewer so that the
+ * inline script in the head can set it before the first paint — main.js is a module, so it is
+ * deferred, and waiting for it would show a bone-white screen to somebody who asked for dark.
+ */
+:root[data-theme="dark"] .viewer {
   --bone: #10150f;
   --bone-dim: #161c15;
   --raised: #1a211a;
@@ -74,6 +86,11 @@
   --rule-strong: #465146;
   --departed: #11160f;
   --shadow: 0 10px 34px rgba(0, 0, 0, .45);
+  --forest-hover: #b6dbc3;
+  --on-forest: #06371c;
+  --on-sage: #abe4bc;
+  --glyph-moon: none;
+  --glyph-sun: block;
   color-scheme: dark;
 }
 
@@ -187,6 +204,18 @@
   font-size: calc(15px * var(--ui));
 }
 
+/*
+ * Light and dark, in the bar rather than only in the Display menu.
+ *
+ * The menu lives inside data-when="loaded", so until this button existed there was no way to
+ * turn the lights down while looking at the opener — which is the screen somebody stares at
+ * longest before deciding whether to hand over a file. It is the same round control as the
+ * zoom buttons, and it offers the mode you are not in.
+ */
+.theme-btn svg { display: block; }
+.theme-btn .i-moon { display: var(--glyph-moon); }
+.theme-btn .i-sun { display: var(--glyph-sun); }
+
 .link-btn {
   font-family: var(--mono);
   font-size: calc(12px * var(--ui));
@@ -209,8 +238,7 @@
   gap: 2px;
 }
 .segmented button { border: 0; background: none; padding: calc(6px * var(--ui)) calc(13px * var(--ui)); }
-.segmented button[aria-pressed="true"] { background: var(--forest); color: #fff; }
-.viewer[data-theme="dark"] .segmented button[aria-pressed="true"] { color: var(--forest-deep); }
+.segmented button[aria-pressed="true"] { background: var(--forest); color: var(--on-forest); }
 
 .zoom { display: flex; align-items: center; gap: calc(6px * var(--ui)); }
 .zoom-level {
@@ -424,9 +452,8 @@ canvas:focus-visible { outline: 2px solid var(--forest); outline-offset: -2px; }
   font-size: 14px;
   padding: 13px 24px;
 }
-.btn.primary { background: var(--forest); border-color: var(--forest); color: #fff; }
-.viewer[data-theme="dark"] .btn.primary { color: var(--forest-deep); }
-.btn.primary:hover { background: var(--forest-deep); border-color: var(--forest-deep); color: #fff; }
+.btn.primary { background: var(--forest); border-color: var(--forest); color: var(--on-forest); }
+.btn.primary:hover { background: var(--forest-hover); border-color: var(--forest-hover); color: var(--on-forest); }
 .btn.quiet { background: transparent; }
 
 .assurance {
@@ -657,9 +684,8 @@ canvas:focus-visible { outline: 2px solid var(--forest); outline-offset: -2px; }
   padding: calc(15px * var(--ui));
   border-radius: 12px;
   background: var(--sage-container);
-  color: var(--forest-deep);
+  color: var(--on-sage);
 }
-.viewer[data-theme="dark"] .r-term { color: var(--ink); }
 .r-term b { font-weight: 700; }
 .r-none { background: var(--brass-surface); color: var(--ink); }
 .r-chain { list-style: none; margin: 0; padding: 0; display: grid; gap: 0; }

--- a/site/style.css
+++ b/site/style.css
@@ -4,6 +4,16 @@
  * The palette and the three typographic voices are lifted directly from the app
  * (ui/theme/Color.kt, ui/theme/Type.kt) so the site and the product read as the same
  * object. Brass keeps the single job it has in the app: marking what is not known.
+ *
+ * Both palettes are the app's own — bone and forest ink by day, the app's night ground and
+ * sage by night — so the site, the viewer (playground/playground.css, playground/chart.js)
+ * and the product are recognisably one thing in either mode.
+ *
+ * Roles, not just colours. A handful of tokens below name a *job* rather than a hue
+ * (--on-forest, --on-sage, --forest-hover, --deep) because those jobs do not map onto the
+ * same colour in both modes: forest is a dark green carrying white text by day, and sage is
+ * a pale green carrying dark green text by night. Rules further down ask for the role, so
+ * they never need to know which mode they are in.
  */
 
 :root {
@@ -29,12 +39,143 @@
   --rule: #c1c9c0;
   --rule-strong: #9aa69b;
 
+  /* Roles. See the note above. */
+  --forest-hover: var(--forest-deep);   /* the pressed/hover shade of the accent */
+  --on-forest: #fff;                    /* ink on a forest ground: the CTA, the primary button */
+  --on-sage: var(--forest-deep);        /* ink on a sage ground: a named card, a step number */
+
+  /* The wordmark tile. A launcher icon, so it holds its colour across both modes. */
+  --mark-tile: #2a5138;
+  --mark-line: #cde6d5;
+  --mark-dash: #e3c38c;
+
+  /* The "local first" slab is a dark green panel in both modes; only its ground shifts. */
+  --deep: var(--forest-deep);
+  --deep-ink: #dfe7e0;
+  --deep-ink-soft: #b3c4b8;
+  --deep-faint: #8fa694;
+  --deep-rule: rgba(179, 196, 184, .22);
+  --deep-hair: #c1c9c0;    /* the rule-label's hairline; --rule is tuned for the page, not this band */
+  --deep-brass: #f7eedc;   /* the "no" prefix; --brass-surface goes dark and would vanish here */
+  --deep-btn-line: #4a6a55;
+  --deep-btn-ink: #cde6d5;
+
+  /* The install page's one warning box. */
+  --notice-line: #e3c38c;
+  --notice-ink: #4a3810;
+  --notice-strong: #2c1d00;
+
+  --shadow-soft: 0 1px 2px rgba(12, 36, 23, .04);
+  --shadow-cast: 0 12px 32px -18px rgba(12, 36, 23, .22);
+  --shadow-disc: 0 6px 20px rgba(12, 36, 23, .28);
+
   --serif: "Literata", Georgia, "Times New Roman", serif;
   --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
   --sans: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 
   --gutter: clamp(20px, 5vw, 64px);
   --measure: 1220px;
+
+  /* The toggle offers the mode you are not in, so the glyph is the opposite of the ground. */
+  --glyph-moon: block;
+  --glyph-sun: none;
+}
+
+/*
+ * Night.
+ *
+ * Two entry points, one palette, so the block is written twice and the two copies must be
+ * kept identical — edit one, edit the other. The media query is what a reader with a dark
+ * system and no stored choice gets (it is also the whole of dark mode with JavaScript off);
+ * the attribute is what the masthead toggle sets. `:not([data-theme="light"])` is what lets
+ * an explicit "light" win over a dark system.
+ */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --bone: #10150f;
+    --bone-raised: #1a211a;
+    --bone-dim: #181d17;
+    --bone-sunk: #0b100a;
+
+    --ink: #e0e4dd;
+    --ink-soft: #c1c9c0;
+    --ink-faint: #8b938a;   /* 5.4:1 on the dim band, the lowest-contrast ground it lands on */
+
+    --forest: #8fc7a1;
+    --forest-deep: #0c2417;
+    --sage: #24402e;
+    --sage-line: #8fc7a1;
+
+    --brass: #e3c38c;
+    --brass-surface: #2c2618;
+
+    --rule: #333c33;
+    --rule-strong: #5c665c;
+
+    --forest-hover: #b6dbc3;
+    --on-forest: #06371c;
+    --on-sage: #abe4bc;
+
+    --mark-tile: #2f5c3f;
+
+    --deep: #132b1c;
+
+    --notice-line: #5e4100;
+    --notice-ink: #e8dcc4;
+    --notice-strong: #ffdea8;
+
+    --shadow-soft: 0 1px 2px rgba(0, 0, 0, .5);
+    --shadow-cast: 0 14px 34px -18px rgba(0, 0, 0, .75);
+    --shadow-disc: 0 6px 20px rgba(0, 0, 0, .55);
+
+    --glyph-moon: none;
+    --glyph-sun: block;
+  }
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --bone: #10150f;
+  --bone-raised: #1a211a;
+  --bone-dim: #181d17;
+  --bone-sunk: #0b100a;
+
+  --ink: #e0e4dd;
+  --ink-soft: #c1c9c0;
+  --ink-faint: #8b938a;   /* 5.4:1 on the dim band, the lowest-contrast ground it lands on */
+
+  --forest: #8fc7a1;
+  --forest-deep: #0c2417;
+  --sage: #24402e;
+  --sage-line: #8fc7a1;
+
+  --brass: #e3c38c;
+  --brass-surface: #2c2618;
+
+  --rule: #333c33;
+  --rule-strong: #5c665c;
+
+  --forest-hover: #b6dbc3;
+  --on-forest: #06371c;
+  --on-sage: #abe4bc;
+
+  --mark-tile: #2f5c3f;
+
+  --deep: #132b1c;
+
+  --notice-line: #5e4100;
+  --notice-ink: #e8dcc4;
+  --notice-strong: #ffdea8;
+
+  --shadow-soft: 0 1px 2px rgba(0, 0, 0, .5);
+  --shadow-cast: 0 14px 34px -18px rgba(0, 0, 0, .75);
+  --shadow-disc: 0 6px 20px rgba(0, 0, 0, .55);
+
+  --glyph-moon: none;
+  --glyph-sun: block;
 }
 
 * { box-sizing: border-box; }
@@ -112,15 +253,67 @@ input:focus-visible {
   font-family: var(--sans);
   font-size: 14px;
   font-weight: 500;
-  color: #fff;
+  color: var(--on-forest);
   background: var(--forest);
   padding: 8px 16px;
   border-radius: 999px;
   text-decoration: none;
 }
-.masthead .nav-cta:hover { background: var(--forest-deep); text-decoration: none; }
+.masthead .nav-cta:hover { background: var(--forest-hover); text-decoration: none; }
 @media (max-width: 620px) {
   .masthead nav .nav-link { display: none; }
+}
+
+
+/* ---------------------------------------------------------- light and dark */
+/*
+ * The toggle is a JavaScript control, so it is hidden until the inline script in the head has
+ * marked the document as scripted — the same bargain the demo's play button makes. With
+ * JavaScript off the page still follows prefers-color-scheme; it just cannot be overridden,
+ * and no dead button is offered.
+ *
+ * It sits outside .nav-link, so unlike the section links it survives on a phone: on a small
+ * screen the nav is the wordmark, this, and the download button.
+ */
+
+.theme-toggle { display: none; }
+:root[data-js] .theme-toggle {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border-radius: 999px;
+  border: 1px solid var(--rule);
+  background: transparent;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: border-color .15s ease, color .15s ease, background-color .15s ease;
+}
+.theme-toggle:hover {
+  border-color: var(--forest);
+  color: var(--forest);
+  background: var(--bone-dim);
+}
+.theme-toggle svg { display: block; }
+.theme-toggle .i-moon { display: var(--glyph-moon); }
+.theme-toggle .i-sun { display: var(--glyph-sun); }
+
+/*
+ * Repainting the whole page on a click is the one place this site animates a colour, and it is
+ * worth it: without it the swap reads as a flicker rather than as the lights being turned down.
+ * Only the two grounds and the body text are transitioned — transitioning everything would drag
+ * the hairlines and the chart along with it and cost more than it buys.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  :root[data-js] body,
+  :root[data-js] .masthead,
+  :root[data-js] .band-sunk,
+  :root[data-js] .slab,
+  :root[data-js] .chart-frame {
+    transition: background-color .2s ease, color .2s ease, border-color .2s ease;
+  }
 }
 
 /* ------------------------------------------------------- register headings */
@@ -231,8 +424,8 @@ h2.rule-label,
 .btn:hover { text-decoration: none; }
 .btn:active { transform: translateY(1px); }
 
-.btn-primary { background: var(--forest); color: #fff; }
-.btn-primary:hover { background: var(--forest-deep); }
+.btn-primary { background: var(--forest); color: var(--on-forest); }
+.btn-primary:hover { background: var(--forest-hover); }
 
 .btn-quiet {
   background: transparent;
@@ -298,7 +491,7 @@ h2.rule-label,
   border: 1px solid var(--rule);
   border-radius: 14px;
   padding: 10px 10px 0;
-  box-shadow: 0 1px 2px rgba(12, 36, 23, .04), 0 12px 32px -18px rgba(12, 36, 23, .22);
+  box-shadow: var(--shadow-soft), var(--shadow-cast);
 }
 .chart-stage { position: relative; }
 .chart-stage svg { display: block; width: 100%; height: auto; }
@@ -353,7 +546,7 @@ h2.rule-label,
 .node-slot:focus-visible .node-card { stroke-width: 2.5; stroke-dasharray: none; }
 
 .node-named .node-card { fill: var(--sage); stroke: var(--forest); stroke-dasharray: none; }
-.node-named .node-name { fill: var(--forest-deep); font-style: normal; }
+.node-named .node-name { fill: var(--on-sage); font-style: normal; }
 
 .name-input {
   position: absolute;
@@ -361,7 +554,7 @@ h2.rule-label,
   font-size: 15px;
   font-weight: 600;
   text-align: center;
-  color: var(--forest-deep);
+  color: var(--on-sage);
   background: var(--bone-raised);
   border: 2px solid var(--forest);
   border-radius: 8px;
@@ -372,7 +565,7 @@ h2.rule-label,
 
 .band { padding: clamp(52px, 7vw, 92px) 0; }
 .band-sunk { background: var(--bone-dim); border-block: 1px solid var(--rule); }
-.band-deep { background: var(--forest-deep); color: #dfe7e0; }
+.band-deep { background: var(--deep); color: var(--deep-ink); }
 
 /* Note: h2.rule-label deliberately out-specifies this — see the rule above the hero. */
 .band h2 {
@@ -384,7 +577,18 @@ h2.rule-label,
   text-wrap: balance;
 }
 .band p { margin: 0 0 18px; color: var(--ink-soft); max-width: 34em; }
-.band-deep p { color: #b3c4b8; }
+.band-deep p { color: var(--deep-ink-soft); }
+/*
+ * The deep band brings its own ground with it, so its label, its rule and its one button are
+ * set from the band's own tokens rather than the page's — they must read on dark green in
+ * either mode, not on whatever the page happens to be.
+ */
+.band-deep .rule-label { color: var(--deep-faint); }
+.band-deep .rule-label::after { background: var(--deep-hair); }
+.band-deep .btn-quiet { border-color: var(--deep-btn-line); color: var(--deep-btn-ink); }
+.band-deep .btn-quiet:hover { border-color: var(--deep-btn-ink); background: rgba(223, 231, 224, .07); }
+.band-deep a:focus-visible,
+.band-deep button:focus-visible { outline-color: var(--deep-btn-ink); }
 
 .split {
   display: grid;
@@ -435,15 +639,15 @@ h2.rule-label,
   align-items: baseline;
   gap: 14px;
   padding: 13px 0;
-  border-bottom: 1px solid rgba(179, 196, 184, .22);
+  border-bottom: 1px solid var(--deep-rule);
   font-family: var(--mono);
   font-size: 14px;
-  color: #dfe7e0;
+  color: var(--deep-ink);
 }
 .nots li::before {
   content: "no";
   flex: none;
-  color: var(--brass-surface);
+  color: var(--deep-brass);
   opacity: .8;
   font-size: 11px;
   letter-spacing: .14em;
@@ -517,11 +721,12 @@ h2.rule-label,
   height: 66px;
   border-radius: 999px;
   background: var(--forest);
-  box-shadow: 0 6px 20px rgba(12, 36, 23, .28);
+  color: var(--on-forest);   /* the triangle inside is filled with currentColor */
+  box-shadow: var(--shadow-disc);
   transition: background-color .15s ease, transform .15s ease;
 }
 .demo-play .disc svg { margin-left: 3px; }   /* a triangle looks off-centre when it is centred */
-.demo-play:hover .disc { background: var(--forest-deep); }
+.demo-play:hover .disc { background: var(--forest-hover); }
 .demo-play:focus-visible { outline: 2px solid var(--forest); outline-offset: 3px; }
 @media (prefers-reduced-motion: no-preference) {
   .demo-play:hover .disc { transform: scale(1.05); }
@@ -626,7 +831,7 @@ h2.rule-label,
   place-items: center;
   border-radius: 50%;
   background: var(--sage);
-  color: var(--forest-deep);
+  color: var(--on-sage);
   font-family: var(--mono);
   font-size: 13px;
   font-weight: 500;
@@ -657,13 +862,13 @@ h2.rule-label,
   gap: 14px;
   padding: 18px 20px;
   background: var(--brass-surface);
-  border: 1px solid #e3c38c;
+  border: 1px solid var(--notice-line);
   border-radius: 12px;
   font-size: 15.5px;
   line-height: 1.55;
-  color: #4a3810;
+  color: var(--notice-ink);
 }
-.notice strong { color: #2c1d00; }
+.notice strong { color: var(--notice-strong); }
 
 .hash {
   font-family: var(--mono);

--- a/site/thanks/index.html
+++ b/site/thanks/index.html
@@ -6,11 +6,34 @@
 <title>Installing f-tree</title>
 <meta name="description" content="How to install the f-tree APK on Android: the browser warning, allowing installs from this source, the Play Protect prompt, and how to verify the file you downloaded.">
 <meta name="robots" content="noindex">
+<meta name="theme-color" content="#f7f6f1" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#10150f" media="(prefers-color-scheme: dark)">
 <link rel="icon" href="../favicon.svg" type="image/svg+xml">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=JetBrains+Mono:wght@400;500&display=swap">
 <link rel="stylesheet" href="../style.css">
+
+<!--
+  The theme, decided before the first paint.
+
+  This runs where it sits, in the head, so the ground is already the right colour when the page
+  first draws — pushed to the end of the body it would flash bone at a reader who chose dark.
+  Nothing is stamped when there is no stored choice: the absence of the attribute is what lets
+  the prefers-color-scheme rule in style.css keep following the system, including live, while
+  data-js is what reveals the toggle (see style.css).
+-->
+<script>
+(function () {
+  var root = document.documentElement;
+  root.setAttribute('data-js', '');
+  try {
+    var saved = localStorage.getItem('ftree.theme');
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) { /* private windows and blocked storage both land here; the system decides */ }
+})();
+</script>
+
 </head>
 <body>
 
@@ -18,17 +41,28 @@
   <div class="shell">
     <a class="wordmark" href="../">
       <svg width="26" height="26" viewBox="0 0 32 32" aria-hidden="true">
-        <rect width="32" height="32" rx="7" fill="#2A5138"/>
-        <g fill="none" stroke="#CDE6D5" stroke-width="1.7" stroke-linecap="round">
+        <rect width="32" height="32" rx="7" fill="var(--mark-tile)"/>
+        <g fill="none" stroke="var(--mark-line)" stroke-width="1.7" stroke-linecap="round">
           <circle cx="11" cy="9.5" r="3.1"/><circle cx="21" cy="9.5" r="3.1"/>
           <path d="M14.1 9.5h3.8"/><path d="M16 12.6v3.4M9 16h14M9 16v2.6M23 16v2.6"/>
           <circle cx="9" cy="22" r="3.1"/>
-          <circle cx="23" cy="22" r="3.1" stroke="#E3C38C" stroke-dasharray="2.2 2"/>
+          <circle cx="23" cy="22" r="3.1" stroke="var(--mark-dash)" stroke-dasharray="2.2 2"/>
         </g>
       </svg>
       f-tree
     </a>
-    <nav><a class="nav-link" href="../">Back to the start</a></nav>
+    <nav>
+      <a class="nav-link" href="../">Back to the start</a>
+      <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Switch theme">
+        <svg class="i-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20.5 14.3A8.5 8.5 0 0 1 9.7 3.5a8.5 8.5 0 1 0 10.8 10.8z"/>
+        </svg>
+        <svg class="i-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4.1"/>
+          <path d="M12 2.6v2.2M12 19.2v2.2M4.35 4.35l1.55 1.55M18.1 18.1l1.55 1.55M2.6 12h2.2M19.2 12h2.2M4.35 19.65 5.9 18.1M18.1 5.9l1.55-1.55"/>
+        </svg>
+      </button>
+    </nav>
   </div>
 </header>
 


### PR DESCRIPTION
Closes #83.

The app has had a dark theme since the start and the viewer's canvas already carried a copy of it, but the site itself was light only. A reader with a dark system met a sheet of bone, and the viewer's own dark mode was unreachable until a file was open.

## The palette is the app's, not a new one

Lifted from `ui/theme/Color.kt` the same way the light palette was — night ground `#10150f`, raised `#1a211a`, sage where forest was, `BrassLight` for brass — so the site, the viewer and the product stay recognisably one object. Brass keeps its single job in both modes: marking what is not known.

The one thing that does not map across is that **forest is a dark green carrying white text, while sage is a pale green carrying dark green text**. So a few tokens now name a job rather than a hue — `--on-forest`, `--on-sage`, `--forest-hover`, `--deep` — and the rules ask for the role. That is what carries the download button, a named card, the step numbers and the viewer's relation answer across without per-theme overrides scattered through the file.

The "local first" band is the exception that proves it: it is dark green in *both* modes, so everything it carries except its own ground is declared once as a constant.

## Three states, not two

No stored choice means *follow the system*, and choosing the mode you are already in clears the override rather than pinning today's answer. An inline script in the head settles it before the first paint, so nobody who asked for dark is shown bone first. With JavaScript off the page still follows `prefers-color-scheme`; it simply offers no dead button.

## Two gaps in the viewer close with it

Its Display menu lives inside `data-when="loaded"`, so the opener — the screen somebody looks at longest before deciding whether to hand over a file — had no way to switch at all. The `d` shortcut sat behind the same guard. Both work before a file is open now.

## How it was checked

- **Calibrated, not merely compliant.** The night values are set against the light ones rather than against a bare contrast floor, so a hairline reads as a hairline in both (1.57:1 by day, 1.61:1 by night) and text lands between 5.4:1 and 14.4:1.
- **30 behaviour checks** under both a light and a dark system: following, pinning, carrying across pages, clearing back to auto, browser chrome agreeing, the Display tick staying in sync with the bar button, the `d` shortcut on the opener, and reduced motion suppressing the repaint.
- **No flash.** Sampled the ground as early as the document can be scripted, on a light system with dark stored — bone never paints.
- **Light mode is unchanged.** Rendered `main` alongside and diffed pixels. That caught two real regressions in the deep band, now fixed; afterwards every light-mode difference is confined to the navbar row where the toggle sits.
- Phone (360px) and tablet (768px) both hold the toggle with no horizontal overflow.

## Judgement calls worth a look

- The wordmark tile lightens slightly at night (`#2f5c3f`) so it does not sink into the ground. Holding the launcher icon's exact green constant is a defensible alternative.
- The screenshots stay light-mode captures. They read as photographs of a phone either way, but they are bright against the dark page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)