### PR TITLE
fix(ci): actually ship the portable tarball

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            targets: --linux AppImage deb
+            targets: --linux
           - os: windows-latest
             targets: --win nsis
     runs-on: ${{ matrix.os }}
@@ -86,6 +86,7 @@ jobs:
           path: |
             desktop/dist/*.AppImage
             desktop/dist/*.deb
+            desktop/dist/*.tar.gz
             desktop/dist/*.exe
           if-no-files-found: error
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "f-tree-desktop",
   "productName": "f-tree",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A local-first family tree, on your own machine",
   "author": {
     "name": "thisisankit27",


### PR DESCRIPTION
0.3.0 added a `tar.gz` target — the whole point being a Linux build that needs no FUSE on Ubuntu 24.04+ — and then published a release **without it**.

Two causes, and I had updated neither place:

- the workflow named its own target list on the command line (`--linux AppImage deb`), overriding `package.json`
- the upload glob did not mention `*.tar.gz`

Targets now live in `package.json` alone, so adding one cannot silently fail to ship again.

Caught by reading the published release assets rather than trusting the green tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)