### PR TITLE
The .ftree writer

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -60,6 +60,12 @@ jobs:
           python3 tools/make_sample_tree.py "$RUNNER_TEMP/fixtures"
           node tools/check_layout.mjs "$RUNNER_TEMP/fixtures"
 
+      # The writer is the first piece of the editor, and the only reader that matters for it is the
+      # Android app's: it walks local file headers, so an archive whose sizes live in a data
+      # descriptor reads as empty there. Checked against a real export, both directions.
+      - name: Check the .ftree writer
+        run: node tools/check_writer.mjs "$RUNNER_TEMP/fixtures"
+
       # A desktop app cannot be checked by reading it: the shell, the preload bridge and the viewer
       # only meet once a window exists. So this starts the real app and asserts what would actually
       # be broken if the wiring came apart.

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,6 +58,12 @@ jobs:
           python3 tools/make_sample_tree.py "$RUNNER_TEMP/fixtures"
           node tools/check_layout.mjs "$RUNNER_TEMP/fixtures"
 
+      # The writer is the first piece of the editor, and the only reader that matters for it is the
+      # Android app's: it walks local file headers, so an archive whose sizes live in a data
+      # descriptor reads as empty there. Checked against a real export, both directions.
+      - name: Check the .ftree writer
+        run: node tools/check_writer.mjs "$RUNNER_TEMP/fixtures"
+
       - name: Check the viewer's module graph resolves
         run: |
           set -euo pipefail

--- a/site/playground/write.js
+++ b/site/playground/write.js
@@ -1,0 +1,248 @@
+/*
+ * Writing a .ftree archive.
+ *
+ * The counterpart to archive.js, and the first piece of the editor: until a tree can go back to
+ * disk, nothing that changes one can be built. What it produces has to be openable by the Android
+ * app, because that is where these files live — a file only this code can read would be a private
+ * format wearing the same extension.
+ *
+ * Two facts about the other end shape everything here, and they pull in opposite directions.
+ *
+ * Reading, the app writes with `java.util.zip.ZipOutputStream`, which for a DEFLATED entry zeroes
+ * the CRC and both sizes in the local header, sets general purpose bit 3, and puts the real values
+ * in a data descriptor after the compressed bytes. So archive.js must read the central directory;
+ * a reader trusting local headers sees every entry as empty. That note is at the top of that file.
+ *
+ * Writing, the app reads with `java.util.zip.ZipInputStream` (TreeImporter.readDocument), which
+ * walks *local headers* forward and never looks at the central directory at all. So the asymmetry
+ * runs the other way and is the single most important thing in this file:
+ *
+ *      every local header must carry the true CRC-32 and both sizes, up front.
+ *
+ * No data descriptor, no bit 3, no streaming. The whole archive is built in memory and every size
+ * is known before its header is written. A family tree is a few hundred kilobytes plus photographs
+ * the machine was already holding, so buying certainty with memory is the right trade — and the
+ * archive stays readable by both readers, and by `unzip`, Python and anything else.
+ *
+ * The JSON matches what the app's own exporter emits, field for field: `format` and `version`
+ * always, everything else omitted when it equals its default. Kotlin would accept explicit nulls,
+ * so this is not required — but a file written here should be indistinguishable from one written
+ * there, and small for the same reasons.
+ */
+
+const ENTRY_JSON = 'tree.json';
+const ENTRY_PHOTOS = 'photos/';
+const FORMAT = 'f-tree';
+const VERSION = 1;
+
+const SIG_LOCAL = 0x04034b50;
+const SIG_CENTRAL = 0x02014b50;
+const SIG_EOCD = 0x06054b50;
+
+const METHOD_STORE = 0;
+const METHOD_DEFLATE = 8;
+
+/* Written into every header. 20 means "2.0", which is what DEFLATE requires and no more. */
+const VERSION_MADE_BY = 20;
+const VERSION_NEEDED = 20;
+
+export class WriteError extends Error {}
+
+/** Present wherever this runs: a modern browser, the Electron renderer, and Node 18+. */
+export const canCompress = typeof CompressionStream === 'function';
+
+/* ------------------------------------------------------------------ the document */
+
+/**
+ * The exchange format, with defaults left out.
+ *
+ * Mirrors `ExportJson` in the app (`encodeDefaults = false`), so `deceased` appears only when
+ * true, `origins` only when there is one, and an absent name is an absent key rather than a null.
+ * `format` and `version` are always written even though they equal their defaults: they are how a
+ * reader knows what it is holding, and the app marks them `@EncodeDefault(ALWAYS)` for that reason.
+ */
+export function encodeDocument(document) {
+  const doc = { format: FORMAT, version: VERSION };
+  if (document.exportedAt) doc.exportedAt = document.exportedAt;
+  if (document.sourceTreeId) doc.sourceTreeId = document.sourceTreeId;
+
+  const people = (document.people ?? []).map((person) => {
+    if (!person?.id) throw new WriteError('Every person needs an id.');
+    const out = { id: person.id };
+    if (person.name != null) out.name = person.name;
+    if (person.gender != null) out.gender = person.gender;
+    if (person.birthDate != null) out.birthDate = person.birthDate;
+    if (person.deathDate != null) out.deathDate = person.deathDate;
+    if (person.deceased) out.deceased = true;
+    if (person.photo != null) out.photo = person.photo;
+    if (person.notes != null) out.notes = person.notes;
+    const origins = (person.origins ?? [])
+      .filter((o) => o && o.treeId && o.personId)
+      .map((o) => ({ treeId: o.treeId, personId: o.personId }));
+    if (origins.length) out.origins = origins;
+    return out;
+  });
+  if (people.length) doc.people = people;
+
+  const relationships = (document.relationships ?? []).map((edge) => {
+    if (!edge?.id || !edge.from || !edge.to || !edge.type) {
+      throw new WriteError('Every relationship needs an id, both ends and a type.');
+    }
+    const out = { id: edge.id, from: edge.from, to: edge.to, type: edge.type };
+    if (edge.subtype != null) out.subtype = edge.subtype;
+    return out;
+  });
+  if (relationships.length) doc.relationships = relationships;
+
+  return doc;
+}
+
+/* ------------------------------------------------------------------ the ZIP */
+
+let crcTable = null;
+
+function crc32(bytes) {
+  if (!crcTable) {
+    crcTable = new Uint32Array(256);
+    for (let n = 0; n < 256; n += 1) {
+      let c = n;
+      for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+      crcTable[n] = c >>> 0;
+    }
+  }
+  let crc = 0xffffffff;
+  for (let i = 0; i < bytes.length; i += 1) crc = crcTable[(crc ^ bytes[i]) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+async function deflateRaw(bytes) {
+  const stream = new Blob([bytes]).stream().pipeThrough(new CompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/**
+ * MS-DOS date and time, which is what a ZIP header stores.
+ *
+ * Two-second resolution and no time zone: that is the format, not an approximation chosen here.
+ * Local time, because every other tool writes local time and a reader showing a file's timestamp
+ * two hours out is a puzzle nobody needs. Dates before 1980 cannot be represented and clamp.
+ */
+function dosDateTime(date) {
+  const year = Math.max(1980, date.getFullYear());
+  return {
+    time: (date.getHours() << 11) | (date.getMinutes() << 5) | (Math.floor(date.getSeconds() / 2)),
+    date: ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate(),
+  };
+}
+
+/**
+ * One entry, compressed and measured.
+ *
+ * Stored rather than deflated when deflating made it bigger, which happens with small already-
+ * compressed data — a JPEG thumbnail, most often. Both methods are ordinary ZIP and every reader
+ * handles them; there is no reason to pay bytes for the label.
+ */
+async function prepareEntry(name, bytes) {
+  const nameBytes = new TextEncoder().encode(name);
+  if (nameBytes.length > 0xffff) throw new WriteError(`Entry name too long: ${name}`);
+
+  let method = METHOD_STORE;
+  let body = bytes;
+  if (bytes.length > 0 && canCompress) {
+    const deflated = await deflateRaw(bytes);
+    if (deflated.length < bytes.length) {
+      method = METHOD_DEFLATE;
+      body = deflated;
+    }
+  }
+  return { nameBytes, method, body, crc: crc32(bytes), size: bytes.length };
+}
+
+/**
+ * A `.ftree`: `tree.json` first, then one entry per photo.
+ *
+ * `tree.json` leads because the app's reader stops at it, so putting it first means opening a
+ * tree never reads past the only entry it wanted. No `photos/` directory entry is written; the
+ * app's exporter does not write one either, and the paths carry the structure.
+ *
+ * @param {object} document        the tree, in the exchange shape
+ * @param {Map<string, Uint8Array>|object} photos  entry path -> bytes, e.g. `photos/abc.jpg`
+ * @param {Date} now               timestamp for the entries
+ * @returns {Promise<Uint8Array>}  the whole archive
+ */
+export async function writeTreeArchive(document, photos = new Map(), now = new Date()) {
+  const json = new TextEncoder().encode(JSON.stringify(encodeDocument(document)));
+
+  const photoEntries = photos instanceof Map ? [...photos] : Object.entries(photos ?? {});
+  for (const [name] of photoEntries) {
+    if (!name.startsWith(ENTRY_PHOTOS) || name.endsWith('/')) {
+      throw new WriteError(`A photo entry must be a file under ${ENTRY_PHOTOS}, got: ${name}`);
+    }
+  }
+
+  const entries = [await prepareEntry(ENTRY_JSON, json)];
+  for (const [name, bytes] of photoEntries) {
+    entries.push(await prepareEntry(name, bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes)));
+  }
+
+  const { time, date } = dosDateTime(now);
+  const local = entries.reduce((n, e) => n + 30 + e.nameBytes.length + e.body.length, 0);
+  const central = entries.reduce((n, e) => n + 46 + e.nameBytes.length, 0);
+
+  const out = new Uint8Array(local + central + 22);
+  const view = new DataView(out.buffer);
+  let at = 0;
+
+  for (const entry of entries) {
+    entry.offset = at;
+    view.setUint32(at, SIG_LOCAL, true);
+    view.setUint16(at + 4, VERSION_NEEDED, true);
+    // Flags zero: no data descriptor, because the app reads local headers and would believe them.
+    view.setUint16(at + 6, 0, true);
+    view.setUint16(at + 8, entry.method, true);
+    view.setUint16(at + 10, time, true);
+    view.setUint16(at + 12, date, true);
+    view.setUint32(at + 14, entry.crc, true);
+    view.setUint32(at + 18, entry.body.length, true);
+    view.setUint32(at + 22, entry.size, true);
+    view.setUint16(at + 26, entry.nameBytes.length, true);
+    view.setUint16(at + 28, 0, true);
+    at += 30;
+    out.set(entry.nameBytes, at); at += entry.nameBytes.length;
+    out.set(entry.body, at); at += entry.body.length;
+  }
+
+  const centralAt = at;
+  for (const entry of entries) {
+    view.setUint32(at, SIG_CENTRAL, true);
+    view.setUint16(at + 4, VERSION_MADE_BY, true);
+    view.setUint16(at + 6, VERSION_NEEDED, true);
+    view.setUint16(at + 8, 0, true);
+    view.setUint16(at + 10, entry.method, true);
+    view.setUint16(at + 12, time, true);
+    view.setUint16(at + 14, date, true);
+    view.setUint32(at + 16, entry.crc, true);
+    view.setUint32(at + 20, entry.body.length, true);
+    view.setUint32(at + 24, entry.size, true);
+    view.setUint16(at + 28, entry.nameBytes.length, true);
+    view.setUint16(at + 30, 0, true);   // extra
+    view.setUint16(at + 32, 0, true);   // comment
+    view.setUint16(at + 34, 0, true);   // disk
+    view.setUint16(at + 36, 0, true);   // internal attributes
+    view.setUint32(at + 38, 0, true);   // external attributes
+    view.setUint32(at + 42, entry.offset, true);
+    at += 46;
+    out.set(entry.nameBytes, at); at += entry.nameBytes.length;
+  }
+
+  view.setUint32(at, SIG_EOCD, true);
+  view.setUint16(at + 4, 0, true);
+  view.setUint16(at + 6, 0, true);
+  view.setUint16(at + 8, entries.length, true);
+  view.setUint16(at + 10, entries.length, true);
+  view.setUint32(at + 12, central, true);
+  view.setUint32(at + 16, centralAt, true);
+  view.setUint16(at + 20, 0, true);
+
+  return out;
+}

--- a/tools/check_writer.mjs
+++ b/tools/check_writer.mjs
@@ -1,0 +1,294 @@
+/*
+ * The .ftree writer, checked against the reader that matters.
+ *
+ * `site/playground/write.js` exists so the desktop app can save a tree. The question it has to
+ * answer is not "can we read back what we wrote" - that only proves this code agrees with itself -
+ * but "will the Android app open it". So the assertions below are about the format, and the sharp
+ * one is about local file headers.
+ *
+ *   TreeImporter.readDocument reads with java.util.zip.ZipInputStream, which walks LOCAL headers
+ *   forward and never consults the central directory.
+ *
+ * The app's own exporter gets away with zeroed local headers because it writes a data descriptor
+ * and ZipInputStream understands its own convention. This writer does not rely on that: it writes
+ * the true CRC and both sizes into every local header, so the archive is readable by a reader that
+ * trusts local headers, by one that reads the central directory, and by `unzip`.
+ *
+ * Run: node tools/check_writer.mjs [fixtures-dir]
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const playground = path.join(here, '..', 'site', 'playground');
+
+const { writeTreeArchive, encodeDocument, WriteError } = await import(
+  path.join(playground, 'write.js'));
+const { openArchive, parseDocument } = await import(path.join(playground, 'archive.js'));
+
+let failures = 0;
+let checks = 0;
+
+function ok(what, condition, detail = '') {
+  checks += 1;
+  if (condition) {
+    console.log(`  ok   ${what}${detail ? '  ' + detail : ''}`);
+  } else {
+    failures += 1;
+    console.log(` FAIL  ${what}${detail ? '  ' + detail : ''}`);
+  }
+}
+
+function section(title) {
+  console.log(`\n=== ${title}`);
+}
+
+/**
+ * Compares content, not key order.
+ *
+ * The app's exporter writes a person's fields in declaration order and so does this writer; the
+ * generated fixture happens to write `gender` before `name`. That difference is invisible to every
+ * reader of JSON and asserting on it would be asserting on the fixture generator, not the format.
+ */
+function same(a, b) {
+  const norm = (v) => {
+    if (Array.isArray(v)) return v.map(norm);
+    if (v && typeof v === 'object') {
+      return Object.fromEntries(Object.keys(v).sort().map((k) => [k, norm(v[k])]));
+    }
+    return v;
+  };
+  return JSON.stringify(norm(a)) === JSON.stringify(norm(b));
+}
+
+/* ---------------------------------------------------------------- a local-header reader */
+
+/**
+ * Walks local file headers the way ZipInputStream does, and refuses to guess.
+ *
+ * Deliberately does NOT implement data descriptors. Java would cope with those; this is here to
+ * show that our archive needs no such coping, which is the property being asserted. Anything it
+ * cannot read from the header alone, it reports rather than repairs.
+ */
+function walkLocalHeaders(bytes) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const entries = [];
+  let at = 0;
+  while (at + 30 <= bytes.length && view.getUint32(at, true) === 0x04034b50) {
+    const flags = view.getUint16(at + 6, true);
+    const method = view.getUint16(at + 8, true);
+    const crc = view.getUint32(at + 14, true);
+    const compressed = view.getUint32(at + 18, true);
+    const uncompressed = view.getUint32(at + 22, true);
+    const nameLen = view.getUint16(at + 26, true);
+    const extraLen = view.getUint16(at + 28, true);
+    const name = new TextDecoder().decode(bytes.subarray(at + 30, at + 30 + nameLen));
+    const start = at + 30 + nameLen + extraLen;
+    entries.push({
+      name, flags, method, crc, compressed, uncompressed,
+      streamed: Boolean(flags & 0x8),
+      body: bytes.subarray(start, start + compressed),
+    });
+    at = start + compressed;
+  }
+  return entries;
+}
+
+async function inflate(entry) {
+  if (entry.method === 0) return entry.body;
+  const stream = new Blob([entry.body]).stream()
+    .pipeThrough(new DecompressionStream('deflate-raw'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+/* ---------------------------------------------------------------- the document under test */
+
+const sample = {
+  exportedAt: '2026-09-09T12:00:00Z',
+  sourceTreeId: 'tree-under-test',
+  people: [
+    { id: 'p1', name: 'Ada', gender: 'FEMALE', birthDate: '1815-12-10', deceased: true,
+      deathDate: '1852-11-27', notes: 'first', origins: [{ treeId: 't0', personId: 'x1' }] },
+    { id: 'p2', name: 'Byron', gender: 'MALE' },
+    { id: 'p3' },
+  ],
+  relationships: [
+    { id: 'r1', from: 'p2', to: 'p1', type: 'PARENT' },
+    { id: 'r2', from: 'p1', to: 'p3', type: 'SPOUSE', subtype: 'MARRIED' },
+  ],
+};
+
+section('the JSON matches what the app writes');
+{
+  const doc = encodeDocument(sample);
+  ok('format and version are always written', doc.format === 'f-tree' && doc.version === 1);
+  ok('a person with nothing but an id is just an id',
+    JSON.stringify(doc.people[2]) === '{"id":"p3"}', JSON.stringify(doc.people[2]));
+  ok('deceased:false is left out, as encodeDefaults=false does',
+    !('deceased' in doc.people[1]));
+  ok('deceased:true is written', doc.people[0].deceased === true);
+  ok('an empty origins list is left out', !('origins' in doc.people[1]));
+  ok('origins are written when present',
+    doc.people[0].origins[0].treeId === 't0' && doc.people[0].origins[0].personId === 'x1');
+  ok('an absent name is an absent key, not a null',
+    !('name' in doc.people[2]) && !JSON.stringify(doc).includes('null'));
+  ok('a null subtype is left out', !('subtype' in doc.relationships[0]));
+
+  let refused = null;
+  try { encodeDocument({ people: [{ name: 'no id' }] }); } catch (e) { refused = e; }
+  ok('a person without an id is refused, not written', refused instanceof WriteError,
+    refused ? refused.message : 'nothing thrown');
+
+  refused = null;
+  try { encodeDocument({ relationships: [{ id: 'r', from: 'a', type: 'PARENT' }] }); }
+  catch (e) { refused = e; }
+  ok('a relationship missing an end is refused', refused instanceof WriteError,
+    refused ? refused.message : 'nothing thrown');
+}
+
+section('every local header carries the truth — what ZipInputStream needs');
+const written = await writeTreeArchive(sample, new Map([
+  ['photos/one.jpg', new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3, 4, 5, 6, 7, 8])],
+]));
+{
+  const entries = walkLocalHeaders(written);
+  ok('every entry is found by walking local headers alone', entries.length === 2,
+    entries.map((e) => e.name).join(', '));
+  ok('tree.json comes first, so a reader stops at the entry it wanted',
+    entries[0]?.name === 'tree.json');
+  ok('no entry defers its sizes to a data descriptor',
+    entries.every((e) => !e.streamed));
+  ok('every local header states a real uncompressed size',
+    entries.every((e) => e.uncompressed > 0),
+    entries.map((e) => `${e.name}=${e.uncompressed}`).join(' '));
+  ok('every local header states a real CRC', entries.every((e) => e.crc !== 0));
+
+  const json = new TextDecoder().decode(await inflate(entries[0]));
+  ok('tree.json inflates from the local header alone', json.startsWith('{"format":"f-tree"'));
+  ok('the document survives that route',
+    parseDocument(json).people.length === 3);
+  ok('no photos/ directory entry is written, as the app does not write one',
+    !entries.some((e) => e.name === 'photos/'));
+}
+
+section('the central directory agrees with the local headers');
+{
+  const archive = await openArchive(written.buffer.slice(
+    written.byteOffset, written.byteOffset + written.byteLength));
+  ok('archive.js finds both entries', archive.names().length === 2, archive.names().join(', '));
+  const doc = parseDocument(await archive.readText('tree.json'));
+  ok('the people come back', doc.people.length === 3);
+  ok('the relationships come back', doc.relationships.length === 2);
+  ok('a photo comes back byte for byte',
+    (await archive.read('photos/one.jpg'))[0] === 0xff);
+}
+
+section('a real export from the app round-trips');
+{
+  const fixtures = process.argv[2] || playground;
+  const file = path.join(fixtures, 'sample-family.ftree');
+  const original = new Uint8Array(await readFile(file));
+
+  const first = await openArchive(original.buffer.slice(
+    original.byteOffset, original.byteOffset + original.byteLength));
+  const before = parseDocument(await first.readText('tree.json'));
+
+  const photos = new Map();
+  for (const name of first.names()) {
+    if (name.startsWith('photos/') && !name.endsWith('/')) photos.set(name, await first.read(name));
+  }
+
+  const rewritten = await writeTreeArchive(before, photos);
+  const second = await openArchive(rewritten.buffer.slice(
+    rewritten.byteOffset, rewritten.byteOffset + rewritten.byteLength));
+  const after = parseDocument(await second.readText('tree.json'));
+
+  ok('the same people, in the same order',
+    same(before.people, after.people), `${before.people.length} people`);
+  ok('the same relationships',
+    same(before.relationships, after.relationships), `${before.relationships.length} edges`);
+  ok('every photo survives',
+    [...photos.keys()].every((n) => second.has(n)), `${photos.size} photos`);
+
+  /*
+   * The asymmetry, asserted rather than described.
+   *
+   * The app's own archive defers its sizes to data descriptors - which is exactly why archive.js
+   * must read the central directory. Ours does not. If this ever stops being true of the app's
+   * file, the note at the top of archive.js needs revisiting; if it stops being true of ours, the
+   * Android app stops opening what the desktop saved.
+   */
+  const ours = walkLocalHeaders(rewritten);
+  ok('this writer does not defer, so a local-header reader can read it',
+    ours.every((e) => !e.streamed && e.uncompressed > 0),
+    `${ours.length} entries, sizes ${ours.map((e) => e.uncompressed).join('/')}`);
+
+  /*
+   * The asymmetry, asserted rather than described - against the archive that actually has data
+   * descriptors. `sample-family.ftree` is written seekably and does not; `sample-streamed.ftree`
+   * exists precisely to stand in for what Java's ZipOutputStream emits, and is what archive.js's
+   * central-directory reading is for. If this ever stops holding, that note needs revisiting.
+   */
+  const streamedFile = path.join(fixtures, 'sample-streamed.ftree');
+  const streamed = await readFile(streamedFile).then((b) => new Uint8Array(b), () => null);
+  if (!streamed) {
+    ok('a streamed archive is available to contrast against', false,
+      `${streamedFile} is missing - run tools/make_sample_tree.py`);
+  } else {
+    const theirs = walkLocalHeaders(streamed);
+    ok('an archive written the way the app writes defers its sizes',
+      theirs.length > 0 && theirs.every((e) => e.streamed && e.uncompressed === 0),
+      `${theirs.length} entries, sizes ${theirs.map((e) => e.uncompressed).join('/')}`);
+  }
+}
+
+/*
+ * If a real export from the phone is lying about, use it. It is the only artifact here that the
+ * Android app itself produced, so it is the one that settles what the format really looks like.
+ * Absent in CI, and absence is reported rather than passed over in silence.
+ */
+section('a real export from the phone, when there is one');
+{
+  const real = path.join(here, '..', 'temp');
+  const names = await (await import('node:fs/promises')).readdir(real).catch(() => []);
+  const found = names.filter((n) => n.endsWith('.ftree')).sort().pop();
+  if (!found) {
+    console.log('  --   none in temp/, skipped (this runs on a developer machine, not in CI)');
+  } else {
+    const bytes = new Uint8Array(await readFile(path.join(real, found)));
+    /*
+     * The walk stops after one entry, and that is the finding, not a shortfall. A data-descriptor
+     * header declares a compressed size of zero, so a reader that trusts it steps forward zero
+     * bytes and lands in the middle of the deflate stream rather than on the next signature. That
+     * is precisely why archive.js reads the central directory, and precisely what this writer
+     * avoids. Reported plainly so the entry count is not mistaken for the archive's size.
+     */
+    const headers = walkLocalHeaders(bytes);
+    const total = (await openArchive(bytes.buffer.slice(
+      bytes.byteOffset, bytes.byteOffset + bytes.byteLength))).names().length;
+    ok(`${found} defers its sizes, as ZipOutputStream does`,
+      headers.length > 0 && headers.every((e) => e.streamed && e.uncompressed === 0),
+      `walking local headers reaches ${headers.length} of ${total} entries before losing the trail`);
+
+    const a = await openArchive(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    const doc = parseDocument(await a.readText('tree.json'));
+    const photos = new Map();
+    for (const n of a.names()) {
+      if (n.startsWith('photos/') && !n.endsWith('/')) photos.set(n, await a.read(n));
+    }
+    const out = await writeTreeArchive(doc, photos);
+    const b = await openArchive(out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength));
+    const back = parseDocument(await b.readText('tree.json'));
+    ok('a real tree round-trips unchanged',
+      same(doc.people, back.people) && same(doc.relationships, back.relationships),
+      `${doc.people.length} people, ${doc.relationships.length} edges, ${photos.size} photos`);
+    ok('every local header in what we wrote states its size',
+      walkLocalHeaders(out).every((e) => !e.streamed && e.uncompressed > 0));
+  }
+}
+
+console.log(failures ? `\n${failures} of ${checks} FAILED.` : `\nAll ${checks} checks passed.`);
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
First piece of the editor (#101), and the one everything else waits on: `archive.js` reads archives
and there was no writer, so nothing that *changes* a tree could be built.

## The fact that decides the design

The requirement is not "read back what we wrote" — that only proves this code agrees with itself.
It is **"the Android app opens it"**. And that turns on one fact which runs *opposite* to the one
already documented at the top of `archive.js`:

| direction | the app uses | consequence |
|---|---|---|
| the app writes | `ZipOutputStream` | zeroes CRC and both sizes in local headers, truth in a data descriptor → **archive.js must read the central directory** |
| the app reads | `ZipInputStream` | walks **local headers** forward, never consults the central directory → **the writer must fill local headers in** |

So every local header here carries the true CRC and both sizes, bit 3 clear. No data descriptor, no
streaming: the archive is built in memory where every size is known before its header is written. A
tree is a few hundred kilobytes plus photographs already in memory, so certainty is cheap.

Had I written it the streaming way, it would have round-tripped perfectly here and read as **empty**
on the phone.

## The JSON

Matches the app's exporter field for field, including `encodeDefaults = false` — `format` and
`version` always, `deceased` only when true, an absent name an absent *key* rather than a null.
Kotlin would accept explicit nulls; a file written here should simply be indistinguishable from one
written there.

## The test asserts the format, not the round trip

`tools/check_writer.mjs` walks local headers with a reader that **deliberately does not implement
data descriptors**, so "our archive needs no coping" is a property under test rather than a claim.
The contrast is asserted too, against `sample-streamed.ftree` — the fixture that exists to emit what
Java emits.

Two failures during development were the test's fault and worth recording: it compared people by
`JSON.stringify`, which tests key *order* (not part of the format), and it asserted the
data-descriptor contrast against `sample-family.ftree`, which is written seekably and does not have
them. Both fixed at the test.

## Verified beyond our own reader

- `unzip -t` — no errors
- Python `zipfile` — all 13 entries, `testzip()` clean, 148 people / 226 relationships
- A **real 148-person export from the phone** round-trips with its 12 photos: 261,086 bytes against
  the original's 261,294
- Walking that real export's local headers reaches **1 of 13 entries before losing the trail** — the
  asymmetry, demonstrated rather than described

## Not done, and not faked

**Nothing here has been opened by the Android app itself.** That needs an import on a device, or a
JVM test under `app/` — and `app/` is not touched for desktop work while there are live users on it.
A written file is attached to the conversation for exactly that check. Until it passes, this is a
writer that every *other* reader accepts.

Refs #101.

🤖 Generated with [Claude Code](https://claude.com/claude-code)