### PR TITLE
fix(viewer): measure the connectors after the cards have stopped moving

### DIFF
--- a/site/playground/layout.js
+++ b/site/playground/layout.js
@@ -527,7 +527,6 @@ export function layoutArchive(graph, options = {}) {
   }
 
   const byId = new Map(nodes.map((n) => [n.id, n]));
-  const links = buildLinks(graph, byId);
 
   let width = 0;
   let height = 0;
@@ -539,12 +538,17 @@ export function layoutArchive(graph, options = {}) {
   for (const n of nodes) { n.x += dx; n.y += dy; }
   for (const g of groups) { g.x += dx; g.y += dy; }
   for (const b of bands) { b.x += dx; b.y += dy; b.width = width + dx; }
-  for (const l of links.couples) { l.x1 += dx; l.x2 += dx; l.y += dy; }
-  for (const l of links.siblings) { l.x1 += dx; l.x2 += dx; l.y += dy; }
-  for (const l of links.descents) {
-    l.originX += dx; l.originY += dy; l.busY += dy; l.childTopY += dy;
-    l.childXs = l.childXs.map((x) => x + dx);
-  }
+
+  /*
+   * The connectors are measured last, from where the cards ended up.
+   *
+   * They used to be built first and then translated field by field, which meant the shift had to
+   * name every coordinate a link carries - and it named all of them but one. `childYs` kept its
+   * pre-shift value, so every descent dropped to a point exactly one margin above the child and
+   * the bracket pointed upwards. Deriving the geometry after the last thing that moves a card
+   * makes that class of mistake impossible rather than merely fixed.
+   */
+  const links = buildLinks(graph, byId);
 
   return {
     nodes,
@@ -613,6 +617,9 @@ function buildLinks(graph, byId) {
       originY,
       busY: Math.max(busY, originY + 12),
       childTopY,
+      // Drawn from the cards that were actually placed, and named by the same list, so the three
+      // arrays stay parallel even if the family names somebody the chart has nowhere to put.
+      childIds: children.map((c) => c.id),
       childXs: children.map((c) => c.x + METRICS.NODE_W / 2),
       childYs: children.map((c) => c.y),
       parents: fam.parents,

--- a/tools/check_layout.mjs
+++ b/tools/check_layout.mjs
@@ -82,6 +82,28 @@ async function run(name, { expectPhotos = false } = {}) {
   ).length;
   check('every descent connector lands on placed people', danglingDescents === 0);
 
+  /*
+   * Stronger, and the check that was missing: a connector's own coordinates must meet the card it
+   * names. "Lands on somebody who exists" was satisfied for a year by a bracket drawn one whole
+   * margin above the children with its arms pointing the wrong way, because the ids were right and
+   * only the geometry was wrong. Assert the drawing, not the bookkeeping.
+   */
+  let misdrawn = 0;
+  let upward = 0;
+  for (const d of layout.descents) {
+    for (let i = 0; i < d.childIds.length; i++) {
+      const node = layout.byId.get(d.childIds[i]);
+      if (!node) { misdrawn++; continue; }
+      if (Math.abs(d.childXs[i] - (node.x + METRICS.NODE_W / 2)) > 0.5) misdrawn++;
+      else if (Math.abs(d.childYs[i] - node.y) > 0.5) misdrawn++;
+      if (d.childYs[i] < d.busY) upward++;
+    }
+  }
+  check('every descent drop ends on the top edge of its child', misdrawn === 0,
+    `${misdrawn} drops land somewhere other than the card they name`);
+  check('every descent drop runs downward, from the bar to the child', upward === 0,
+    `${upward} drops point back up at the parents`);
+
   // A child must be drawn below its parents, or the chart is lying about direction.
   let inverted = 0;
   for (const id of graph.order) {


### PR DESCRIPTION
Closes #85.

Every parent-to-child bracket in the playground pointed **upward** and stopped one whole margin short of the children. The viewer drew a family tree whose lines joined nothing.

### Cause

Links were built first, then the drawing was shifted clear of the margin by naming each coordinate a link carries — and it named all of them but one:

```js
l.originX += dx; l.originY += dy; l.busY += dy; l.childTopY += dy;
l.childXs = l.childXs.map((x) => x + dx);   // childYs never shifted
```

Measured on `sample-family.ftree`: `busY 175`, `childTopY 212`, `childYs [152, 152]`. `childTopY` and `childYs` are read from the same `node.y`, so they can only disagree because one was moved afterwards. 212 − 152 = 60 = `METRICS.MARGIN`.

### Fix

Build the links **after** the translation. That deletes the three lines of per-link shifting rather than adding a fourth coordinate to remember, so the next field added to a link cannot go stale the same way. The descent's coordinate arrays now also carry their own ids (`childIds`), keeping them parallel even for a family that names somebody the chart has nowhere to place.

### The check that was missing

`tools/check_layout.mjs` asserted connectors reference people who exist, and that parents sit above children. Both were true the whole time. Nothing asserted that a connector's **own coordinates** meet the card it names — exactly where the bug lived. Two invariants added.

**Verified against the unfixed layout**, not just the fixed one:

| fixture | drops landing off their card | drops pointing up |
|---|---|---|
| sample-family | 10 | 10 |
| sample-streamed | 10 | 10 |
| large-tree | 1334 | 1334 |

After the fix: `All checks passed.`

No layout orientation change — the viewer stays landscape, generations as rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)