### PR TITLE
Desktop: draw generations as rows, and pin the pre-release rule to #89

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -9,6 +9,19 @@ name: Desktop
 # beta channel. Publishing as a pre-release on top of that keeps `releases/latest` - the endpoint
 # the ordinary channel reads - answering with the newest *app* release. Two independent reasons a
 # phone will never be offered an .AppImage, because there are live users on the app.
+#
+# The pre-release flag now carries a second meaning as well: the desktop app stays a pre-release
+# until issue #89 is finished. Until then it reads a tree and does not build one, and calling any
+# build of it a stable release would claim a completeness it does not have.
+#
+# Worth keeping straight, because the two senses of "beta" are not the same mechanism:
+#
+#   GitHub's pre-release flag  ->  how finished this is. Set on every desktop release.
+#   the tag's suffix           ->  the app's own beta channel. `desktop-v0.3.3` is stable to it;
+#                                  `desktop-v0.3.3-beta.1` is not. See update.js.
+#
+# So a reader who has not opted into betas is still offered `desktop-v0.3.3`. That is deliberate:
+# withholding it would strand people on a build that will not start on current Ubuntu.
 on:
   push:
     branches: [main]
@@ -39,8 +52,9 @@ jobs:
         working-directory: desktop
         run: npm test
 
-      # The layout is checked in both orientations here as well as in the site workflow: the
-      # desktop draws in columns, and that is this app's invariant to keep, not the website's.
+      # The layout is checked in both orientations here as well as in the site workflow. Both
+      # shells draw rows today, but the engine keeps columns and so does this check: an
+      # orientation nobody currently ships is exactly the one that rots unnoticed.
       - name: Check the layout, rows and columns
         run: |
           python3 tools/make_sample_tree.py "$RUNNER_TEMP/fixtures"
@@ -133,5 +147,7 @@ jobs:
             Chromium a working sandbox helper without you touching anything; the portable
             \`.tar.gz\` and the \`.AppImage\` need one \`sudo chmod 4755\` on Ubuntu 24.04+.
 
-          Marked a pre-release on purpose. It is how this repository keeps the Android app's update
-          channel pointing at Android releases; it says nothing about how finished this build is."
+          Marked a pre-release on purpose, for two reasons. It keeps the Android app's update
+          channel pointing at Android releases; and the desktop app stays a pre-release until
+          [#89](https://github.com/thisisankit27/f-tree/issues/89) is done, because it reads a
+          tree today and does not yet build one."

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ package name and signing certificate before it installs anything. See
 ### On a laptop — Windows and Ubuntu
 
 The **[desktop app](https://ftree.vibethroughcode.com/desktop/)**
-opens an exported `.ftree` on a big screen and draws it the way the phone does: a generation is a
-column, ancestors at the left. Windows gets an installer; Linux gets an AppImage or a `.deb`.
+opens an exported `.ftree` on a big screen, laid out for the screen it is on: a generation is a
+row, ancestors at the top, the tree running across the width. Windows gets an installer; on Linux
+take the `.deb`.
 
 It reads a tree today — editing, settings and the updater are
 [being built](https://github.com/thisisankit27/f-tree/issues/89). Nothing leaves the machine.

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -52,6 +52,22 @@ const VIEWER = app.isPackaged
 /* The mark, for the window and its place in the taskbar. */
 const ICON_FOR_WINDOW = path.join(__dirname, 'build', 'icons', '256x256.png');
 
+/*
+ * The smoke test gets a userData directory of its own.
+ *
+ * Several of its assertions are about *defaults* - update checking off, beta releases off - and
+ * settings persist, so run from a machine where somebody has been using the app and the test reads
+ * their choices and reports the app broken. That is a false alarm on a developer's machine and,
+ * worse, silence on CI: there the directory is always fresh, so a bug that flipped a default would
+ * pass. Neither is a test. Point it somewhere empty and it asserts what it says it asserts.
+ *
+ * Before `app.whenReady()` on purpose: `setPath` is only honoured this early.
+ */
+if (process.env.FTREE_SMOKE) {
+  app.setPath('userData', require('node:fs')
+    .mkdtempSync(path.join(os.tmpdir(), 'ftree-smoke-')));
+}
+
 const stateFile = () => path.join(app.getPath('userData'), 'session.json');
 const settingsFile = () => path.join(app.getPath('userData'), 'settings.json');
 
@@ -545,7 +561,7 @@ ipcMain.handle('tree:last', async () => {
  * shell, the preload bridge and the viewer only meet each other once a window exists. So the test
  * is the real app, started the real way, opening a real `.ftree` - and it asserts the things that
  * would actually be broken if the wiring came apart: the bridge is reachable, the tree arrived,
- * every person was drawn, and the generations run in columns rather than rows.
+ * every person was drawn, and the layout ran.
  */
 async function runSmoke(win, file) {
   const failures = [];
@@ -593,8 +609,13 @@ async function runSmoke(win, file) {
   check('the tree opened', seen.state === 'loaded',
     `${seen.state}${seen.openerError ? ' — ' + seen.openerError : ''}${seen.hint ? ' — ' + seen.hint : ''}`);
   check('the file name is shown', Boolean(seen.fileName), String(seen.fileName));
-  // The whole reason the desktop app is not just the website in a window.
-  check('generations run in columns, as they do in the app', seen.orientation === 'columns',
+  /*
+   * Both shells are landscape readers: a generation is a row. This asserted `columns` until the
+   * desktop app was looked at on an actual laptop, where following the phone read badly. It is
+   * kept, pointing the other way, because it is the assertion that catches the layout silently
+   * not running -- `orientation` is only set once `layoutArchive` has returned.
+   */
+  check('generations run in rows, as they do on the website', seen.orientation === 'rows',
     String(seen.orientation));
   check('the archive was read and counted', /\d+ people/.test(seen.status ?? ''), String(seen.status));
   // Refusing the network must not quietly cost the app its typography.

--- a/site/desktop/index.html
+++ b/site/desktop/index.html
@@ -75,8 +75,9 @@
       f-tree on Windows and Ubuntu.
     </h1>
     <p class="lede" style="max-width:38em">
-      Opens a <code>.ftree</code> exported from the phone and draws it the way the phone does —
-      a generation is a column, ancestors at the left. Free, open source, no account.
+      Opens a <code>.ftree</code> exported from the phone and lays it out for the screen it is
+      on — a generation is a row, ancestors at the top, the tree running across the width. Free,
+      open source, no account.
     </p>
 
     <div class="beta-note">

--- a/site/playground/main.js
+++ b/site/playground/main.js
@@ -119,7 +119,7 @@ async function openFile(file) {
     if (graph.people.size === 0) {
       throw new ArchiveError('That file parsed, but it has no people in it.');
     }
-    const layout = layoutArchive(graph, { orientation: ORIENTATION });
+    const layout = layoutArchive(graph, { orientation: 'rows' });
 
     releasePhotos();
     state.graph = graph;
@@ -836,12 +836,16 @@ function wireKeys() {
  * for. Everything below is additive: with no shell there is no `desktop`, and the website behaves
  * exactly as it did.
  *
- * The one thing that genuinely differs is which way the tree runs. On the web this is a landscape
- * reader for a whole archive on a big screen, and generations read as rows. The desktop app is the
- * Android app's sibling and follows the app: a generation is a column, ancestors at the left.
+ * The tree runs the same way in both. It did not at first: the desktop app followed the phone and
+ * drew a generation as a column, on the reasoning that it is the Android app's sibling. Seen on a
+ * laptop that was simply worse -- a column layout is what you reach for when the screen is taller
+ * than it is wide, and a laptop never is. So both shells are landscape readers now, generations as
+ * rows, and the shell no longer changes how the tree is drawn at all.
+ *
+ * The engine still does both, and `tools/check_layout.mjs` still checks both in CI. Columns are a
+ * layout this can offer again -- as a setting, if it is ever wanted -- not a capability thrown away.
  */
 const desktop = globalThis.ftreeDesktop ?? null;
-const ORIENTATION = desktop ? 'columns' : 'rows';
 
 function wireDesktop() {
   if (!desktop) return;


### PR DESCRIPTION
Two things Ankit asked for after 0.3.3 finally started on his Ubuntu machine.

## 1. Rows, not columns

The desktop app followed the phone: a generation was a column, ancestors at the left. #89 called
for that explicitly, and the reasoning was that the desktop app is the Android app's sibling.

On an actual laptop it reads badly, and the reason is not subtle: **columns are the layout for a
screen taller than it is wide, and a laptop never is.** Following the phone gave the desktop the
phone's answer to a question it was not asking. Both shells are landscape readers now — a
generation is a row, ancestors at the top, the tree running across the width.

`layoutArchive` is asked for rows at its one call site and the shell no longer changes how the
tree is drawn at all. That removes the last behavioural difference between the website viewer and
the desktop app, and with it a divergence that could drift.

**The engine keeps both orientations and CI still checks both.** Deliberate: an orientation nobody
currently ships is exactly the one that rots unnoticed, and columns should stay available as a
setting if it is ever wanted.

## 2. The desktop app stays a pre-release until #89

It already published as one, but for an unrelated reason — keeping `releases/latest` pointing at
Android releases so a phone is never offered an `.AppImage`. The workflow now records the second
reason too, and the release notes say it.

**The two senses of "beta" are different mechanisms, and conflating them would strand people:**

| | means | set by |
|---|---|---|
| GitHub pre-release flag | how finished this is | every desktop release |
| the tag's suffix | the app's own beta channel | `desktop-v0.3.3` stable, `-beta.1` not |

`update.js` reads the **suffix**, never the flag. So a reader who has not opted into betas is still
offered `desktop-v0.3.3` — which matters right now, because withholding it would strand Ubuntu
users on a build that will not start.

## Also: the smoke test was not hermetic

Several assertions are about *defaults* — update checking off, beta releases off — but settings
persist, so on a machine where the app has actually been used it read the real user's choices and
reported the app broken. **It did exactly that here**, and I nearly filed it as a regression.

On CI the directory is always fresh, so the same test would stay silent if a default were ever
flipped. Noisy locally, blind where it matters. It now gets a `userData` directory of its own.

## Checks

- Smoke: 11/11, including `generations run in rows` and the updater reaching GitHub
- `tools/check_layout.mjs`: all invariants, **both** orientations
- Screenshot verified: G1–G5 down the left, tree across the width
- Measured `fit()` while I was there — `sy = (465−80)/1208 = 0.319`, the scale it picks. Correct.
- `git status --short app/` empty: **the Android app is untouched**

🤖 Generated with [Claude Code](https://claude.com/claude-code)