### PR TITLE
feat(site): download the desktop app here, with the warnings explained

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Ask how any two people are related and it names the relationship, in English or 
 &nbsp;
 <a href="https://ftree.vibethroughcode.com/playground/"><img src="https://img.shields.io/badge/Try%20it%20in%20your%20browser-8a6420?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Try it in your browser" height="34"></a>
 
-<a href="https://github.com/thisisankit27/f-tree/releases?q=desktop&expanded=true"><img src="https://img.shields.io/badge/Desktop%20app-1f3d2b?style=for-the-badge&logo=linux&logoColor=white" alt="Desktop app for Windows and Linux" height="34"></a>
+<a href="https://ftree.vibethroughcode.com/desktop/"><img src="https://img.shields.io/badge/Desktop%20app-1f3d2b?style=for-the-badge&logo=linux&logoColor=white" alt="Desktop app for Windows and Linux" height="34"></a>
 &nbsp;
 <a href="https://ftree.vibethroughcode.com/"><img src="https://img.shields.io/badge/Website-414942?style=for-the-badge&logo=safari&logoColor=white" alt="Website" height="34"></a>
 &nbsp;
@@ -101,7 +101,7 @@ package name and signing certificate before it installs anything. See
 
 ### On a laptop — Windows and Ubuntu
 
-The **[desktop app](https://github.com/thisisankit27/f-tree/releases?q=desktop&expanded=true)**
+The **[desktop app](https://ftree.vibethroughcode.com/desktop/)**
 opens an exported `.ftree` on a big screen and draws it the way the phone does: a generation is a
 column, ancestors at the left. Windows gets an installer; Linux gets an AppImage or a `.deb`.
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -10,7 +10,7 @@
  * What the shell adds is the part a browser tab cannot have: a real file picker, a native menu,
  * and a memory of which tree you were reading.
  */
-const { app, BrowserWindow, Menu, dialog, ipcMain, shell } = require('electron');
+const { app, BrowserWindow, Menu, dialog, ipcMain, session, shell } = require('electron');
 const fs = require('node:fs/promises');
 const path = require('node:path');
 
@@ -138,6 +138,45 @@ function buildMenu(win) {
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
+/*
+ * The typefaces, from disk.
+ *
+ * The viewer's HTML asks Google for Literata and JetBrains Mono, which is right for a web page and
+ * wrong for an app that tells people nothing leaves their machine: it would announce every launch
+ * to a third party. The same two files the Android app ships are read off disk instead, and the
+ * request to Google is refused outright below rather than merely made redundant.
+ */
+const FONT_DIR = app.isPackaged
+  ? path.join(process.resourcesPath, 'fonts')
+  : path.join(__dirname, '..', 'app', 'src', 'main', 'res', 'font');
+
+async function localFontCss() {
+  const face = async (family, file, weight) => {
+    const data = await fs.readFile(path.join(FONT_DIR, file));
+    return `@font-face{font-family:"${family}";src:url(data:font/ttf;base64,${data.toString('base64')})`
+      + ` format("truetype");font-weight:${weight};font-style:normal;font-display:block}`;
+  };
+  return [
+    await face('Literata', 'literata.ttf', '100 900'),
+    await face('JetBrains Mono', 'jetbrains_mono.ttf', '100 900'),
+  ].join('');
+}
+
+/*
+ * Nothing reaches the network.
+ *
+ * Not a promise in a privacy policy - the requests are refused by the session, so the claim holds
+ * whatever the page's markup happens to ask for now or later. Only `file:` and `devtools:` are
+ * allowed through.
+ */
+function refuseTheNetwork(ses) {
+  ses.webRequest.onBeforeRequest({ urls: ['http://*/*', 'https://*/*', 'ws://*/*', 'wss://*/*'] },
+    (details, callback) => {
+      console.warn(`f-tree: refused a network request to ${details.url}`);
+      callback({ cancel: true });
+    });
+}
+
 async function createWindow() {
   const win = new BrowserWindow({
     width: 1440,
@@ -156,7 +195,16 @@ async function createWindow() {
   });
 
   win.once('ready-to-show', () => win.show());
+
+  refuseTheNetwork(session.defaultSession);
   await win.loadFile(VIEWER);
+  try {
+    await win.webContents.insertCSS(await localFontCss());
+  } catch (error) {
+    // Without them the app falls back to the system serif and monospace. Worth a line in the log,
+    // not worth refusing to open somebody's family tree over.
+    console.warn(`f-tree: could not load the bundled typefaces — ${error.message}`);
+  }
   buildMenu(win);
 
   // A link to the project should open in the browser, never navigate the app away from the viewer.
@@ -213,6 +261,8 @@ async function runSmoke(win, file) {
     state: document.getElementById('viewer')?.dataset.state ?? null,
     fileName: document.getElementById('file-name')?.textContent ?? null,
     orientation: document.body.dataset.orientation ?? null,
+    literata: document.fonts.check('16px Literata'),
+    mono: document.fonts.check('13px "JetBrains Mono"'),
     people: document.querySelectorAll('#index-list li, #index-list button, #index-list tr').length,
     status: document.querySelector('#status')?.textContent?.trim().slice(0, 90) ?? null,
   })).toString()})()`);
@@ -225,6 +275,9 @@ async function runSmoke(win, file) {
   check('generations run in columns, as they do in the app', seen.orientation === 'columns',
     String(seen.orientation));
   check('the archive was read and counted', /\d+ people/.test(seen.status ?? ''), String(seen.status));
+  // Refusing the network must not quietly cost the app its typography.
+  check('the bundled typefaces loaded without the network', seen.literata && seen.mono,
+    `Literata ${seen.literata}, JetBrains Mono ${seen.mono}`);
 
   if (process.env.FTREE_SMOKE_SHOT) {
     const image = await win.webContents.capturePage();

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -40,6 +40,13 @@
         "filter": [
           "**/*"
         ]
+      },
+      {
+        "from": "../app/src/main/res/font",
+        "to": "fonts",
+        "filter": [
+          "*.ttf"
+        ]
       }
     ],
     "linux": {

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -36,6 +36,18 @@ The page reaches the machine only through the names in `preload.js`. A tree is s
 and the reason the app never uploads it is the reason that list is short and explicit rather than
 a general-purpose `fs`.
 
+## It refuses the network
+
+`refuseTheNetwork` cancels every `http`, `https` and websocket request in the session. Not a
+promise in a policy — the request is refused, so the claim holds whatever the page's markup asks
+for now or later, and the one request the viewer does make (Google Fonts, right for a web page and
+wrong for this) is logged and dropped.
+
+Literata and JetBrains Mono are therefore read from disk: the same two files the Android app ships,
+carried in as a resource and injected as `@font-face`. Without them the app falls back to the
+system serif and monospace, which is worth a line in the log and not worth refusing to open
+somebody's family tree over.
+
 ## Which way the generations run
 
 `layoutArchive(graph, { orientation })` takes `'rows'` (the website — a landscape reader for a

--- a/site/app.js
+++ b/site/app.js
@@ -13,7 +13,7 @@
 
   var REPO = 'thisisankit27/f-tree';
   var API = 'https://api.github.com/repos/' + REPO + '/releases';
-  var CACHE_KEY = 'ftree.release.v1';
+  var CACHE_KEY = 'ftree.release.v2';
   var CACHE_TTL = 10 * 60 * 1000;
 
   var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -49,7 +49,47 @@
         // GitHub returns this as "sha256:<hex>".
         sha256: (apk.digest || '').replace(/^sha256:/, ''),
         url: apk.browser_download_url
-      }
+      },
+      desktop: desktopFrom(releases)
+    };
+  }
+
+  /*
+   * The newest desktop release.
+   *
+   * Found by its tag rather than by being newest, because desktop releases are published as
+   * pre-releases on purpose - it is what keeps `releases/latest` answering with the newest
+   * Android release for the app's own updater. See docs/desktop.md.
+   */
+  function desktopFrom(releases) {
+    var rel = null;
+    for (var i = 0; i < releases.length; i++) {
+      if (releases[i].draft) continue;
+      if (/^desktop-v/.test(releases[i].tag_name || '')) { rel = releases[i]; break; }
+    }
+    if (!rel) return null;
+
+    var files = {};
+    (rel.assets || []).forEach(function (a) {
+      var kind = /\.exe$/i.test(a.name) ? 'windows'
+        : /\.AppImage$/i.test(a.name) ? 'appimage'
+        : /\.deb$/i.test(a.name) ? 'deb'
+        : null;
+      if (!kind) return;
+      files[kind] = {
+        kind: kind,
+        name: a.name,
+        size: a.size,
+        sha256: (a.digest || '').replace(/^sha256:/, ''),
+        url: a.browser_download_url
+      };
+    });
+
+    return {
+      version: (rel.tag_name || '').replace(/^desktop-v/, ''),
+      published: rel.published_at,
+      notesUrl: rel.html_url,
+      files: files
     };
   }
 
@@ -74,6 +114,12 @@
   }
 
   /* ---------------------------------------------------------------- helpers */
+
+  function longDate(iso) {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric', month: 'long', day: 'numeric'
+    });
+  }
 
   function megabytes(bytes) {
     return (bytes / 1048576).toFixed(1) + ' MB';
@@ -386,9 +432,7 @@
     }
     if ((el = document.getElementById('fact-notes'))) el.href = data.notesUrl;
     if ((el = document.getElementById('fact-date')) && data.published) {
-      el.textContent = new Date(data.published).toLocaleDateString(undefined, {
-        year: 'numeric', month: 'long', day: 'numeric'
-      });
+      el.textContent = longDate(data.published);
     }
 
     // Start the download without navigating away from the instructions.
@@ -399,8 +443,111 @@
     if (status) status.textContent = 'Your download has started.';
   }
 
+  /* ------------------------------------------------------ the desktop page */
+
+  /*
+   * Which file this reader wants.
+   *
+   * A guess, and treated as one: it picks the primary button and nothing else, with the other two
+   * kept one click away rather than hidden. `userAgentData` where it exists, the platform string
+   * where it does not, and no pretence of certainty either way.
+   */
+  function guessPlatform() {
+    // `?platform=windows` overrides the guess. It is how somebody on one machine gets the file for
+    // another - "send me the Windows link" - and it is what makes the routing testable in a real
+    // browser rather than only by reading it.
+    var forced = (location.search.match(/[?&]platform=([a-z]+)/i) || [])[1];
+    if (forced) return forced.toLowerCase();
+
+    var hint = (navigator.userAgentData && navigator.userAgentData.platform)
+      || navigator.platform || '';
+    var ua = navigator.userAgent || '';
+    if (/android/i.test(ua)) return 'android';
+    if (/iphone|ipad|ipod/i.test(ua)) return 'ios';
+    if (/win/i.test(hint) || /windows/i.test(ua)) return 'windows';
+    if (/linux/i.test(hint) || /linux|x11|ubuntu/i.test(ua)) return 'linux';
+    if (/mac/i.test(hint) || /mac os/i.test(ua)) return 'mac';
+    return 'unknown';
+  }
+
+  var KIND_LABEL = {
+    windows: 'the Windows installer',
+    deb: 'the .deb for Ubuntu and Debian',
+    appimage: 'the AppImage'
+  };
+
+  function wireDesktop(desktop) {
+    var button = document.getElementById('desktop-primary');
+    var label = document.getElementById('desktop-primary-label');
+    var status = document.getElementById('desktop-status');
+    var others = document.getElementById('desktop-others');
+    if (!button) return;
+
+    if (!desktop || !Object.keys(desktop.files).length) {
+      status.textContent = 'Could not reach GitHub just now. The releases page has every build.';
+      label.textContent = 'Open the releases page';
+      return;
+    }
+
+    var platform = guessPlatform();
+
+    // A phone cannot run any of these, and saying so is more use than offering an 80MB installer.
+    if (platform === 'android' || platform === 'ios') {
+      label.textContent = 'Get f-tree for Android';
+      button.href = platform === 'android' ? '../thanks/' : '../';
+      status.textContent = 'This page is for a laptop. On a phone, f-tree is an Android app.';
+      others.innerHTML = '';
+      return;
+    }
+
+    var order = platform === 'windows' ? ['windows', 'deb', 'appimage'] : ['deb', 'appimage', 'windows'];
+    var first = null;
+    order.forEach(function (kind) { if (!first && desktop.files[kind]) first = desktop.files[kind]; });
+    if (!first) return;
+
+    button.href = first.url;
+    button.setAttribute('download', first.name);
+    label.textContent = 'Download ' + KIND_LABEL[first.kind];
+    status.textContent = first.name + ' · ' + megabytes(first.size) + ' · version ' + desktop.version;
+
+    // Mac is not built yet, and pretending otherwise would waste somebody's afternoon.
+    if (platform === 'mac') {
+      status.textContent = 'There is no macOS build yet. These are the Windows and Linux files.';
+    }
+
+    var rest = order.slice(1).filter(function (k) { return desktop.files[k]; });
+    others.innerHTML = rest.length
+      ? 'On another system? ' + rest.map(function (kind) {
+        var f = desktop.files[kind];
+        return '<a href="' + f.url + '" download="' + f.name + '">' + KIND_LABEL[kind]
+          + '</a> (' + megabytes(f.size) + ')';
+      }).join(' &middot; ')
+      : '';
+
+    fillDesktopFacts(desktop);
+  }
+
+  function fillDesktopFacts(desktop) {
+    var version = document.getElementById('dfact-version');
+    var date = document.getElementById('dfact-date');
+    var notes = document.getElementById('dfact-notes');
+    var hashes = document.getElementById('desktop-hashes');
+    if (version) version.textContent = desktop.version;
+    if (date && desktop.published) date.textContent = longDate(desktop.published);
+    if (notes && desktop.notesUrl) notes.href = desktop.notesUrl;
+    if (!hashes) return;
+
+    var rows = ['windows', 'deb', 'appimage'].filter(function (k) { return desktop.files[k]; });
+    hashes.innerHTML = rows.map(function (kind) {
+      var f = desktop.files[kind];
+      return '<div class="hash-row"><p class="hash-name">' + f.name + '</p>'
+        + '<p class="hash">' + (f.sha256 || 'published on the release page') + '</p></div>';
+    }).join('');
+  }
+
   /* -------------------------------------------------------------------- init */
 
+  var onDesktop = !!document.getElementById('desktop-downloads');
   var onThanks = !!document.getElementById('apk-link');
 
   wireTheme();
@@ -410,9 +557,13 @@
   loadRelease().then(function (data) {
     if (!data) throw new Error('no releases published');
     fillSpecs(data);
-    if (onThanks) wireThanks(data); else showCounter(data);
+    if (onDesktop) wireDesktop(data.desktop);
+    else if (onThanks) wireThanks(data);
+    else showCounter(data);
   }).catch(function (err) {
     if (window.console) console.warn('f-tree: release data unavailable —', err.message);
-    if (onThanks) wireThanks(null); else hideCounter();
+    if (onDesktop) wireDesktop(null);
+    else if (onThanks) wireThanks(null);
+    else hideCounter();
   });
 })();

--- a/site/desktop/index.html
+++ b/site/desktop/index.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>f-tree for Windows and Linux</title>
+<meta name="description" content="Download f-tree for Windows or Ubuntu, with the SmartScreen and AppImage warnings explained, the install steps for each system, and the checksum to verify what you downloaded.">
+<meta name="theme-color" content="#f7f6f1" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#10150f" media="(prefers-color-scheme: dark)">
+<link rel="icon" href="../favicon.svg" type="image/svg+xml">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=JetBrains+Mono:wght@400;500&display=swap">
+<link rel="stylesheet" href="../style.css">
+
+<!--
+  The theme, decided before the first paint.
+
+  This runs where it sits, in the head, so the ground is already the right colour when the page
+  first draws — pushed to the end of the body it would flash bone at a reader who chose dark.
+  Nothing is stamped when there is no stored choice: the absence of the attribute is what lets
+  the prefers-color-scheme rule in style.css keep following the system, including live, while
+  data-js is what reveals the toggle (see style.css).
+-->
+<script>
+(function () {
+  var root = document.documentElement;
+  root.setAttribute('data-js', '');
+  try {
+    var saved = localStorage.getItem('ftree.theme');
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) { /* private windows and blocked storage both land here; the system decides */ }
+})();
+</script>
+
+</head>
+<body>
+
+<header class="masthead">
+  <div class="shell">
+    <a class="wordmark" href="../">
+      <svg width="26" height="26" viewBox="0 0 32 32" aria-hidden="true">
+        <rect width="32" height="32" rx="7" fill="var(--mark-tile)"/>
+        <g fill="none" stroke="var(--mark-line)" stroke-width="1.7" stroke-linecap="round">
+          <circle cx="11" cy="9.5" r="3.1"/><circle cx="21" cy="9.5" r="3.1"/>
+          <path d="M14.1 9.5h3.8"/><path d="M16 12.6v3.4M9 16h14M9 16v2.6M23 16v2.6"/>
+          <circle cx="9" cy="22" r="3.1"/>
+          <circle cx="23" cy="22" r="3.1" stroke="var(--mark-dash)" stroke-dasharray="2.2 2"/>
+        </g>
+      </svg>
+      f-tree
+    </a>
+    <nav>
+      <a class="nav-link" href="../">Back to the start</a>
+      <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Switch theme">
+        <svg class="i-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20.5 14.3A8.5 8.5 0 0 1 9.7 3.5a8.5 8.5 0 1 0 10.8 10.8z"/>
+        </svg>
+        <svg class="i-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4.1"/>
+          <path d="M12 2.6v2.2M12 19.2v2.2M4.35 4.35l1.55 1.55M18.1 18.1l1.55 1.55M2.6 12h2.2M19.2 12h2.2M4.35 19.65 5.9 18.1M18.1 5.9l1.55-1.55"/>
+        </svg>
+      </button>
+    </nav>
+  </div>
+</header>
+
+
+<main>
+
+<section class="band" style="padding-bottom:0">
+  <div class="shell" style="max-width:780px">
+    <p class="eyebrow">For your laptop</p>
+    <h1 style="font-size:clamp(32px,4.6vw,48px);line-height:1.1;font-weight:600;letter-spacing:-0.02em;margin:0 0 18px">
+      f-tree on Windows and Ubuntu.
+    </h1>
+    <p class="lede" style="max-width:38em">
+      It opens a <code>.ftree</code> exported from the phone and draws it the way the phone does —
+      a generation is a column, ancestors at the left. Everything stays on the machine.
+    </p>
+
+    <!--
+      The download the reader is most likely to want, chosen from their own platform, with the
+      others a click away rather than hidden. Filled in by app.js from the published release, so
+      a new version needs no edit here; the markup is the fallback if GitHub cannot be reached.
+    -->
+    <div id="desktop-downloads">
+      <p style="margin:28px 0 0">
+        <a class="btn btn-primary" id="desktop-primary"
+           href="https://github.com/thisisankit27/f-tree/releases?q=desktop&amp;expanded=true">
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 3v12m0 0l-4.5-4.5M12 15l4.5-4.5M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/>
+          </svg>
+          <span id="desktop-primary-label">Get the desktop app</span>
+        </a>
+      </p>
+      <p class="status-line" id="desktop-status">Finding the latest build…</p>
+      <p class="status-line" id="desktop-others"></p>
+    </div>
+  </div>
+</section>
+
+<!--
+  One set of steps per system. Both are shown: a reader on Windows sometimes installs for a
+  relative on Ubuntu, and a page that hides the other half makes them go looking for it.
+-->
+<section class="band" id="windows">
+  <div class="shell" style="max-width:780px">
+    <h2 class="rule-label">Installing on Windows</h2>
+
+    <ol class="steps">
+      <li>
+        <h3>Windows will refuse to run it</h3>
+        <p>
+          Not because of anything in the file. Windows trusts installers whose publisher has paid
+          for a code-signing certificate, and f-tree has not — so it arrives as an unrecognised app
+          and Defender stops it. Choose <b>More info</b>, then <b>Run anyway</b>.
+        </p>
+        <p class="quote">
+          <b>“Windows protected your PC.”</b> Microsoft Defender SmartScreen prevented an
+          unrecognised app from starting. — More info → Run anyway
+        </p>
+        <p>
+          The publisher will read <b>Unknown</b>. That is the honest state of it: nobody has
+          vouched for this file except the checksum below, which you can check yourself.
+        </p>
+      </li>
+
+      <li>
+        <h3>Choose where it goes</h3>
+        <p>
+          The installer offers a folder and installs for your account only, so it never asks for an
+          administrator password. Nothing is written outside that folder and your own app data.
+        </p>
+      </li>
+
+      <li>
+        <h3>Open it and open your tree</h3>
+        <p>
+          Export a <code>.ftree</code> from the phone — <b>Settings → Export your tree</b> — get it
+          onto the laptop however you like, and open it with <b>File → Open tree</b>. The app
+          reopens it by itself next time.
+        </p>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<section class="band band-sunk" id="linux">
+  <div class="shell" style="max-width:780px">
+    <h2 class="rule-label">Installing on Ubuntu and other Linux</h2>
+
+    <p style="max-width:38em">
+      Two ways, and the <code>.deb</code> is the easier one if you are on Ubuntu, Debian or Mint —
+      it puts f-tree in your applications menu like anything else. The <code>.AppImage</code> is
+      one file that runs anywhere and installs nothing.
+    </p>
+
+    <ol class="steps">
+      <li>
+        <h3>The .deb — apt, not a double-click</h3>
+        <p>
+          Double-clicking a <code>.deb</code> opens an archive manager on most desktops now, which
+          is not what you want. Install it from the folder you downloaded it to:
+        </p>
+        <p class="quote"><code>sudo apt install ./f-tree-desktop_*_amd64.deb</code></p>
+        <p>The leading <code>./</code> matters — without it apt goes looking for a package by that name.</p>
+      </li>
+
+      <li>
+        <h3>The .AppImage — make it executable first</h3>
+        <p>
+          A downloaded AppImage is not executable, by design. Give it permission and run it:
+        </p>
+        <p class="quote"><code>chmod +x f-tree-*.AppImage &amp;&amp; ./f-tree-*.AppImage</code></p>
+        <p>
+          On Ubuntu 22.04 and newer it may stop with <code>dlopen(): error loading libfuse.so.2</code>.
+          AppImages need the older FUSE library, which no longer ships by default:
+        </p>
+        <p class="quote"><code>sudo apt install libfuse2</code></p>
+        <p>
+          Or skip it entirely with <code>./f-tree-*.AppImage --appimage-extract-and-run</code>, which
+          unpacks to a temporary folder instead.
+        </p>
+      </li>
+
+      <li>
+        <h3>Open your tree</h3>
+        <p>
+          Export a <code>.ftree</code> from the phone — <b>Settings → Export your tree</b> — and open
+          it with <b>File → Open tree</b>. The app reopens it by itself next time.
+        </p>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<section class="band">
+  <div class="shell" style="max-width:780px">
+    <p class="rule-label">Why your computer complains</p>
+    <div class="slab">
+      <h2 style="font-size:26px;margin-bottom:14px">Nobody has vouched for this file</h2>
+      <p>
+        Windows and macOS trust software whose publisher has bought a code-signing certificate and
+        kept a reputation with it. That costs a few hundred pounds a year and identifies a company.
+        f-tree is a free app with no company behind it, so it has neither, and every operating
+        system it lands on will say so.
+      </p>
+      <p>
+        The warning is doing its job. Clicking past one is a habit worth keeping rare, so here is
+        what you can check instead of taking my word for it: every file below was built by GitHub
+        Actions from the public source, in the open, and GitHub — not this page — publishes the
+        checksum. If the hash of your download matches, the file is byte-for-byte the one that came
+        out of that build.
+      </p>
+      <div class="notice">
+        <span aria-hidden="true">◌</span>
+        <span>
+          <strong>What the app can reach.</strong> It reads the file you open and writes one small
+          note of which file that was, so it can reopen it next time. There is no account, no server
+          and no telemetry — and the app <em>refuses</em> network requests rather than merely not
+          making any: every <code>http</code> and <code>https</code> request is cancelled by the
+          app itself, so the typefaces are read from disk and nothing announces that you opened it.
+          Pull the plug on your internet and it behaves identically.
+        </span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="band band-sunk">
+  <div class="shell" style="max-width:780px">
+    <p class="rule-label">Checking what you got</p>
+    <div class="slab">
+      <h2 style="font-size:26px;margin-bottom:14px">Verify the download</h2>
+      <p>
+        On Linux run <code>sha256sum &lt;file&gt;</code>; on Windows,
+        <code>certutil -hashfile &lt;file&gt; SHA256</code>. Compare the result with the matching
+        line below.
+      </p>
+      <dl class="facts" id="desktop-facts">
+        <div><dt>Version</dt><dd id="dfact-version">the latest desktop release</dd></div>
+        <div><dt>Released</dt><dd id="dfact-date">see the release page</dd></div>
+      </dl>
+      <div id="desktop-hashes"></div>
+      <p style="margin-top:18px">
+        <a id="dfact-notes" href="https://github.com/thisisankit27/f-tree/releases?q=desktop&amp;expanded=true">Release notes and every build on GitHub</a>
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="band">
+  <div class="shell" style="max-width:780px">
+    <p class="rule-label">One more thing</p>
+    <p style="max-width:38em">
+      The desktop app <b>reads</b> a tree today: the chart, the people index, the search and the
+      relation finder. Editing, settings and the updater are being built —
+      <a href="https://github.com/thisisankit27/f-tree/issues/89">follow along here</a>. Building
+      and editing a tree is the phone's job for now, and the
+      <a href="../thanks/">Android app</a> does all of it.
+    </p>
+  </div>
+</section>
+
+</main>
+
+
+<footer class="footer">
+  <div class="shell">
+    <span>f-tree — built by <a href="https://github.com/thisisankit27">thisisankit27</a>. MIT licensed.</span>
+    <nav>
+      <a href="../">Home</a>
+      <a href="../playground/">Viewer</a>
+      <a href="https://github.com/thisisankit27/f-tree">Source</a>
+      <a href="https://github.com/thisisankit27/f-tree/releases">Releases</a>
+    </nav>
+  </div>
+</footer>
+
+<script src="../app.js"></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -96,6 +96,7 @@
       <a class="nav-link" href="#what">What it does</a>
       <a class="nav-link" href="#merge">Sharing</a>
       <a class="nav-link" href="playground/">Viewer</a>
+      <a class="nav-link" href="desktop/">Desktop</a>
       <a class="nav-link" href="https://github.com/thisisankit27/f-tree">Source</a>
       <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Switch theme">
         <svg class="i-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -131,7 +132,7 @@
         </svg>
         Download for Android
       </a>
-      <a class="btn btn-quiet" href="#desktop">Windows &amp; Linux</a>
+      <a class="btn btn-quiet" href="desktop/">Windows &amp; Linux</a>
       <a class="btn btn-quiet" href="https://github.com/thisisankit27/f-tree">Read the source</a>
     </div>
 
@@ -441,7 +442,7 @@
           <span>Windows &amp; Ubuntu</span><span class="sep" aria-hidden="true">&middot;</span><span>Reads a tree today</span><span class="sep" aria-hidden="true">&middot;</span><span>Editing on the way</span>
         </p>
         <div class="cta-row">
-          <a class="btn btn-primary" href="https://github.com/thisisankit27/f-tree/releases?q=desktop&amp;expanded=true">Get the desktop app</a>
+          <a class="btn btn-primary" href="desktop/">Get the desktop app</a>
         </div>
       </div>
       <div>
@@ -561,7 +562,7 @@
     <span>f-tree — built by <a href="https://github.com/thisisankit27">thisisankit27</a>. MIT licensed.</span>
     <nav>
       <a href="playground/">Viewer</a>
-      <a href="https://github.com/thisisankit27/f-tree/releases?q=desktop&amp;expanded=true">Desktop app</a>
+      <a href="desktop/">Desktop app</a>
       <a href="https://github.com/thisisankit27/f-tree">Source</a>
       <a href="https://github.com/thisisankit27/f-tree/releases">Releases</a>
       <a href="https://github.com/thisisankit27/f-tree/issues">Report a problem</a>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -2,5 +2,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://ftree.vibethroughcode.com/</loc><priority>1.0</priority></url>
   <url><loc>https://ftree.vibethroughcode.com/playground/</loc><priority>0.8</priority></url>
+  <url><loc>https://ftree.vibethroughcode.com/desktop/</loc><priority>0.7</priority></url>
   <url><loc>https://ftree.vibethroughcode.com/thanks/</loc><priority>0.5</priority></url>
 </urlset>

--- a/site/style.css
+++ b/site/style.css
@@ -783,11 +783,28 @@ h2.rule-label,
   padding: 11px 0;
   border-bottom: 1px solid var(--rule);
 }
-.facts dt { color: var(--ink-faint); letter-spacing: .04em; }
+.facts dt { color: var(--ink-faint); letter-spacing: .04em; overflow-wrap: anywhere; }
 .facts dd { margin: 0; color: var(--ink); overflow-wrap: anywhere; }
 @media (max-width: 560px) {
   .facts div { grid-template-columns: 1fr; gap: 2px; }
 }
+
+/*
+ * A checksum and the file it belongs to.
+ *
+ * Not a `.facts` row: a filename and a 64-character hash are both too long for a label column,
+ * and side by side they collide. The name goes above its hash, each with the whole width.
+ */
+.hash-row {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--mono);
+  font-size: 13px;
+}
+.hash-row:first-child { border-top: 1px solid var(--rule); }
+.hash-row p { margin: 0; font-family: var(--mono); font-size: 13px; line-height: 1.5; }
+.hash-row .hash-name { color: var(--ink-faint); letter-spacing: .04em; margin-bottom: 5px; }
+.hash-row .hash { color: var(--ink); overflow-wrap: anywhere; }
 
 /* ------------------------------------------------------------------ footer */
 


### PR DESCRIPTION
Closes #92.

The landing page sent people to the GitHub releases page, which meets them with three files and no indication of which one is theirs. The Android app has never done that — it has `/thanks/`. The desktop app needs the same, and needs it more, because the warnings are worse.

### [`/desktop/`](https://ftree.vibethroughcode.com/desktop/)

Picks the file for the reader's platform, keeps the other two one click away, and quotes what their computer is about to say:

- **Windows** — *"Windows protected your PC"*, SmartScreen, and the *More info → Run anyway* out of it. Publisher will read **Unknown**, and the page says so before they see it.
- **`.deb`** — `sudo apt install ./file.deb`, because double-clicking opens an archive manager on most desktops now.
- **`.AppImage`** — `chmod +x`, and on Ubuntu 22.04+ the `libfuse2` it needs, whose absence is otherwise a bare `dlopen(): error loading libfuse.so.2` that tells nobody anything.

Then a section on **why** the warnings happen — no code-signing certificate, nobody has vouched for the file — and the checksums as the thing to check instead. GitHub publishes a digest per asset, so all three come from the API rather than being pasted in to go stale.

`?platform=windows` overrides the guess: it is how somebody gets the other machine's link, and how the routing is testable in a real browser rather than only by reading it.

### The privacy line was going to be a lie

Writing *"the app does not talk to the network"* sent me to check, and it was false: the viewer's HTML asks Google for Literata and JetBrains Mono, so **the packaged app announced every launch to a third party**.

Rather than soften the sentence, the app now **refuses** the network — every `http`, `https` and websocket request cancelled by the session, so the claim holds whatever the markup asks for later — and reads the typefaces off disk, the same two files the Android app ships.

Verified: exactly one refused request logged on launch, typography unchanged, and **the smoke test now asserts both typefaces loaded**, so refusing the network cannot quietly cost the app its type.

### Verified

| | |
|---|---|
| `?platform=windows` | primary → `.exe`, others listed |
| `?platform=linux` | primary → `.deb` |
| `?platform=android` | points at the Android app instead of an 80MB installer |
| `?platform=mac` | says there is no macOS build rather than pretending |
| Checksums | all three read from the API and rendered |
| Smoke test | 7/7, from source and from the packaged binary |
| Every site link | resolves |

Also fixed a real overlap found on the way: a 64-character hash and a filename collided in the 118px label column of `.facts`. Checksums get their own stacked row.

**No file under `app/` changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)