### PR TITLE
The editing core: relationship rules and an editable tree

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -46,9 +46,11 @@ jobs:
         working-directory: desktop
         run: npm ci || npm install
 
-      # The update rules are pure and their table is the mitigation for porting rules out of the
-      # Kotlin: a divergence fails here rather than offering somebody the wrong build.
-      - name: Update rules
+      # Everything ported out of the Kotlin lives behind this: the update rules, the relationship
+      # rules, and the editable tree. Each carries the Kotlin's own test table where there is one,
+      # because a second implementation of somebody's family rules is a thing that can drift, and
+      # a divergence should fail here rather than in a tree nobody can get back.
+      - name: The rules ported out of the Kotlin
         working-directory: desktop
         run: npm test
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
     "smoke": "electron . --no-sandbox",
     "pack:linux": "electron-builder --linux",
     "pack:win": "electron-builder --win nsis",
-    "test": "node --test update.test.js"
+    "test": "node --test update.test.js \"renderer/*.test.js\""
   },
   "devDependencies": {
     "electron": "^33.2.0",

--- a/desktop/renderer/document.js
+++ b/desktop/renderer/document.js
@@ -1,0 +1,306 @@
+/*
+ * A tree you can change, and change back.
+ *
+ * `archive.js` reads a document and `write.js` writes one; both deal in the flat exchange shape,
+ * which is right for a file and wrong for editing. This sits between them: it holds one tree,
+ * applies edits under the relationship rules, remembers what it did, and hands back the exchange
+ * shape when it is time to save.
+ *
+ * Three decisions worth stating, because they are what make an editor safe to hand somebody:
+ *
+ * **Every edit is a whole snapshot.** Undo restores a copy of the previous state rather than
+ * running an inverse operation. Inverse operations are where undo bugs live -- deleting a person
+ * removes their relationships too, and an inverse that forgets one of them silently corrupts the
+ * tree. A tree of a few hundred people is tens of kilobytes; correctness is worth the copies.
+ *
+ * **Nothing is edited in place.** Callers get frozen objects. A screen that mutated a person
+ * directly would change the tree without passing the rules, without marking it unsaved and
+ * without anything to undo -- and it would do it invisibly.
+ *
+ * **A refusal is a value, not an exception.** `addRelationship` returns why it said no, using the
+ * same reasons as `RelationshipRules.kt`, so the interface can explain rather than just fail.
+ */
+
+import { checkRelationship, isSymmetric, RelationshipType, Rejection } from './rules.js';
+
+export { RelationshipType, Rejection };
+
+/** How many steps back a person can go. Beyond this the oldest are dropped. */
+const HISTORY_LIMIT = 100;
+
+const clone = (value) => structuredClone(value);
+
+function newId() {
+  // Present in every browser this runs in, in the Electron renderer, and in Node 19+.
+  return crypto.randomUUID();
+}
+
+/** The fields a person actually has. Anything else a caller passes is ignored, not stored. */
+const PERSON_FIELDS = ['name', 'gender', 'birthDate', 'deathDate', 'deceased', 'photo', 'notes'];
+
+/**
+ * Trims a person down to the format's fields, and to values the format can hold.
+ *
+ * Empty strings become absent: a name someone typed and then cleared is not a name, and writing
+ * `""` would make the app show a person called nothing rather than one whose name is unknown.
+ */
+function tidyPerson(fields) {
+  const out = {};
+  for (const key of PERSON_FIELDS) {
+    if (!Object.hasOwn(fields, key)) continue;
+    const value = fields[key];
+    if (key === 'deceased') {
+      if (value) out.deceased = true;
+      continue;
+    }
+    if (value == null) continue;
+    const text = String(value).trim();
+    if (text) out[key] = text;
+  }
+  return out;
+}
+
+export class Tree {
+  /**
+   * @param {object} document a document in the exchange shape, as `archive.js` returns
+   */
+  constructor(document = {}) {
+    this.state = {
+      exportedAt: document.exportedAt ?? '',
+      sourceTreeId: document.sourceTreeId ?? '',
+      people: clone(document.people ?? []),
+      relationships: clone(document.relationships ?? []),
+    };
+    this.past = [];
+    this.future = [];
+    /* What the tree looked like when it was last saved, so "unsaved" is a fact and not a flag. */
+    this.savedAt = this.signature();
+  }
+
+  /* -------------------------------------------------------------- reading */
+
+  get people() {
+    return this.state.people.map((p) => Object.freeze({ ...p }));
+  }
+
+  get relationships() {
+    return this.state.relationships.map((r) => Object.freeze({ ...r }));
+  }
+
+  person(id) {
+    const found = this.state.people.find((p) => p.id === id);
+    return found ? Object.freeze({ ...found }) : null;
+  }
+
+  /**
+   * Cheap enough to take on every edit, and the honest answer to "has this changed?".
+   *
+   * A dirty *flag* would say yes after an edit and its undo, and nag somebody to save a file
+   * identical to the one on disk. Comparing content means undoing back to the start is genuinely
+   * unmodified, which is what the person doing it believes.
+   */
+  signature() {
+    return JSON.stringify([this.state.people, this.state.relationships]);
+  }
+
+  get isDirty() {
+    return this.signature() !== this.savedAt;
+  }
+
+  get canUndo() {
+    return this.past.length > 0;
+  }
+
+  get canRedo() {
+    return this.future.length > 0;
+  }
+
+  /** What undo would take back, for a menu item that says so. */
+  get undoLabel() {
+    return this.past.at(-1)?.label ?? null;
+  }
+
+  get redoLabel() {
+    return this.future.at(-1)?.label ?? null;
+  }
+
+  /** Called after a successful save. */
+  markSaved() {
+    this.savedAt = this.signature();
+  }
+
+  /* -------------------------------------------------------------- the graph, for the rules */
+
+  parentsOf(id) {
+    return this.state.relationships
+      .filter((r) => r.type === RelationshipType.PARENT && r.to === id)
+      .map((r) => r.from);
+  }
+
+  edgeExists(from, to, type) {
+    return this.state.relationships.some((r) => r.from === from && r.to === to && r.type === type);
+  }
+
+  /* -------------------------------------------------------------- changing */
+
+  /**
+   * Runs `change`, keeping the state it replaced.
+   *
+   * The snapshot is taken before and only kept if something actually changed, so an edit that
+   * sets a name to the name it already had does not put a no-op on the undo stack for somebody
+   * to wonder about later.
+   */
+  edit(label, change) {
+    const before = clone(this.state);
+    const beforeSignature = this.signature();
+    const result = change();
+    if (result?.ok === false) {
+      this.state = before;
+      return result;
+    }
+    if (this.signature() === beforeSignature) return result ?? { ok: true };
+
+    this.past.push({ label, state: before });
+    if (this.past.length > HISTORY_LIMIT) this.past.shift();
+    this.future.length = 0;
+    return result ?? { ok: true };
+  }
+
+  undo() {
+    if (!this.past.length) return { ok: false, reason: 'NOTHING_TO_UNDO' };
+    const step = this.past.pop();
+    this.future.push({ label: step.label, state: clone(this.state) });
+    this.state = step.state;
+    return { ok: true, label: step.label };
+  }
+
+  redo() {
+    if (!this.future.length) return { ok: false, reason: 'NOTHING_TO_REDO' };
+    const step = this.future.pop();
+    this.past.push({ label: step.label, state: clone(this.state) });
+    this.state = step.state;
+    return { ok: true, label: step.label };
+  }
+
+  /* -------------------------------------------------------------- people */
+
+  addPerson(fields = {}) {
+    const person = { id: fields.id ?? newId(), ...tidyPerson(fields) };
+    if (this.state.people.some((p) => p.id === person.id)) {
+      return { ok: false, reason: 'DUPLICATE_ID' };
+    }
+    return this.edit(`Add ${person.name ?? 'person'}`, () => {
+      this.state.people.push(person);
+      return { ok: true, id: person.id };
+    });
+  }
+
+  updatePerson(id, fields = {}) {
+    const at = this.state.people.findIndex((p) => p.id === id);
+    if (at < 0) return { ok: false, reason: 'NO_SUCH_PERSON' };
+
+    /*
+     * A field named with an explicit null or empty string is being cleared, and a field not
+     * named is being left alone. Without that distinction a screen that edits only the notes
+     * would silently wipe the birth date it never showed.
+     */
+    const next = { id };
+    const current = this.state.people[at];
+    for (const key of PERSON_FIELDS) {
+      if (Object.hasOwn(fields, key)) continue;
+      if (Object.hasOwn(current, key)) next[key] = current[key];
+    }
+    Object.assign(next, tidyPerson(fields));
+    if (current.origins) next.origins = current.origins;
+
+    return this.edit(`Edit ${current.name ?? 'person'}`, () => {
+      this.state.people[at] = next;
+      return { ok: true };
+    });
+  }
+
+  /**
+   * Removes a person and every relationship that touched them.
+   *
+   * Leaving the edges behind would put ends in the file that point at nobody. `model.js` drops
+   * those when reading, so the tree would look right here and be wrong on disk -- the worst of
+   * both, and invisible until somebody opened the file elsewhere.
+   */
+  removePerson(id) {
+    const person = this.state.people.find((p) => p.id === id);
+    if (!person) return { ok: false, reason: 'NO_SUCH_PERSON' };
+
+    return this.edit(`Delete ${person.name ?? 'person'}`, () => {
+      const before = this.state.relationships.length;
+      this.state.people = this.state.people.filter((p) => p.id !== id);
+      this.state.relationships = this.state.relationships
+        .filter((r) => r.from !== id && r.to !== id);
+      return { ok: true, removedEdges: before - this.state.relationships.length };
+    });
+  }
+
+  /* -------------------------------------------------------------- relationships */
+
+  /**
+   * Records an edge, if the rules allow it.
+   *
+   * Both ends must exist. The Kotlin does not check that because its rows are foreign keys into
+   * a table that enforces it; here nothing does, and an edge to a person who was never added
+   * would write a file no reader can resolve.
+   */
+  addRelationship({ from, to, type, subtype = null }) {
+    if (!this.person(from) || !this.person(to)) {
+      return { ok: false, reason: 'NO_SUCH_PERSON' };
+    }
+    const verdict = checkRelationship({
+      from,
+      to,
+      type,
+      existingEdgeExists: (f, t, ty) => this.edgeExists(f, t, ty),
+      parentsOf: (who) => this.parentsOf(who),
+    });
+    if (!verdict.allowed) return { ok: false, reason: verdict.reason };
+
+    const edge = { id: newId(), from, to, type };
+    if (subtype != null && String(subtype).trim()) edge.subtype = String(subtype).trim();
+
+    return this.edit(this.labelFor(type, from, to), () => {
+      this.state.relationships.push(edge);
+      return { ok: true, id: edge.id };
+    });
+  }
+
+  labelFor(type, from, to) {
+    const name = (id) => this.person(id)?.name ?? 'someone';
+    if (type === RelationshipType.PARENT) return `Make ${name(from)} a parent of ${name(to)}`;
+    if (isSymmetric(type)) return `Connect ${name(from)} and ${name(to)}`;
+    return 'Add a relationship';
+  }
+
+  removeRelationship(id) {
+    const edge = this.state.relationships.find((r) => r.id === id);
+    if (!edge) return { ok: false, reason: 'NO_SUCH_RELATIONSHIP' };
+    return this.edit('Remove a relationship', () => {
+      this.state.relationships = this.state.relationships.filter((r) => r.id !== id);
+      return { ok: true };
+    });
+  }
+
+  /* -------------------------------------------------------------- saving */
+
+  /**
+   * The exchange shape, ready for `write.js`.
+   *
+   * `exportedAt` is stamped now because that is what the field means -- when this file was
+   * written. `sourceTreeId` is carried through untouched: it identifies the installation a tree
+   * came from, and rewriting it here would break the identity matching an import depends on.
+   */
+  toExchange(now = new Date()) {
+    return {
+      exportedAt: now.toISOString(),
+      sourceTreeId: this.state.sourceTreeId,
+      people: clone(this.state.people),
+      relationships: clone(this.state.relationships),
+    };
+  }
+}

--- a/desktop/renderer/document.test.js
+++ b/desktop/renderer/document.test.js
@@ -1,0 +1,235 @@
+/*
+ * The editable tree.
+ *
+ * What is being defended here is somebody's family record, so the cases that matter are the ones
+ * where an editor quietly loses something: an undo that half-restores, a delete that leaves edges
+ * pointing at nobody, a screen that saves a field it never showed as empty.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { Tree, RelationshipType, Rejection } from './document.js';
+import { writeTreeArchive } from '../../site/playground/write.js';
+import { openArchive, parseDocument } from '../../site/playground/archive.js';
+
+const { PARENT, SPOUSE, SIBLING } = RelationshipType;
+
+function family() {
+  const tree = new Tree();
+  const father = tree.addPerson({ name: 'Shyam', gender: 'MALE' }).id;
+  const mother = tree.addPerson({ name: 'Kamla', gender: 'FEMALE' }).id;
+  const child = tree.addPerson({ name: 'Ravi', gender: 'MALE' }).id;
+  tree.addRelationship({ from: father, to: child, type: PARENT });
+  tree.addRelationship({ from: mother, to: child, type: PARENT });
+  tree.addRelationship({ from: father, to: mother, type: SPOUSE });
+  return { tree, father, mother, child };
+}
+
+/* ---------------------------------------------------------------- people */
+
+test('a person is added with an id and read back', () => {
+  const tree = new Tree();
+  const added = tree.addPerson({ name: 'Ada', gender: 'FEMALE' });
+  assert.ok(added.ok && added.id);
+  assert.strictEqual(tree.person(added.id).name, 'Ada');
+  assert.strictEqual(tree.people.length, 1);
+});
+
+test('fields the format does not have are ignored, not stored', () => {
+  const tree = new Tree();
+  const { id } = tree.addPerson({ name: 'Ada', favouriteColour: 'green', id: 'chosen' });
+  assert.strictEqual(id, 'chosen');
+  assert.ok(!('favouriteColour' in tree.person(id)));
+});
+
+test('a name typed and then cleared is absent, not empty', () => {
+  const tree = new Tree();
+  const { id } = tree.addPerson({ name: '   ' });
+  assert.ok(!('name' in tree.person(id)), JSON.stringify(tree.person(id)));
+});
+
+test('deceased is stored only when true, as the format does', () => {
+  const tree = new Tree();
+  const alive = tree.addPerson({ name: 'A', deceased: false }).id;
+  const gone = tree.addPerson({ name: 'B', deceased: true }).id;
+  assert.ok(!('deceased' in tree.person(alive)));
+  assert.strictEqual(tree.person(gone).deceased, true);
+});
+
+test('editing one field leaves the others alone', () => {
+  const tree = new Tree();
+  const { id } = tree.addPerson({ name: 'Ada', birthDate: '1815', notes: 'first' });
+  tree.updatePerson(id, { notes: 'still first' });
+  const after = tree.person(id);
+  assert.strictEqual(after.name, 'Ada');
+  assert.strictEqual(after.birthDate, '1815');
+  assert.strictEqual(after.notes, 'still first');
+});
+
+test('a field named as empty is cleared, one not named is kept', () => {
+  const tree = new Tree();
+  const { id } = tree.addPerson({ name: 'Ada', birthDate: '1815', notes: 'first' });
+  tree.updatePerson(id, { birthDate: '' });
+  assert.ok(!('birthDate' in tree.person(id)));
+  assert.strictEqual(tree.person(id).notes, 'first');
+});
+
+test('a returned person cannot be edited behind the tree back', () => {
+  const tree = new Tree();
+  const { id } = tree.addPerson({ name: 'Ada' });
+  assert.throws(() => { tree.person(id).name = 'Changed'; }, TypeError);
+  assert.strictEqual(tree.person(id).name, 'Ada');
+});
+
+test('origins survive an edit, because an import depends on them', () => {
+  const tree = new Tree({ people: [{ id: 'p', name: 'Ada', origins: [{ treeId: 't', personId: 'x' }] }] });
+  tree.updatePerson('p', { name: 'Ada Lovelace' });
+  assert.deepStrictEqual(tree.person('p').origins, [{ treeId: 't', personId: 'x' }]);
+});
+
+/* ---------------------------------------------------------------- relationships */
+
+test('the rules are enforced on the way in', () => {
+  const { tree, father, child } = family();
+  assert.deepStrictEqual(
+    tree.addRelationship({ from: child, to: father, type: PARENT }),
+    { ok: false, reason: Rejection.ANCESTOR_CYCLE });
+  assert.deepStrictEqual(
+    tree.addRelationship({ from: father, to: child, type: SIBLING }),
+    { ok: false, reason: Rejection.CONTRADICTS_EXISTING });
+  assert.deepStrictEqual(
+    tree.addRelationship({ from: father, to: child, type: PARENT }),
+    { ok: false, reason: Rejection.DUPLICATE });
+});
+
+test('an edge to somebody who does not exist is refused', () => {
+  const { tree, father } = family();
+  assert.deepStrictEqual(
+    tree.addRelationship({ from: father, to: 'nobody', type: PARENT }),
+    { ok: false, reason: 'NO_SUCH_PERSON' });
+});
+
+test('a refused edge changes nothing and leaves no undo step', () => {
+  const { tree, father, child } = family();
+  const before = tree.relationships.length;
+  const steps = tree.past.length;
+  tree.addRelationship({ from: child, to: father, type: PARENT });
+  assert.strictEqual(tree.relationships.length, before);
+  assert.strictEqual(tree.past.length, steps);
+});
+
+test('deleting a person takes their relationships with them', () => {
+  const { tree, child } = family();
+  const result = tree.removePerson(child);
+  assert.strictEqual(result.removedEdges, 2);
+  assert.strictEqual(tree.people.length, 2);
+  assert.ok(tree.relationships.every((r) => r.from !== child && r.to !== child));
+});
+
+/* ---------------------------------------------------------------- undo */
+
+test('undo restores a deleted person and every edge they had', () => {
+  const { tree, child } = family();
+  const before = tree.signature();
+  tree.removePerson(child);
+  tree.undo();
+  assert.strictEqual(tree.signature(), before);
+  assert.strictEqual(tree.person(child).name, 'Ravi');
+  assert.strictEqual(tree.relationships.length, 3);
+});
+
+test('undo and redo walk the same path', () => {
+  const tree = new Tree();
+  const a = tree.addPerson({ name: 'A' }).id;
+  tree.addPerson({ name: 'B' });
+  tree.updatePerson(a, { name: 'A2' });
+
+  assert.strictEqual(tree.people.length, 2);
+  tree.undo(); tree.undo(); tree.undo();
+  assert.strictEqual(tree.people.length, 0);
+  assert.ok(!tree.canUndo);
+  tree.redo(); tree.redo(); tree.redo();
+  assert.strictEqual(tree.people.length, 2);
+  assert.strictEqual(tree.person(a).name, 'A2');
+  assert.ok(!tree.canRedo);
+});
+
+test('a new edit discards the redo branch', () => {
+  const tree = new Tree();
+  tree.addPerson({ name: 'A' });
+  tree.undo();
+  assert.ok(tree.canRedo);
+  tree.addPerson({ name: 'B' });
+  assert.ok(!tree.canRedo);
+  assert.strictEqual(tree.people.length, 1);
+  assert.strictEqual(tree.people[0].name, 'B');
+});
+
+test('an edit that changes nothing is not a step to undo', () => {
+  const tree = new Tree();
+  const { id } = tree.addPerson({ name: 'Ada' });
+  const steps = tree.past.length;
+  tree.updatePerson(id, { name: 'Ada' });
+  assert.strictEqual(tree.past.length, steps);
+});
+
+test('undo says what it will take back', () => {
+  const { tree, child } = family();
+  tree.removePerson(child);
+  assert.strictEqual(tree.undoLabel, 'Delete Ravi');
+  tree.undo();
+  assert.strictEqual(tree.redoLabel, 'Delete Ravi');
+});
+
+/* ---------------------------------------------------------------- unsaved */
+
+test('a tree is unmodified until it is changed', () => {
+  const { tree } = family();
+  tree.markSaved();
+  assert.ok(!tree.isDirty);
+  tree.addPerson({ name: 'New' });
+  assert.ok(tree.isDirty);
+});
+
+test('undoing back to the saved state is not unsaved work', () => {
+  // A dirty flag would still be set here, and would nag somebody to save a file identical to
+  // the one already on disk.
+  const { tree } = family();
+  tree.markSaved();
+  const added = tree.addPerson({ name: 'Mistake' });
+  assert.ok(tree.isDirty);
+  tree.undo();
+  assert.ok(!tree.isDirty, 'undoing the only change should leave nothing to save');
+  assert.ok(!tree.person(added.id));
+});
+
+/* ---------------------------------------------------------------- out to disk */
+
+test('an edited tree writes a file the reader accepts', async () => {
+  const { tree, father, child } = family();
+  tree.updatePerson(child, { birthDate: '1970', notes: 'moved to Kanpur' });
+
+  const bytes = await writeTreeArchive(tree.toExchange());
+  const archive = await openArchive(
+    bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+  const back = parseDocument(await archive.readText('tree.json'));
+
+  assert.strictEqual(back.people.length, 3);
+  assert.strictEqual(back.relationships.length, 3);
+  const ravi = back.people.find((p) => p.id === child);
+  assert.strictEqual(ravi.birthDate, '1970');
+  assert.strictEqual(ravi.notes, 'moved to Kanpur');
+  assert.ok(back.relationships.some((r) => r.from === father && r.to === child && r.type === PARENT));
+});
+
+test('sourceTreeId is carried through, not reissued', () => {
+  const tree = new Tree({ sourceTreeId: 'the-phone', people: [{ id: 'a' }] });
+  assert.strictEqual(tree.toExchange().sourceTreeId, 'the-phone');
+});
+
+test('exportedAt is stamped at save time', () => {
+  const tree = new Tree({ people: [{ id: 'a' }] });
+  const when = new Date('2026-01-02T03:04:05Z');
+  assert.strictEqual(tree.toExchange(when).exportedAt, '2026-01-02T03:04:05.000Z');
+});

--- a/desktop/renderer/package.json
+++ b/desktop/renderer/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "f-tree-renderer",
+  "private": true,
+  "type": "module",
+  "description": "The desktop app's own page: everything the viewer is not. ES modules, stated rather than detected."
+}

--- a/desktop/renderer/rules.js
+++ b/desktop/renderer/rules.js
@@ -1,0 +1,115 @@
+/*
+ * Whether a proposed relationship is a sane thing to record.
+ *
+ * A port of `graph/RelationshipRules.kt`, and the reason the editor can be trusted with somebody's
+ * family: without it a few clicks can make a person their own grandfather, and the layout engine
+ * will then loop rather than draw.
+ *
+ * Ported deliberately as a *pure* module, exactly as the Kotlin is, because this is a second
+ * implementation of rules that already exist in another language and can therefore drift. The
+ * mitigation is that `rules.test.js` is the Kotlin's own test table, case for case: a divergence
+ * fails a test here rather than surprising somebody's grandmother.
+ *
+ * The one deliberate difference is that nothing is asynchronous. The Kotlin suspends because its
+ * answers come from a database; here the whole tree is already in memory, and threading promises
+ * through a pure predicate would buy nothing but noise. The callback *shape* is kept so the two
+ * read alike side by side.
+ */
+
+/** Edge kinds, mirroring `data/RelationshipType.kt`. Stored and compared by name. */
+export const RelationshipType = Object.freeze({
+  PARENT: 'PARENT',
+  SPOUSE: 'SPOUSE',
+  SIBLING: 'SIBLING',
+  UNKNOWN: 'UNKNOWN',
+});
+
+/**
+ * Symmetric edges have no direction, so a duplicate can arrive either way round.
+ *
+ * PARENT is the odd one out and must stay so: reversing it is not the same statement, and treating
+ * it as symmetric would let a child be recorded as their parent's parent without complaint.
+ */
+export function isSymmetric(type) {
+  return type === RelationshipType.SPOUSE || type === RelationshipType.SIBLING;
+}
+
+/** Anything unrecognised becomes UNKNOWN rather than being dropped, as `fromName` does. */
+export function relationshipTypeFrom(value) {
+  return Object.hasOwn(RelationshipType, value) ? RelationshipType[value] : RelationshipType.UNKNOWN;
+}
+
+/** Why a proposed relationship was refused. The names match `RelationshipRejection`. */
+export const Rejection = Object.freeze({
+  SELF_REFERENCE: 'SELF_REFERENCE',
+  DUPLICATE: 'DUPLICATE',
+  ANCESTOR_CYCLE: 'ANCESTOR_CYCLE',
+  CONTRADICTS_EXISTING: 'CONTRADICTS_EXISTING',
+});
+
+const ALLOWED = Object.freeze({ allowed: true });
+const rejected = (reason) => Object.freeze({ allowed: false, reason });
+
+/**
+ * Everyone `id` descends from, walked upwards.
+ *
+ * Mirrors `FamilyGraph.ancestorsOf`, including the detail that makes it safe on a tree that is
+ * already broken: a node equal to the start is skipped rather than followed, and every node is
+ * visited once. An import can hand us a cycle, and a rule that hangs while checking for cycles
+ * would be a poor joke.
+ */
+function ancestorsOf(id, parentsOf) {
+  const found = new Set();
+  const queue = [...parentsOf(id)];
+  while (queue.length) {
+    const node = queue.shift();
+    if (node === id || found.has(node)) continue;
+    found.add(node);
+    queue.push(...parentsOf(node));
+  }
+  return found;
+}
+
+/** Would recording `parentId` as a parent of `childId` make somebody their own ancestor? */
+export function wouldCreateAncestorCycle(parentId, childId, parentsOf) {
+  return parentId === childId || ancestorsOf(parentId, parentsOf).has(childId);
+}
+
+/**
+ * The check itself.
+ *
+ * Order matters and is the Kotlin's: self-reference, then duplicate, then contradiction, then
+ * cycle. It decides which reason a person is told about when more than one applies, and the
+ * sequence is chosen so the answer is the most specific true thing rather than the first one
+ * noticed. A `PARENT` edge pointing back up an existing line is reported as a cycle, not as a
+ * duplicate, because "that would make him his own grandfather" explains the refusal and
+ * "you already have that" does not.
+ *
+ * @param {object} proposal
+ * @param {string} proposal.from
+ * @param {string} proposal.to
+ * @param {string} proposal.type
+ * @param {(from: string, to: string, type: string) => boolean} proposal.existingEdgeExists
+ * @param {(id: string) => string[]} proposal.parentsOf
+ * @returns {{allowed: true} | {allowed: false, reason: string}}
+ */
+export function checkRelationship({ from, to, type, existingEdgeExists, parentsOf }) {
+  if (from === to) return rejected(Rejection.SELF_REFERENCE);
+
+  const duplicate = existingEdgeExists(from, to, type)
+    || (isSymmetric(type) && existingEdgeExists(to, from, type));
+  if (duplicate) return rejected(Rejection.DUPLICATE);
+
+  // A parent cannot also be a spouse or sibling of their own child.
+  if (type !== RelationshipType.PARENT) {
+    const alreadyParentChild = existingEdgeExists(from, to, RelationshipType.PARENT)
+      || existingEdgeExists(to, from, RelationshipType.PARENT);
+    if (alreadyParentChild) return rejected(Rejection.CONTRADICTS_EXISTING);
+  }
+
+  if (type === RelationshipType.PARENT && wouldCreateAncestorCycle(from, to, parentsOf)) {
+    return rejected(Rejection.ANCESTOR_CYCLE);
+  }
+
+  return ALLOWED;
+}

--- a/desktop/renderer/rules.test.js
+++ b/desktop/renderer/rules.test.js
@@ -1,0 +1,117 @@
+/*
+ * RelationshipRulesTest.kt, case for case.
+ *
+ * These are not new tests. Every one is a translation of a case in
+ * `app/src/test/java/com/vibethroughcode/ftree/graph/RelationshipRulesTest.kt`, kept in the same
+ * order and with the same names, because the point of the exercise is that two implementations of
+ * one set of rules must not drift apart. Reading the two files side by side should be dull.
+ *
+ * Where a case is added rather than translated it says so.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import {
+  RelationshipType, Rejection, checkRelationship, isSymmetric, relationshipTypeFrom,
+} from './rules.js';
+
+const { PARENT, SPOUSE, SIBLING, UNKNOWN } = RelationshipType;
+
+/** The Kotlin's `rules()` helper: a fake graph of existing edges and known parents. */
+function rules({ existing = [], parents = {} } = {}) {
+  const edges = new Set(existing.map(([from, to, type]) => `${from} ${to} ${type}`));
+  return (from, to, type) => checkRelationship({
+    from,
+    to,
+    type,
+    existingEdgeExists: (f, t, ty) => edges.has(`${f} ${t} ${ty}`),
+    parentsOf: (id) => parents[id] ?? [],
+  });
+}
+
+const assertRejected = (reason, actual) =>
+  assert.deepStrictEqual(actual, { allowed: false, reason });
+const assertAllowed = (actual) => assert.deepStrictEqual(actual, { allowed: true });
+
+test('a person cannot be their own parent spouse or sibling', () => {
+  const check = rules();
+  for (const type of [PARENT, SPOUSE, SIBLING, UNKNOWN]) {
+    assertRejected(Rejection.SELF_REFERENCE, check('me', 'me', type));
+  }
+});
+
+test('an identical edge is a duplicate', () => {
+  const check = rules({ existing: [['father', 'me', PARENT]] });
+  assertRejected(Rejection.DUPLICATE, check('father', 'me', PARENT));
+});
+
+test('a symmetric edge is a duplicate from either side', () => {
+  const check = rules({ existing: [['a', 'b', SPOUSE]] });
+  assertRejected(Rejection.DUPLICATE, check('b', 'a', SPOUSE));
+});
+
+test('a parent edge is directional so the reverse is not a duplicate', () => {
+  // The existing father-to-me edge must not block me-to-father being *checked*; it is instead
+  // rejected as a cycle, which is the accurate reason.
+  const check = rules({
+    existing: [['father', 'me', PARENT]],
+    parents: { me: ['father'] },
+  });
+  assertRejected(Rejection.ANCESTOR_CYCLE, check('me', 'father', PARENT));
+});
+
+test('a parent cannot also be a spouse or sibling of their child', () => {
+  const check = rules({ existing: [['father', 'me', PARENT]] });
+  assertRejected(Rejection.CONTRADICTS_EXISTING, check('father', 'me', SPOUSE));
+  assertRejected(Rejection.CONTRADICTS_EXISTING, check('me', 'father', SIBLING));
+});
+
+test('an edge that would make someone their own ancestor is rejected', () => {
+  const check = rules({ parents: { me: ['father'], father: ['grandfather'] } });
+  assertRejected(Rejection.ANCESTOR_CYCLE, check('me', 'grandfather', PARENT));
+});
+
+test('ordinary relationships are allowed', () => {
+  const check = rules({ parents: { me: ['father'] } });
+  assertAllowed(check('mother', 'me', PARENT));
+  assertAllowed(check('me', 'wife', SPOUSE));
+  assertAllowed(check('me', 'child', PARENT));
+  assertAllowed(check('me', 'brother', SIBLING));
+});
+
+/* ---------------------------------------------------------------- beyond the Kotlin's table */
+
+/*
+ * Added here, not translated. The Kotlin reaches its graph through a database that cannot return
+ * a cycle it did not already contain; this port is handed whatever an imported file said, and a
+ * file can say anything. These pin the behaviour that keeps a bad import from hanging the app.
+ */
+
+test('a cycle already in the data does not hang the check', () => {
+  // Each is recorded as the other's parent: nonsense, and importable.
+  const check = rules({ parents: { a: ['b'], b: ['a'] } });
+  assertRejected(Rejection.ANCESTOR_CYCLE, check('a', 'b', PARENT));
+  assertAllowed(check('c', 'd', PARENT));
+});
+
+test('a long line is walked without recursion', () => {
+  const parents = {};
+  for (let i = 1; i < 5000; i += 1) parents[`p${i}`] = [`p${i + 1}`];
+  const check = rules({ parents });
+  assertRejected(Rejection.ANCESTOR_CYCLE, check('p1', 'p5000', PARENT));
+  assertAllowed(check('p1', 'stranger', PARENT));
+});
+
+test('an unrecognised type becomes UNKNOWN rather than being dropped', () => {
+  assert.strictEqual(relationshipTypeFrom('PARENT'), PARENT);
+  assert.strictEqual(relationshipTypeFrom('MARRIED_TO'), UNKNOWN);
+  assert.strictEqual(relationshipTypeFrom(undefined), UNKNOWN);
+  // Guards against a prototype key being mistaken for a type.
+  assert.strictEqual(relationshipTypeFrom('toString'), UNKNOWN);
+});
+
+test('only spouse and sibling are symmetric', () => {
+  assert.ok(isSymmetric(SPOUSE) && isSymmetric(SIBLING));
+  assert.ok(!isSymmetric(PARENT) && !isSymmetric(UNKNOWN));
+});


### PR DESCRIPTION
Steps 2 and 3 of #101 — the whole editing core short of a screen. Both pure, both tested, neither
touching the running app.

## The rules

`renderer/rules.js` ports `graph/RelationshipRules.kt`. This is what keeps a few clicks from making
somebody their own grandfather — after which the layout engine loops rather than draws.

`rules.test.js` is **the Kotlin's own test table, case for case and name for name.** A second
implementation of somebody's family rules is a thing that drifts; reading the two files side by side
should be dull.

Four cases are added rather than translated, and they earn their place. The Kotlin reaches its graph
through a database whose foreign keys cannot hand back a cycle. This port is handed whatever an
imported file said, and **a file can say anything**:

- a cycle already in the data does not hang the check
- a 5,000-deep line is walked without recursion
- an unrecognised type becomes `UNKNOWN` rather than being dropped
- `relationshipTypeFrom('toString')` is not mistaken for a type

Nothing is asynchronous, deliberately: the Kotlin suspends because its answers come from a database,
and the whole tree is in memory here. The callback *shape* is kept so the two read alike.

## The editable tree

`renderer/document.js` holds one document, applies edits under those rules, and can put every change
back. Three decisions carry it:

**Every edit keeps a whole snapshot, not an inverse operation.** Inverse operations are where undo
bugs live — deleting a person removes their relationships too, and an inverse that forgets one
silently corrupts the tree. A few hundred people is tens of kilobytes; correctness is worth the copy.

**Nothing is edited in place.** Callers get frozen objects, so a screen cannot change the tree
without passing the rules, without marking it unsaved, and without anything to undo.

**"Unsaved" compares content, it is not a flag.** Undo back to the saved state leaves nothing to
save, rather than nagging somebody to write a file identical to the one on disk.

## Two details that would each have lost data quietly

| | why it matters |
|---|---|
| deleting a person also deletes every edge that touched them | otherwise the file has ends pointing at nobody. `model.js` drops those on read — so the tree would look right here and be **wrong on disk**, invisible until opened elsewhere |
| an update distinguishes a field named as empty (clear it) from a field not named (leave it) | a screen that edits only the notes must not wipe a birth date it never showed |

Both are tests, not intentions.

## Where this sits

`desktop/renderer/` is new, with its own `package.json` declaring `"type": "module"` — stated rather
than relying on Node's ESM syntax detection, which needs ≥22.7 and CI pins `22`.

## Checks

- `npm test` in `desktop/`: **45 pass** (12 update rules, 11 relationship rules, 22 tree)
- The last of those writes an edited tree through `write.js` and reads it back through
  `archive.js`, so the editing core reaches disk in this PR even though no screen does yet
- `git status --short app/` empty: the Android app is untouched

Refs #101, #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)