### PR TITLE
fix(desktop): the AppImage would not start on current Ubuntu, and the download page asked too much

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -19,6 +19,19 @@ const path = require('node:path');
 const { chooseUpdate } = require('./update');
 
 /*
+ * A window needs somewhere to be.
+ *
+ * With neither DISPLAY nor WAYLAND_DISPLAY, Chromium fails to bring up its platform layer and the
+ * process dies of a segmentation fault - no window, no message, nothing to search for. Saying so
+ * first costs one line and turns a silent crash into an answer.
+ */
+if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+  console.error('f-tree: no display found. $DISPLAY and $WAYLAND_DISPLAY are both unset, so there '
+    + 'is nowhere to open a window. If you are on a remote shell, this needs a desktop session.');
+  process.exit(1);
+}
+
+/*
  * The viewer, which lives beside this app rather than inside it.
  *
  * In the repository it is `site/playground/`, the same directory the website serves. Packaged, it
@@ -210,6 +223,9 @@ async function checkForUpdates(win, { quiet = false } = {}) {
     currentVersion: app.getVersion(),
     platform: process.platform,
     allowPreRelease: settings.betaReleases,
+    // The AppImage runtime sets this, so it is the one reliable way to know the reader is running
+    // an AppImage - and therefore that another one will actually start for them.
+    linuxFormat: process.env.APPIMAGE ? 'appimage' : null,
   });
 
   if (found.kind !== 'newer') {
@@ -222,6 +238,27 @@ async function checkForUpdates(win, { quiet = false } = {}) {
         buttons: ['OK'],
       });
     }
+    return;
+  }
+
+  /*
+   * A new version this install cannot apply for itself.
+   *
+   * A .deb needs root and a tarball was unpacked wherever the reader chose, so the app has no
+   * business rewriting either. Saying so and opening the page is the honest end of the sentence.
+   */
+  if (!found.file) {
+    const go = await dialog.showMessageBox(win, {
+      type: 'info',
+      message: `f-tree ${found.version} is available.`,
+      detail: 'This copy was installed in a way the app should not overwrite by itself — a .deb '
+        + 'needs your permission, and a folder you unpacked is yours to replace. The download '
+        + 'page has the file for your system.',
+      buttons: ['Open the download page', 'Not now'],
+      defaultId: 0,
+      cancelId: 1,
+    });
+    if (go.response === 0) shell.openExternal('https://ftree.vibethroughcode.com/desktop/');
     return;
   }
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "f-tree-desktop",
   "productName": "f-tree",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A local-first family tree, on your own machine",
   "author": {
     "name": "thisisankit27",
@@ -54,8 +54,9 @@
     ],
     "linux": {
       "target": [
-        "AppImage",
-        "deb"
+        "deb",
+        "tar.gz",
+        "AppImage"
       ],
       "category": "Office",
       "synopsis": "A local-first family tree",

--- a/desktop/update.js
+++ b/desktop/update.js
@@ -40,13 +40,22 @@ function compareVersions(a, b) {
   return a.suffix < b.suffix ? -1 : 1;
 }
 
-/** Which file this platform can actually use. */
-function assetFor(platform, assets) {
+/**
+ * Which file this install can actually use, or null if none of them can be handled for it.
+ *
+ * On Linux this depends on how the app was installed, not merely on the platform, and getting it
+ * wrong is worse than doing nothing: an AppImage will not start at all on a system whose
+ * `fusermount` is FUSE 3 (Ubuntu 24.04 and later), and a `.deb` cannot be installed without root.
+ * So the AppImage is offered only to somebody already running one - where it is known to work,
+ * because they are running it - and everybody else is sent to the download page instead.
+ */
+function assetFor(platform, assets, { linuxFormat = null } = {}) {
   const pick = (test) => assets.find((a) => test(a.name) && /^https:/.test(a.browser_download_url || ''));
   if (platform === 'win32') return pick((n) => /\.exe$/i.test(n));
-  // A .deb can only be installed by apt, an AppImage is a file the reader replaces themselves.
-  // The AppImage is offered because it is the one that needs no permission to put in place.
-  if (platform === 'linux') return pick((n) => /\.AppImage$/i.test(n));
+  if (platform === 'linux') {
+    if (linuxFormat === 'appimage') return pick((n) => /\.AppImage$/i.test(n));
+    return null;
+  }
   return null;
 }
 
@@ -57,7 +66,8 @@ function assetFor(platform, assets) {
  * to stay invisible to the Android updater, so `prerelease` cannot mean "beta" here the way it does
  * there - the *suffix on the tag* does. `desktop-v0.2.0` is stable; `desktop-v0.2.0-beta.1` is not.
  */
-function chooseUpdate({ releases, currentVersion, platform, allowPreRelease = false }) {
+function chooseUpdate({ releases, currentVersion, platform, allowPreRelease = false,
+  linuxFormat = null }) {
   const current = parseVersion(currentVersion);
   if (!current) return { kind: 'no-usable-release' };
   if (!Array.isArray(releases)) return { kind: 'no-usable-release' };
@@ -89,27 +99,34 @@ function chooseUpdate({ releases, currentVersion, platform, allowPreRelease = fa
   const best = candidates[0];
   if (compareVersions(best.version, current) <= 0) return { kind: 'up-to-date' };
 
-  const asset = assetFor(platform, best.release.assets || []);
-  // "Up to date" and "nothing usable" are told apart deliberately: the second is a state of the
-  // repository, not of the reader, and alarming somebody about it points at the wrong thing.
-  if (!asset) return { kind: 'no-usable-release' };
+  const asset = assetFor(platform, best.release.assets || [], { linuxFormat });
 
+  /*
+   * A newer release with nothing this install can apply is still news worth having.
+   *
+   * `file: null` says "there is one, but you fetch it yourself" - which is the honest answer for a
+   * .deb, where installing needs root, and for a tarball the reader unpacked where they chose.
+   * Calling that "nothing usable" would hide a release that exists.
+   */
   return {
     kind: 'newer',
+    file: null,
     version: String(best.release.tag_name).replace(/^desktop-v?/, ''),
     tag: best.release.tag_name,
     notes: (best.release.body || '').trim() || null,
     notesUrl: best.release.html_url,
     publishedAt: best.release.published_at,
-    file: {
-      name: asset.name,
-      size: asset.size,
-      url: asset.browser_download_url,
-      // GitHub publishes this as "sha256:<hex>"; absent on older releases.
-      sha256: /^sha256:[0-9a-f]{64}$/i.test(asset.digest || '')
-        ? asset.digest.slice(7).toLowerCase()
-        : null,
-    },
+    ...(asset ? {
+      file: {
+        name: asset.name,
+        size: asset.size,
+        url: asset.browser_download_url,
+        // GitHub publishes this as "sha256:<hex>"; absent on older releases.
+        sha256: /^sha256:[0-9a-f]{64}$/i.test(asset.digest || '')
+          ? asset.digest.slice(7).toLowerCase()
+          : null,
+      },
+    } : {}),
   };
 }
 

--- a/desktop/update.test.js
+++ b/desktop/update.test.js
@@ -65,12 +65,26 @@ test("the Android app's own releases are not desktop releases", () => {
     browser_download_url: 'https://example.invalid/a.apk' }])]).kind, 'no-usable-release');
 });
 
-test('a release with nothing this platform can use is not an update', () => {
-  // A .deb cannot be installed by the app, so on Linux only the AppImage counts.
-  assert.equal(ask([release('desktop-v0.2.0', [deb('0.2.0')])], { platform: 'linux' }).kind,
-    'no-usable-release');
-  assert.equal(ask([release('desktop-v0.2.0', [appimage('0.2.0')])], { platform: 'linux' }).kind,
-    'newer');
+/*
+ * The bug that started this: an AppImage will not start at all on a system whose `fusermount` is
+ * FUSE 3, which is every Ubuntu from 24.04. Handing one to somebody who installed the .deb would
+ * be handing them a file that does nothing when they double-click it.
+ */
+test('an AppImage is offered only to somebody already running one', () => {
+  const releases = [release('desktop-v0.2.0', [appimage('0.2.0'), deb('0.2.0')])];
+
+  const fromDeb = ask(releases, { platform: 'linux' });
+  assert.equal(fromDeb.kind, 'newer', 'a .deb install should still be told there is a new version');
+  assert.equal(fromDeb.file, null, 'but handed no file it cannot install');
+
+  const fromAppImage = ask(releases, { platform: 'linux', linuxFormat: 'appimage' });
+  assert.equal(fromAppImage.kind, 'newer');
+  assert.match(fromAppImage.file.name, /\.AppImage$/);
+});
+
+test('Windows is always handed its installer', () => {
+  const found = ask([release('desktop-v0.2.0', [exe('0.2.0'), deb('0.2.0')])]);
+  assert.match(found.file.name, /\.exe$/);
 });
 
 test('a missing or malformed digest is reported as absent rather than trusted', () => {
@@ -79,9 +93,13 @@ test('a missing or malformed digest is reported as absent rather than trusted', 
   assert.equal(found.file.sha256, null);
 });
 
-test('a download that is not https is refused', () => {
-  assert.equal(ask([release('desktop-v0.2.0', [{ ...exe('0.2.0'),
-    browser_download_url: 'http://example.invalid/x.exe' }])]).kind, 'no-usable-release');
+test('a download that is not https is never handed over', () => {
+  // The release is still announced - it exists - but the app will not fetch it over plain http,
+  // so there is no file to offer and the reader is sent to the page instead.
+  const found = ask([release('desktop-v0.2.0', [{ ...exe('0.2.0'),
+    browser_download_url: 'http://example.invalid/x.exe' }])]);
+  assert.equal(found.kind, 'newer');
+  assert.equal(found.file, null);
 });
 
 test('version ordering', () => {

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -91,6 +91,28 @@ npm run pack:win     # NSIS installer, on Windows
 CI does both, on `ubuntu-latest` and `windows-latest`, for every change to `desktop/` or to the
 viewer.
 
+## Linux packaging, and the AppImage problem
+
+Three Linux targets, in the order the download page offers them:
+
+| | |
+|---|---|
+| `.deb` | the ordinary answer on Ubuntu, Debian and Mint |
+| `.tar.gz` | a portable folder: unpack anywhere, run it, install nothing |
+| `.AppImage` | for people who prefer them, with a caveat |
+
+**An AppImage will not start on Ubuntu 24.04 or newer by double-clicking.** Those releases replaced
+the FUSE 2 helper the AppImage runtime needs: `/usr/bin/fusermount` is now a symlink to
+`fusermount3`, which speaks a different protocol, and the failure is
+`fusermount: file descriptor 5 is not a socket, can't send fuse fd` in a terminal or nothing at all
+from the desktop. **Installing `libfuse2` does not fix it** — the library is present and the helper
+is what is missing — so the advice found all over the internet is wrong for these releases.
+`--appimage-extract-and-run` works, and the `.deb` and `.tar.gz` need nothing.
+
+That is why the updater only offers an AppImage to somebody already running one, where it is known
+to work because they are running it. A `.deb` install is told a new version exists and sent to the
+download page, because installing one needs root and the app has no business asking for it.
+
 ## Releases, and why they are pre-releases
 
 A desktop release is tagged `desktop-v<version>` and published as a **pre-release**. Neither is

--- a/site/app.js
+++ b/site/app.js
@@ -69,27 +69,24 @@
     }
     if (!rel) return null;
 
-    var files = {};
-    (rel.assets || []).forEach(function (a) {
-      var kind = /\.exe$/i.test(a.name) ? 'windows'
-        : /\.AppImage$/i.test(a.name) ? 'appimage'
-        : /\.deb$/i.test(a.name) ? 'deb'
-        : null;
-      if (!kind) return;
-      files[kind] = {
-        kind: kind,
-        name: a.name,
-        size: a.size,
-        sha256: (a.digest || '').replace(/^sha256:/, ''),
-        url: a.browser_download_url
-      };
-    });
+    // Handed on as a flat list: which files a release has is the pages' business, not this
+    // function's, and naming them here meant adding a branch every time a target was added.
+    var assets = (rel.assets || [])
+      .filter(function (a) { return /^https:/.test(a.browser_download_url || ''); })
+      .map(function (a) {
+        return {
+          name: a.name,
+          size: a.size,
+          sha256: (a.digest || '').replace(/^sha256:/, ''),
+          url: a.browser_download_url
+        };
+      });
 
     return {
       version: (rel.tag_name || '').replace(/^desktop-v/, ''),
       published: rel.published_at,
       notesUrl: rel.html_url,
-      files: files
+      assets: assets
     };
   }
 
@@ -443,19 +440,16 @@
     if (status) status.textContent = 'Your download has started.';
   }
 
-  /* ------------------------------------------------------ the desktop page */
+  /* ------------------------------------------------------ the desktop pages */
 
   /*
-   * Which file this reader wants.
+   * Which file this reader most likely wants.
    *
-   * A guess, and treated as one: it picks the primary button and nothing else, with the other two
-   * kept one click away rather than hidden. `userAgentData` where it exists, the platform string
-   * where it does not, and no pretence of certainty either way.
+   * A guess, and treated as one: it puts a "your system" mark on a card and moves that card first.
+   * It never hides the other one. `?platform=` overrides it, which is how somebody gets the file
+   * for a different machine and how the routing is testable in a browser rather than by reading it.
    */
   function guessPlatform() {
-    // `?platform=windows` overrides the guess. It is how somebody on one machine gets the file for
-    // another - "send me the Windows link" - and it is what makes the routing testable in a real
-    // browser rather than only by reading it.
     var forced = (location.search.match(/[?&]platform=([a-z]+)/i) || [])[1];
     if (forced) return forced.toLowerCase();
 
@@ -470,84 +464,214 @@
     return 'unknown';
   }
 
-  var KIND_LABEL = {
-    windows: 'the Windows installer',
-    deb: 'the .deb for Ubuntu and Debian',
-    appimage: 'the AppImage'
+  /* Each file, as the download page and the thank-you page both need to talk about it. */
+  var FILES = {
+    win: { os: 'windows', what: 'Installer', kind: '.exe', match: /\.exe$/i },
+    deb: { os: 'linux', what: 'Debian / Ubuntu', kind: '.deb', match: /\.deb$/i },
+    tar: { os: 'linux', what: 'Portable folder', kind: '.tar.gz', match: /\.tar\.gz$/i },
+    app: { os: 'linux', what: 'AppImage', kind: '.AppImage', match: /\.AppImage$/i }
   };
+  var ORDER = { windows: ['win'], linux: ['deb', 'tar', 'app'] };
 
-  function wireDesktop(desktop) {
-    var button = document.getElementById('desktop-primary');
-    var label = document.getElementById('desktop-primary-label');
-    var status = document.getElementById('desktop-status');
-    var others = document.getElementById('desktop-others');
-    if (!button) return;
-
-    if (!desktop || !Object.keys(desktop.files).length) {
-      status.textContent = 'Could not reach GitHub just now. The releases page has every build.';
-      label.textContent = 'Open the releases page';
-      return;
-    }
-
-    var platform = guessPlatform();
-
-    // A phone cannot run any of these, and saying so is more use than offering an 80MB installer.
-    if (platform === 'android' || platform === 'ios') {
-      label.textContent = 'Get f-tree for Android';
-      button.href = platform === 'android' ? '../thanks/' : '../';
-      status.textContent = 'This page is for a laptop. On a phone, f-tree is an Android app.';
-      others.innerHTML = '';
-      return;
-    }
-
-    var order = platform === 'windows' ? ['windows', 'deb', 'appimage'] : ['deb', 'appimage', 'windows'];
-    var first = null;
-    order.forEach(function (kind) { if (!first && desktop.files[kind]) first = desktop.files[kind]; });
-    if (!first) return;
-
-    button.href = first.url;
-    button.setAttribute('download', first.name);
-    label.textContent = 'Download ' + KIND_LABEL[first.kind];
-    status.textContent = first.name + ' · ' + megabytes(first.size) + ' · version ' + desktop.version;
-
-    // Mac is not built yet, and pretending otherwise would waste somebody's afternoon.
-    if (platform === 'mac') {
-      status.textContent = 'There is no macOS build yet. These are the Windows and Linux files.';
-    }
-
-    var rest = order.slice(1).filter(function (k) { return desktop.files[k]; });
-    others.innerHTML = rest.length
-      ? 'On another system? ' + rest.map(function (kind) {
-        var f = desktop.files[kind];
-        return '<a href="' + f.url + '" download="' + f.name + '">' + KIND_LABEL[kind]
-          + '</a> (' + megabytes(f.size) + ')';
-      }).join(' &middot; ')
-      : '';
-
-    fillDesktopFacts(desktop);
+  function filesFrom(desktop) {
+    var found = {};
+    Object.keys(FILES).forEach(function (id) {
+      var f = (desktop.assets || []).filter(function (a) { return FILES[id].match.test(a.name); })[0];
+      if (f) found[id] = f;
+    });
+    return found;
   }
 
-  function fillDesktopFacts(desktop) {
-    var version = document.getElementById('dfact-version');
-    var date = document.getElementById('dfact-date');
-    var notes = document.getElementById('dfact-notes');
-    var hashes = document.getElementById('desktop-hashes');
-    if (version) version.textContent = desktop.version;
-    if (date && desktop.published) date.textContent = longDate(desktop.published);
-    if (notes && desktop.notesUrl) notes.href = desktop.notesUrl;
-    if (!hashes) return;
+  function fileRow(id, asset, recommended) {
+    var spec = FILES[id];
+    return '<a class="file' + (recommended ? ' primary' : '') + '" href="thanks/?f=' + id + '">'
+      + '<span class="what">' + spec.what + '</span>'
+      + '<span class="meta">' + spec.kind + '  ·  ' + megabytes(asset.size) + '</span></a>';
+  }
 
-    var rows = ['windows', 'deb', 'appimage'].filter(function (k) { return desktop.files[k]; });
-    hashes.innerHTML = rows.map(function (kind) {
-      var f = desktop.files[kind];
-      return '<div class="hash-row"><p class="hash-name">' + f.name + '</p>'
-        + '<p class="hash">' + (f.sha256 || 'published on the release page') + '</p></div>';
+  function wireDownloads(desktop) {
+    var assurance = document.getElementById('assurance');
+    if (!document.getElementById('platforms')) return;
+
+    if (!desktop || !(desktop.assets || []).length) {
+      assurance.innerHTML = 'Could not reach GitHub just now. '
+        + '<a href="https://github.com/thisisankit27/f-tree/releases?q=desktop&expanded=true">'
+        + 'The releases page has every build.</a>';
+      return;
+    }
+
+    var files = filesFrom(desktop);
+    var platform = guessPlatform();
+
+    ['windows', 'linux'].forEach(function (os) {
+      var ids = ORDER[os].filter(function (id) { return files[id]; });
+      var into = document.getElementById('files-' + os);
+      if (!into) return;
+      into.innerHTML = ids.map(function (id, i) {
+        return fileRow(id, files[id], platform === os && i === 0);
+      }).join('')
+        // Said once, under the row it is about, rather than crammed into a size column.
+        + (files.app && os === 'linux'
+          ? '<p class="caution">On Ubuntu 24.04 and newer an AppImage needs one extra flag to '
+            + 'start. The steps say which; the other two files need nothing.</p>'
+          : '');
+      if (platform === os) {
+        document.getElementById('card-' + os).classList.add('is-yours');
+        document.getElementById('tag-' + os).hidden = false;
+      }
+    });
+
+    assurance.textContent = 'Version ' + desktop.version + ' · released '
+      + (desktop.published ? longDate(desktop.published) : 'recently')
+      + ' · built in the open by GitHub Actions, with a checksum for every file.';
+
+    if (platform === 'android' || platform === 'ios') {
+      assurance.innerHTML = 'This page is for a laptop. On a phone, '
+        + '<a href="../thanks/">f-tree is an Android app</a>.';
+    } else if (platform === 'mac') {
+      assurance.textContent = 'There is no macOS build yet — these are the Windows and Linux files.';
+    }
+  }
+
+  /* ------------------------------------------------ the thank-you page */
+
+  function copyable(command) {
+    return '<span class="copyline"><code>' + command + '</code>'
+      + '<button type="button" class="copy" data-copy="' + command.replace(/"/g, '&quot;')
+      + '">Copy</button></span>';
+  }
+
+  /* The steps for the one file this reader actually took, and no others. */
+  function stepsFor(id, name) {
+    if (id === 'win') return {
+      title: 'Installing on Windows',
+      lede: 'Two clicks past a warning, then it is an ordinary app.',
+      steps: [
+        ['Windows will stop it', 'The installer is not code-signed, so Defender treats it as an '
+          + 'unrecognised app and the publisher reads <b>Unknown</b>. Choose <b>More info</b>, then '
+          + '<b>Run anyway</b>. That is the whole of it — there is nothing else unusual about the file.'],
+        ['Choose where it goes', 'It installs for your account only, so it never asks for an '
+          + 'administrator password and writes nothing outside that folder and your own app data.'],
+        ['Open your tree', 'Export a <code>.ftree</code> from the phone — <b>Settings → Export your '
+          + 'tree</b> — get it onto the laptop, and open it with <b>File → Open tree</b>. It reopens '
+          + 'that file by itself next time.']
+      ]
+    };
+    if (id === 'deb') return {
+      title: 'Installing on Ubuntu or Debian',
+      lede: 'One command, then it is in your applications menu.',
+      steps: [
+        ['Open a terminal where you downloaded it', 'Usually <code>~/Downloads</code>.'],
+        ['Install it', 'The leading <code>./</code> matters — without it apt goes looking for a '
+          + 'package by that name instead of your file.<br>' + copyable('sudo apt install ./' + name)],
+        ['Launch it', 'From the applications menu, or run <code>/opt/f-tree/f-tree-desktop</code>. '
+          + 'Then open a <code>.ftree</code> exported from the phone with <b>File → Open tree</b>.']
+      ]
+    };
+    if (id === 'tar') return {
+      title: 'Running the portable folder',
+      lede: 'Nothing is installed and nothing needs your password.',
+      steps: [
+        ['Unpack it', copyable('tar -xzf ' + name)],
+        ['Run it', 'Straight out of the folder it unpacked into.<br>'
+          + copyable('./' + name.replace(/\.tar\.gz$/, '') + '/f-tree-desktop')],
+        ['Open your tree', 'Export a <code>.ftree</code> from the phone — <b>Settings → Export your '
+          + 'tree</b> — and open it with <b>File → Open tree</b>.']
+      ]
+    };
+    return {
+      title: 'Running the AppImage',
+      lede: 'One file, no install — with one caveat on current Ubuntu.',
+      steps: [
+        ['Make it executable', copyable('chmod +x ' + name)],
+        ['Run it', copyable('./' + name)],
+        ['If nothing happens, run it this way instead', 'On <b>Ubuntu 24.04 and newer</b> an '
+          + 'AppImage will not mount: those releases replaced the FUSE 2 helper it needs with '
+          + '<code>fusermount3</code>. Installing <code>libfuse2</code> does not fix it. This does, '
+          + 'by unpacking to a temporary folder instead:<br>'
+          + copyable('./' + name + ' --appimage-extract-and-run')]
+      ],
+      caution: '<strong>If you would rather not think about any of that,</strong> the '
+        + '<a href="../">.deb or the portable folder</a> both just run.'
+    };
+  }
+
+  function wireThanksDesktop(desktop) {
+    var nameEl = document.getElementById('dl-name');
+    if (!nameEl) return;
+
+    var id = (location.search.match(/[?&]f=([a-z]+)/i) || [])[1] || 'win';
+    if (!FILES[id]) id = 'win';
+
+    if (!desktop) {
+      document.getElementById('dl-eyebrow').textContent = 'Download';
+      document.getElementById('dl-lede').textContent =
+        'Could not reach GitHub just now — the releases page has every build.';
+      return;
+    }
+
+    var files = filesFrom(desktop);
+    var asset = files[id];
+    if (!asset) {
+      document.getElementById('dl-lede').textContent =
+        'That file is not in the latest release. The releases page has every build.';
+      return;
+    }
+
+    nameEl.textContent = asset.name;
+    document.getElementById('dl-meta').textContent =
+      megabytes(asset.size) + '  ·  version ' + desktop.version;
+    var fallback = document.getElementById('dl-fallback');
+    fallback.href = asset.url;
+    fallback.setAttribute('download', asset.name);
+    document.getElementById('dl-sha').textContent = asset.sha256 || 'published with the release';
+
+    var verify = document.getElementById('verify-command');
+    if (verify) {
+      verify.innerHTML = copyable(id === 'win'
+        ? 'certutil -hashfile ' + asset.name + ' SHA256'
+        : 'sha256sum ' + asset.name);
+    }
+
+    var plan = stepsFor(id, asset.name);
+    document.getElementById('steps-title').textContent = plan.title;
+    document.getElementById('steps-lede').textContent = plan.lede;
+    document.getElementById('steps').innerHTML = plan.steps.map(function (step) {
+      return '<li><h3>' + step[0] + '</h3><p>' + step[1] + '</p></li>';
     }).join('');
+    if (plan.caution) {
+      var caution = document.getElementById('steps-caution');
+      caution.innerHTML = plan.caution;
+      caution.hidden = false;
+    }
+
+    wireCopyButtons();
+
+    // Start it without navigating away from the instructions.
+    var frame = document.createElement('iframe');
+    frame.style.display = 'none';
+    frame.src = asset.url;
+    document.body.appendChild(frame);
+  }
+
+  function wireCopyButtons() {
+    document.querySelectorAll('button.copy').forEach(function (button) {
+      button.addEventListener('click', function () {
+        var text = button.dataset.copy;
+        var done = function () {
+          button.textContent = 'Copied';
+          setTimeout(function () { button.textContent = 'Copy'; }, 1600);
+        };
+        if (navigator.clipboard) navigator.clipboard.writeText(text).then(done, function () {});
+        else done();
+      });
+    });
   }
 
   /* -------------------------------------------------------------------- init */
 
-  var onDesktop = !!document.getElementById('desktop-downloads');
+  var onDownloads = !!document.getElementById('platforms');
+  var onDesktopThanks = !!document.getElementById('dl-name');
   var onThanks = !!document.getElementById('apk-link');
 
   wireTheme();
@@ -557,12 +681,14 @@
   loadRelease().then(function (data) {
     if (!data) throw new Error('no releases published');
     fillSpecs(data);
-    if (onDesktop) wireDesktop(data.desktop);
+    if (onDesktopThanks) wireThanksDesktop(data.desktop);
+    else if (onDownloads) wireDownloads(data.desktop);
     else if (onThanks) wireThanks(data);
     else showCounter(data);
   }).catch(function (err) {
     if (window.console) console.warn('f-tree: release data unavailable —', err.message);
-    if (onDesktop) wireDesktop(null);
+    if (onDesktopThanks) wireThanksDesktop(null);
+    else if (onDownloads) wireDownloads(null);
     else if (onThanks) wireThanks(null);
     else hideCounter();
   });

--- a/site/desktop/index.html
+++ b/site/desktop/index.html
@@ -69,227 +69,131 @@
 <main>
 
 <section class="band" style="padding-bottom:0">
-  <div class="shell" style="max-width:780px">
+  <div class="shell" style="max-width:900px">
     <p class="eyebrow">For your laptop</p>
     <h1 style="font-size:clamp(32px,4.6vw,48px);line-height:1.1;font-weight:600;letter-spacing:-0.02em;margin:0 0 18px">
       f-tree on Windows and Ubuntu.
     </h1>
     <p class="lede" style="max-width:38em">
-      It opens a <code>.ftree</code> exported from the phone and draws it the way the phone does —
-      a generation is a column, ancestors at the left. Everything stays on the machine.
+      Opens a <code>.ftree</code> exported from the phone and draws it the way the phone does —
+      a generation is a column, ancestors at the left. Free, open source, no account.
     </p>
+
+    <div class="beta-note">
+      <span class="badge">Beta</span>
+      <span>
+        <strong>This is an early build and it will have rough edges.</strong> It is new, it has been
+        tested by very few people, and it may misbehave — expect that rather than a finished app.
+        The one thing it cannot do is damage your family tree: it only ever <em>reads</em> the
+        <code>.ftree</code> you open, and never writes to it. Building and editing a tree is still
+        the <a href="../thanks/">Android app's</a> job.
+      </span>
+    </div>
 
     <!--
-      The download the reader is most likely to want, chosen from their own platform, with the
-      others a click away rather than hidden. Filled in by app.js from the published release, so
-      a new version needs no edit here; the markup is the fallback if GitHub cannot be reached.
+      One card per system, every file a row of its own.
+      Detection marks a recommendation and nothing more: a reader on a machine the page guessed
+      wrong still sees every file, at the same size, one click away.
     -->
-    <div id="desktop-downloads">
-      <p style="margin:28px 0 0">
-        <a class="btn btn-primary" id="desktop-primary"
-           href="https://github.com/thisisankit27/f-tree/releases?q=desktop&amp;expanded=true">
-          <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M12 3v12m0 0l-4.5-4.5M12 15l4.5-4.5M4 17v2a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-2"/>
-          </svg>
-          <span id="desktop-primary-label">Get the desktop app</span>
-        </a>
-      </p>
-      <p class="status-line" id="desktop-status">Finding the latest build…</p>
-      <p class="status-line" id="desktop-others"></p>
-    </div>
-  </div>
-</section>
+    <div class="platforms" id="platforms">
+      <div class="platform" id="card-windows">
+        <h3>
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 5.6l7.4-1v7.1H3V5.6zm8.6-1.2L21 3v8.7h-9.4V4.4zM3 12.8h7.4v7.1L3 18.9v-6.1zm8.6 0H21V21l-9.4-1.3v-6.9z"/></svg>
+          Windows
+          <span class="tag" id="tag-windows" hidden>Your system</span>
+        </h3>
+        <p>Windows 10 or 11, 64-bit. Installs for your account, so it never asks for an administrator password.</p>
+        <div id="files-windows"></div>
+      </div>
 
-<!--
-  One set of steps per system. Both are shown: a reader on Windows sometimes installs for a
-  relative on Ubuntu, and a page that hides the other half makes them go looking for it.
--->
-<section class="band" id="windows">
-  <div class="shell" style="max-width:780px">
-    <h2 class="rule-label">Installing on Windows</h2>
-
-    <ol class="steps">
-      <li>
-        <h3>Windows will refuse to run it</h3>
-        <p>
-          Not because of anything in the file. Windows trusts installers whose publisher has paid
-          for a code-signing certificate, and f-tree has not — so it arrives as an unrecognised app
-          and Defender stops it. Choose <b>More info</b>, then <b>Run anyway</b>.
-        </p>
-        <p class="quote">
-          <b>“Windows protected your PC.”</b> Microsoft Defender SmartScreen prevented an
-          unrecognised app from starting. — More info → Run anyway
-        </p>
-        <p>
-          The publisher will read <b>Unknown</b>. That is the honest state of it: nobody has
-          vouched for this file except the checksum below, which you can check yourself.
-        </p>
-      </li>
-
-      <li>
-        <h3>Choose where it goes</h3>
-        <p>
-          The installer offers a folder and installs for your account only, so it never asks for an
-          administrator password. Nothing is written outside that folder and your own app data.
-        </p>
-      </li>
-
-      <li>
-        <h3>Open it and open your tree</h3>
-        <p>
-          Export a <code>.ftree</code> from the phone — <b>Settings → Export your tree</b> — get it
-          onto the laptop however you like, and open it with <b>File → Open tree</b>. The app
-          reopens it by itself next time.
-        </p>
-      </li>
-    </ol>
-  </div>
-</section>
-
-<section class="band band-sunk" id="linux">
-  <div class="shell" style="max-width:780px">
-    <h2 class="rule-label">Installing on Ubuntu and other Linux</h2>
-
-    <p style="max-width:38em">
-      Two ways, and the <code>.deb</code> is the easier one if you are on Ubuntu, Debian or Mint —
-      it puts f-tree in your applications menu like anything else. The <code>.AppImage</code> is
-      one file that runs anywhere and installs nothing.
-    </p>
-
-    <ol class="steps">
-      <li>
-        <h3>The .deb — apt, not a double-click</h3>
-        <p>
-          Double-clicking a <code>.deb</code> opens an archive manager on most desktops now, which
-          is not what you want. Install it from the folder you downloaded it to:
-        </p>
-        <p class="quote"><code>sudo apt install ./f-tree-desktop_*_amd64.deb</code></p>
-        <p>The leading <code>./</code> matters — without it apt goes looking for a package by that name.</p>
-      </li>
-
-      <li>
-        <h3>The .AppImage — make it executable first</h3>
-        <p>
-          A downloaded AppImage is not executable, by design. Give it permission and run it:
-        </p>
-        <p class="quote"><code>chmod +x f-tree-*.AppImage &amp;&amp; ./f-tree-*.AppImage</code></p>
-        <p>
-          On Ubuntu 22.04 and newer it may stop with <code>dlopen(): error loading libfuse.so.2</code>.
-          AppImages need the older FUSE library, which no longer ships by default:
-        </p>
-        <p class="quote"><code>sudo apt install libfuse2</code></p>
-        <p>
-          Or skip it entirely with <code>./f-tree-*.AppImage --appimage-extract-and-run</code>, which
-          unpacks to a temporary folder instead.
-        </p>
-      </li>
-
-      <li>
-        <h3>Open your tree</h3>
-        <p>
-          Export a <code>.ftree</code> from the phone — <b>Settings → Export your tree</b> — and open
-          it with <b>File → Open tree</b>. The app reopens it by itself next time.
-        </p>
-      </li>
-    </ol>
-  </div>
-</section>
-
-<section class="band">
-  <div class="shell" style="max-width:780px">
-    <p class="rule-label">Why your computer complains</p>
-    <div class="slab">
-      <h2 style="font-size:26px;margin-bottom:14px">Nobody has vouched for this file</h2>
-      <p>
-        Windows and macOS trust software whose publisher has bought a code-signing certificate and
-        kept a reputation with it. That costs a few hundred pounds a year and identifies a company.
-        f-tree is a free app with no company behind it, so it has neither, and every operating
-        system it lands on will say so.
-      </p>
-      <p>
-        The warning is doing its job. Clicking past one is a habit worth keeping rare, so here is
-        what you can check instead of taking my word for it: every file below was built by GitHub
-        Actions from the public source, in the open, and GitHub — not this page — publishes the
-        checksum. If the hash of your download matches, the file is byte-for-byte the one that came
-        out of that build.
-      </p>
-      <div class="notice">
-        <span aria-hidden="true">◌</span>
-        <span>
-          <strong>What the app can reach.</strong> It reads the file you open and writes one small
-          note of which file that was, so it can reopen it next time. There is no account, no
-          server and no telemetry. The window itself is <em>refused</em> the network outright —
-          every <code>http</code> and <code>https</code> request from the page is cancelled by the
-          app, which is why the typefaces are read from disk rather than fetched from Google. The
-          only request the app can make is the update check below, and that is off until you turn
-          it on. Leave it off and the app never touches the network at all.
-        </span>
+      <div class="platform" id="card-linux">
+        <h3>
+          <svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2c-2.2 0-3.4 1.8-3.4 4 0 1.6.3 2.3-.5 3.6C7 11.4 5.6 13 5.6 15.4c0 .9.3 1.5-.3 2.3-.5.7-.4 1.5.4 1.8.9.3 1.6-.2 2.4.3 1 .6 2.3 1 3.9 1s2.9-.4 3.9-1c.8-.5 1.5 0 2.4-.3.8-.3.9-1.1.4-1.8-.6-.8-.3-1.4-.3-2.3 0-2.4-1.4-4-2.5-5.8-.8-1.3-.5-2-.5-3.6 0-2.2-1.2-4-3.4-4z"/></svg>
+          Ubuntu &amp; Linux
+          <span class="tag" id="tag-linux" hidden>Your system</span>
+        </h3>
+        <p>The <code>.deb</code> if you are on Ubuntu, Debian or Mint. The portable folder if you would rather install nothing.</p>
+        <div id="files-linux"></div>
       </div>
     </div>
+
+    <p class="assurance" id="assurance">Finding the latest build…</p>
   </div>
 </section>
 
 <section class="band band-sunk">
-  <div class="shell" style="max-width:780px">
-    <p class="rule-label">Checking what you got</p>
-    <div class="slab">
-      <h2 style="font-size:26px;margin-bottom:14px">Verify the download</h2>
-      <p>
-        On Linux run <code>sha256sum &lt;file&gt;</code>; on Windows,
-        <code>certutil -hashfile &lt;file&gt; SHA256</code>. Compare the result with the matching
-        line below.
-      </p>
-      <dl class="facts" id="desktop-facts">
-        <div><dt>Version</dt><dd id="dfact-version">the latest desktop release</dd></div>
-        <div><dt>Released</dt><dd id="dfact-date">see the release page</dd></div>
-      </dl>
-      <div id="desktop-hashes"></div>
-      <p style="margin-top:18px">
-        <a id="dfact-notes" href="https://github.com/thisisankit27/f-tree/releases?q=desktop&amp;expanded=true">Release notes and every build on GitHub</a>
-      </p>
-    </div>
-  </div>
-</section>
-
-<section class="band band-sunk" id="updates">
-  <div class="shell" style="max-width:780px">
-    <p class="rule-label">Staying up to date</p>
-    <div class="slab">
-      <h2 style="font-size:26px;margin-bottom:14px">Two switches, both off</h2>
-      <p>
-        Under <b>Updates</b> in the menu bar there are two, and neither is on when you install:
-      </p>
-      <dl class="facts">
-        <div>
-          <dt>Check automatically</dt>
-          <dd>Looks once at startup and says nothing unless there is something to say.</dd>
-        </div>
-        <div>
-          <dt>Offer me betas</dt>
-          <dd>Unfinished builds, as soon as they are published. Asks before it turns on.</dd>
-        </div>
-      </dl>
-      <p style="margin-top:18px">
-        <b>Check for updates now</b> always answers, including &ldquo;you have the newest
-        build&rdquo;, because a question deserves one. Anything downloaded is checked against the
-        SHA-256 GitHub published for it <i>before</i> you are offered it to run; if the two disagree
-        the file is deleted and nothing is installed. On Windows the installer can be run from the
-        app; on Linux the AppImage is downloaded and shown to you, and you put it where you want it.
-      </p>
-    </div>
+  <div class="shell" style="max-width:900px">
+    <p class="expect">
+      <strong>One thing to expect on Windows.</strong> The installer is not code-signed — there is
+      no certificate behind it — so Defender will stop it with <b>“Windows protected your PC”</b>
+      and the publisher will read <b>Unknown</b>. Choose <b>More info</b>, then <b>Run anyway</b>.
+      Every file here is built in the open by GitHub Actions, and each has a checksum you can
+      check on the page that follows your download.
+    </p>
   </div>
 </section>
 
 <section class="band">
-  <div class="shell" style="max-width:780px">
-    <p class="rule-label">One more thing</p>
-    <p style="max-width:38em">
-      The desktop app <b>reads</b> a tree today: the chart, the people index, the search and the
-      relation finder. Editing, settings and the updater are being built —
-      <a href="https://github.com/thisisankit27/f-tree/issues/89">follow along here</a>. Building
-      and editing a tree is the phone's job for now, and the
-      <a href="../thanks/">Android app</a> does all of it.
-    </p>
+  <div class="shell" style="max-width:900px">
+    <p class="rule-label">Good to know</p>
+
+    <details class="folded">
+      <summary>Which Linux file should I take?</summary>
+      <p style="margin:14px 0 0;max-width:40em">
+        The <b>.deb</b> unless you have a reason not to: it puts f-tree in your applications menu
+        like anything else, and updates cleanly. The <b>portable folder</b> installs nothing —
+        unpack it anywhere and run it — which is the one to take on a machine you do not administer.
+      </p>
+      <p style="margin:12px 0 0;max-width:40em">
+        The <b>AppImage</b> is there for people who prefer them, with a caveat worth reading first:
+        on <b>Ubuntu 24.04 and newer</b> it will not start by double-clicking. Those releases
+        replaced the FUSE 2 helper it needs with <code>fusermount3</code>, and the failure is a
+        terse <i>“Cannot mount AppImage”</i> in a terminal, or simply nothing at all from the
+        desktop. Running it as
+        <code>./f-tree-*.AppImage --appimage-extract-and-run</code> works. Installing
+        <code>libfuse2</code> does <em>not</em> fix it on those releases, whatever the internet says.
+      </p>
+    </details>
+
+    <details class="folded">
+      <summary>Is there a macOS build?</summary>
+      <p style="margin:14px 0 0;max-width:40em">
+        Not yet. Windows and Linux are what is built and tested today.
+      </p>
+    </details>
+
+    <details class="folded">
+      <summary>What can the app reach?</summary>
+      <p style="margin:14px 0 0;max-width:40em">
+        It reads the file you open and writes one small note of which file that was, so it can
+        reopen it next time. No account, no server, no telemetry. The window itself is
+        <em>refused</em> the network outright — which is why its typefaces are read from disk rather
+        than fetched from Google. The only request the app can make is the update check, and that
+        is off until you switch it on in <b>Updates</b>.
+      </p>
+    </details>
+
+    <details class="folded">
+      <summary>How do updates work?</summary>
+      <p style="margin:14px 0 0;max-width:40em">
+        Two switches under <b>Updates</b>, both off when you install: <b>check automatically</b>,
+        which looks once at startup and stays quiet unless there is something to say, and
+        <b>offer me betas</b>, which asks before it turns on. Anything downloaded is checked against
+        the SHA-256 GitHub published for it before you are offered it to run; if they disagree the
+        file is deleted and nothing is installed.
+      </p>
+    </details>
+
+    <details class="folded">
+      <summary>What does it do today?</summary>
+      <p style="margin:14px 0 0;max-width:40em">
+        It <b>reads</b> a tree: the chart, the people index, the search and the relation finder.
+        Editing, settings and Hindi kinship are
+        <a href="https://github.com/thisisankit27/f-tree/issues/89">being built</a>. Building and
+        editing a tree is the phone's job for now, and the <a href="../thanks/">Android app</a>
+        does all of it.
+      </p>
+    </details>
   </div>
 </section>
 

--- a/site/desktop/thanks/index.html
+++ b/site/desktop/thanks/index.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Your download — f-tree</title>
+<meta name="description" content="Your f-tree download, with the install steps for the file you took and the checksum to verify it.">
+<meta name="robots" content="noindex">
+<meta name="theme-color" content="#f7f6f1" media="(prefers-color-scheme: light)">
+<meta name="theme-color" content="#10150f" media="(prefers-color-scheme: dark)">
+<link rel="icon" href="../../favicon.svg" type="image/svg+xml">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,600;0,7..72,700;1,7..72,400&family=JetBrains+Mono:wght@400;500&display=swap">
+<link rel="stylesheet" href="../../style.css">
+
+<!--
+  The theme, decided before the first paint.
+
+  This runs where it sits, in the head, so the ground is already the right colour when the page
+  first draws — pushed to the end of the body it would flash bone at a reader who chose dark.
+  Nothing is stamped when there is no stored choice: the absence of the attribute is what lets
+  the prefers-color-scheme rule in style.css keep following the system, including live, while
+  data-js is what reveals the toggle (see style.css).
+-->
+<script>
+(function () {
+  var root = document.documentElement;
+  root.setAttribute('data-js', '');
+  try {
+    var saved = localStorage.getItem('ftree.theme');
+    if (saved === 'dark' || saved === 'light') root.setAttribute('data-theme', saved);
+  } catch (e) { /* private windows and blocked storage both land here; the system decides */ }
+})();
+</script>
+
+</head>
+<body>
+
+<header class="masthead">
+  <div class="shell">
+    <a class="wordmark" href="../../">
+      <svg width="26" height="26" viewBox="0 0 32 32" aria-hidden="true">
+        <rect width="32" height="32" rx="7" fill="var(--mark-tile)"/>
+        <g fill="none" stroke="var(--mark-line)" stroke-width="1.7" stroke-linecap="round">
+          <circle cx="11" cy="9.5" r="3.1"/><circle cx="21" cy="9.5" r="3.1"/>
+          <path d="M14.1 9.5h3.8"/><path d="M16 12.6v3.4M9 16h14M9 16v2.6M23 16v2.6"/>
+          <circle cx="9" cy="22" r="3.1"/>
+          <circle cx="23" cy="22" r="3.1" stroke="var(--mark-dash)" stroke-dasharray="2.2 2"/>
+        </g>
+      </svg>
+      f-tree
+    </a>
+    <nav>
+      <a class="nav-link" href="../">Back to the downloads</a>
+      <button type="button" class="theme-toggle" id="theme-toggle" aria-label="Switch theme">
+        <svg class="i-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M20.5 14.3A8.5 8.5 0 0 1 9.7 3.5a8.5 8.5 0 1 0 10.8 10.8z"/>
+        </svg>
+        <svg class="i-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4.1"/>
+          <path d="M12 2.6v2.2M12 19.2v2.2M4.35 4.35l1.55 1.55M18.1 18.1l1.55 1.55M2.6 12h2.2M19.2 12h2.2M4.35 19.65 5.9 18.1M18.1 5.9l1.55-1.55"/>
+        </svg>
+      </button>
+    </nav>
+  </div>
+</header>
+
+
+<main>
+
+<section class="band" style="padding-bottom:0">
+  <div class="shell" style="max-width:780px">
+    <p class="eyebrow" id="dl-eyebrow">Download started</p>
+    <h1 style="font-size:clamp(30px,4.4vw,44px);line-height:1.12;font-weight:600;letter-spacing:-0.02em;margin:0 0 16px">
+      Thanks — your download is on its way.
+    </h1>
+    <p class="lede" style="max-width:38em" id="dl-lede">
+      It should be in your Downloads folder in a moment. Here is what to do with it.
+    </p>
+
+    <div class="beta-note">
+      <span class="badge">Beta</span>
+      <span>
+        <strong>This is an early build and it will have rough edges.</strong> It is new, it has been
+        tested by very few people, and it may misbehave — expect that rather than a finished app.
+        The one thing it cannot do is damage your family tree: it only ever <em>reads</em> the
+        <code>.ftree</code> you open, and never writes to it. Building and editing a tree is still
+        the <a href="../../thanks/">Android app's</a> job.
+      </span>
+    </div>
+
+    <div class="slab" style="margin-top:26px">
+      <p style="font-family:var(--mono);font-size:15px;margin:0 0 6px" id="dl-name">the latest build</p>
+      <p style="font-family:var(--mono);font-size:12.5px;color:var(--ink-faint);margin:0 0 14px" id="dl-meta"></p>
+      <p style="margin:0"><a id="dl-fallback" href="https://github.com/thisisankit27/f-tree/releases?q=desktop&amp;expanded=true">Download didn't start? Get it here</a></p>
+    </div>
+  </div>
+</section>
+
+<section class="band">
+  <div class="shell" style="max-width:780px">
+    <h2 class="rule-label" id="steps-title">Installing</h2>
+    <p style="max-width:38em;margin:0 0 4px" id="steps-lede"></p>
+    <ol class="steps" id="steps"></ol>
+    <p class="expect" id="steps-caution" hidden></p>
+  </div>
+</section>
+
+<section class="band band-sunk">
+  <div class="shell" style="max-width:780px">
+    <p class="rule-label">Check you got what we built</p>
+    <div class="slab">
+      <h2 style="font-size:24px;margin-bottom:12px">Verify the file</h2>
+      <p style="max-width:40em">
+        Nothing here is code-signed, so this is the honest way to confirm the file is intact. Run
+        the command and compare it with the digest below.
+      </p>
+      <div id="verify-command"></div>
+      <p style="font-family:var(--mono);font-size:12.5px;margin:12px 0 0;overflow-wrap:anywhere">
+        <span style="color:var(--ink-faint)">Expected SHA-256:</span>
+        <span id="dl-sha" style="color:var(--forest)">published with the release</span>
+      </p>
+      <p class="expect" style="margin-top:20px">
+        <strong>What this does and does not prove.</strong> The checksum is published with the
+        release, so it catches a truncated, corrupted or tampered-with <i>download</i> — not a
+        compromised release, since both would come from the same place. Only code signing fixes
+        that. It is still worth thirty seconds before running an installer.
+      </p>
+    </div>
+  </div>
+</section>
+
+<section class="band">
+  <div class="shell" style="max-width:780px">
+    <p class="rule-label">Nothing leaves your computer</p>
+    <p style="max-width:40em">
+      No account, no upload, no telemetry. The window is refused the network outright — its
+      typefaces are read from disk rather than fetched from Google. The only request the app can
+      make is the update check under <b>Updates</b>, and both switches there are off until you turn
+      them on.
+    </p>
+  </div>
+</section>
+
+</main>
+
+
+<footer class="footer">
+  <div class="shell">
+    <span>f-tree — built by <a href="https://github.com/thisisankit27">thisisankit27</a>. MIT licensed.</span>
+    <nav>
+      <a href="../../">Home</a>
+      <a href="../../playground/">Viewer</a>
+      <a href="https://github.com/thisisankit27/f-tree">Source</a>
+      <a href="https://github.com/thisisankit27/f-tree/releases">Releases</a>
+    </nav>
+  </div>
+</footer>
+
+<script src="../../app.js"></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -428,7 +428,7 @@
     <p class="rule-label">On a laptop</p>
     <div class="split split-wide">
       <div>
-        <h2>The way the phone draws it, on a bigger screen</h2>
+        <h2>The way the phone draws it, on a bigger screen <span class="beta-tag">Beta</span></h2>
         <p>
           The desktop app opens the same <code>.ftree</code> and lays it out as the app does &mdash;
           a generation is a column, ancestors at the left, so a family reads from left to right the
@@ -438,8 +438,12 @@
           Windows gets an installer. Ubuntu gets an AppImage or a <code>.deb</code>. Nothing leaves
           the machine and there is no account to make, on either.
         </p>
+        <p style="max-width:34em">
+          It is an <b>early build</b> — new, barely tested, and liable to misbehave. It cannot harm
+          your tree, because it only ever reads the file you open and never writes to it.
+        </p>
         <p class="spec">
-          <span>Windows &amp; Ubuntu</span><span class="sep" aria-hidden="true">&middot;</span><span>Reads a tree today</span><span class="sep" aria-hidden="true">&middot;</span><span>Editing on the way</span>
+          <span>Windows &amp; Ubuntu</span><span class="sep" aria-hidden="true">&middot;</span><span>Beta</span><span class="sep" aria-hidden="true">&middot;</span><span>Reads a tree today</span>
         </p>
         <div class="cta-row">
           <a class="btn btn-primary" href="desktop/">Get the desktop app</a>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -3,5 +3,6 @@
   <url><loc>https://ftree.vibethroughcode.com/</loc><priority>1.0</priority></url>
   <url><loc>https://ftree.vibethroughcode.com/playground/</loc><priority>0.8</priority></url>
   <url><loc>https://ftree.vibethroughcode.com/desktop/</loc><priority>0.7</priority></url>
+  <url><loc>https://ftree.vibethroughcode.com/desktop/thanks/</loc><priority>0.3</priority></url>
   <url><loc>https://ftree.vibethroughcode.com/thanks/</loc><priority>0.5</priority></url>
 </urlset>

--- a/site/style.css
+++ b/site/style.css
@@ -924,3 +924,196 @@ h2.rule-label,
   .steps > li { padding-left: 46px; margin-left: 14px; }
   .steps > li::before { left: -15px; width: 29px; height: 29px; font-size: 12px; }
 }
+
+
+/* ------------------------------------------------- the download cards
+
+   One card per system, every file in it as its own row with its own size, so nothing about
+   choosing depends on the page having guessed the reader's machine correctly. Detection only
+   marks a recommendation; it never hides the other half.
+*/
+
+.platforms {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(310px, 1fr));
+  gap: 20px;
+  margin: 30px 0 0;
+}
+.platform {
+  border: 1px solid var(--rule);
+  border-radius: 16px;
+  padding: 22px 22px 18px;
+  background: var(--raised);
+}
+.platform.is-yours { border-color: var(--forest); box-shadow: 0 0 0 1px var(--forest); }
+.platform h3 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 6px;
+  font-size: 19px;
+  font-weight: 600;
+}
+.platform h3 .tag {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--forest);
+  border: 1px solid var(--forest);
+  border-radius: 999px;
+  padding: 3px 9px;
+}
+.platform > p { margin: 0 0 16px; font-size: 14.5px; color: var(--ink-soft); }
+
+.file {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  width: 100%;
+  border: 1px solid var(--rule);
+  border-radius: 11px;
+  padding: 13px 15px;
+  margin-bottom: 9px;
+  text-decoration: none;
+  color: var(--ink);
+  background: var(--ground);
+  transition: border-color .15s, background .15s;
+}
+.file:hover { border-color: var(--forest); background: var(--raised); }
+.file .what { font-weight: 600; font-size: 15px; }
+.file .meta { margin-left: auto; font-family: var(--mono); font-size: 12px; color: var(--ink-faint); }
+.file.primary { border-color: var(--forest); background: var(--sage-container, var(--raised)); }
+.file.primary .what { color: var(--forest); }
+.platform .caution {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--ink-faint);
+  line-height: 1.55;
+}
+
+/* A single fact bar under the cards. */
+.assurance {
+  margin: 22px 0 0;
+  font-size: 14px;
+  color: var(--ink-faint);
+  text-align: center;
+}
+
+/* "What to expect", set apart by a rule rather than a box within a box. */
+.expect {
+  margin: 34px 0 0;
+  border-left: 3px solid var(--brass);
+  padding: 4px 0 4px 18px;
+  font-size: 14.5px;
+  line-height: 1.65;
+  color: var(--ink-soft);
+}
+.expect strong { color: var(--ink); }
+
+/* The long-form steps, folded away until wanted. */
+details.folded {
+  border-top: 1px solid var(--rule);
+  padding: 16px 0;
+}
+details.folded > summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 16px;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+details.folded > summary::-webkit-details-marker { display: none; }
+details.folded > summary::after {
+  content: "+";
+  margin-left: auto;
+  font-family: var(--mono);
+  color: var(--ink-faint);
+  font-size: 18px;
+}
+details.folded[open] > summary::after { content: "\2013"; }
+details.folded > summary:hover { color: var(--forest); }
+
+
+/* A command you are meant to run, with a button that saves retyping it. */
+.copyline {
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  margin: 10px 0 0;
+  border: 1px solid var(--rule);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--ground);
+}
+.copyline code {
+  flex: 1;
+  padding: 11px 13px;
+  font-family: var(--mono);
+  font-size: 13px;
+  overflow-x: auto;
+  white-space: nowrap;
+  background: none;
+  border: 0;
+}
+.copyline .copy {
+  flex: none;
+  border: 0;
+  border-left: 1px solid var(--rule);
+  background: var(--raised);
+  color: var(--ink-soft);
+  font-family: var(--sans);
+  font-size: 13px;
+  padding: 0 15px;
+  cursor: pointer;
+}
+.copyline .copy:hover { background: var(--forest); color: var(--paper, #fff); }
+
+
+/* An unfinished thing, said plainly rather than in small print. */
+.beta-note {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  margin: 26px 0 0;
+  padding: 16px 18px;
+  border: 1px solid var(--brass);
+  border-radius: 13px;
+  background: var(--brass-surface, transparent);
+  font-size: 14.5px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  max-width: 46em;
+}
+.beta-note .badge {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--brass);
+  border: 1px solid var(--brass);
+  border-radius: 999px;
+  padding: 3px 10px;
+  margin-top: 1px;
+}
+.beta-note strong { color: var(--ink); }
+
+/* A heading that has to carry a caveat with it. */
+.beta-tag {
+  display: inline-block;
+  vertical-align: middle;
+  margin-left: 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--brass);
+  border: 1px solid var(--brass);
+  border-radius: 999px;
+  padding: 3px 10px;
+}


### PR DESCRIPTION
Closes #97. You were right, and I found it by launching things rather than reasoning about them.

### What was actually broken

The **`.deb` was never the problem.** Installed, it launches from the applications menu and draws a window — verified twice, once through `gio launch` to match the menu exactly.

The **AppImage** is:

```
fusermount: file descriptor 5 is not a socket, can't send fuse fd
Cannot mount AppImage, please check your FUSE setup.
```

Ubuntu 24.04+ replaced the FUSE 2 helper the AppImage runtime needs — `/usr/bin/fusermount` is now a symlink to `fusermount3`. `libfuse.so.2` **is** present, so `sudo apt install libfuse2` changes nothing… which is exactly what my download page told people to run. **My advice was wrong for every current Ubuntu.** From a desktop double-click there is no error at all — nothing happens, which is the reported symptom.

Knock-on: the updater was handing Linux users that same file.

### Fixed

- **A `tar.gz` target** — unpack, run, no FUSE, no install, no password. Verified from the tarball on this machine, 10/10 smoke assertions.
- **The updater** offers an AppImage only to somebody already running one (`$APPIMAGE` set), where it demonstrably works. A `.deb` install is told a new version exists and sent to the page, because installing one needs root. That rule has its own test.
- **No display** now prints what is wrong and exits, instead of segfaulting silently.
- Linux guidance corrected everywhere, including that `libfuse2` is *not* the fix.

### The download page, rebuilt

Your criticism was fair. I had one button whose meaning depended on guessing your machine, the alternatives in a run-on sentence, and three walls of install prose for systems you don't have.

Following your sites: **a card per system, every file its own row with its own size**, and each row leads to **its own thank-you page** — the download starts itself, and the page shows the steps for *that one file*, its checksum command with the real filename already in it, and nothing about the other three. Detection only marks a recommendation; it never hides anything.

Verified all four variants render their own steps: `?f=win` gets SmartScreen, `?f=deb` gets `sudo apt install ./…`, `?f=tar` gets extract-and-run, `?f=app` gets the FUSE workaround plus a pointer to the two files that just work.

### Beta, said plainly

On the landing page, the download page and the thank-you page: this is an early build that may misbehave. Paired with the one reassurance that is actually true — **it cannot damage a tree, because it only ever reads the file it opens and never writes to it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)