### PR TITLE
chore(desktop): version 0.1.1

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "f-tree-desktop",
   "productName": "f-tree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A local-first family tree, on your own machine",
   "author": {
     "name": "thisisankit27",


### PR DESCRIPTION
The [download page](https://ftree.vibethroughcode.com/desktop/) now tells people the app refuses the network and reads its typefaces from disk. The published `desktop-v0.1.0` installers were built before that was true, so they contradict the page they are downloaded from.

Version bump only, so the shipped binaries match what the site says about them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)