### PR TITLE
Saving: a tree can go back to disk, and cannot be lost doing it

### DIFF
--- a/desktop/atomic.js
+++ b/desktop/atomic.js
@@ -1,0 +1,70 @@
+/*
+ * Putting a file on disk without ever being able to leave it half-written.
+ */
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+/*
+ * Writing a tree back, without ever being able to leave one half-written.
+ *
+ * Until now this app could only read, and the download page says so. This is where that stops
+ * being true, so this is where the care goes. Three things, in order:
+ *
+ * 1. The page has already read its own bytes back and compared them against the tree it holds
+ *    (renderer/save.js). Nothing reaches here that has not survived that.
+ *
+ * 2. The bytes go to a temporary file in the *same directory*, are flushed to the platter with
+ *    fsync, and are then renamed over the target. Rename within a directory is atomic, so at
+ *    every instant the path holds either the old complete file or the new complete file. A power
+ *    cut in the middle costs the edit, never the tree. The temp file must share the directory:
+ *    a rename across filesystems is a copy, and copies are interruptible.
+ *
+ * 3. Whatever was there before is kept as `<name>.bak`, replaced each save. That is one step
+ *    back on disk, on top of undo in the app and the phone still holding the original.
+ *
+ * The directory itself is fsynced too, which is what actually makes the rename durable; without
+ * it the file contents survive a crash and the directory entry pointing at them may not.
+ */
+async function writeTreeFile(target, bytes) {
+  const directory = path.dirname(target);
+  const temporary = path.join(directory, `.${path.basename(target)}.saving-${process.pid}`);
+
+  let handle;
+  try {
+    handle = await fs.open(temporary, 'w');
+    await handle.writeFile(Buffer.from(bytes));
+    await handle.sync();
+  } finally {
+    await handle?.close();
+  }
+
+  try {
+    /*
+     * The backup is a copy, not a rename: renaming the original away would leave the path with
+     * nothing in it for as long as the copy takes, and a reader arriving in that instant would
+     * find the tree missing. Copying leaves the original in place until the atomic rename.
+     */
+    const existing = await fs.readFile(target).catch(() => null);
+    if (existing) await fs.writeFile(`${target}.bak`, existing);
+
+    await fs.rename(temporary, target);
+  } catch (error) {
+    await fs.rm(temporary, { force: true });
+    throw error;
+  }
+
+  // Makes the rename itself survive a crash, not just the bytes it points at.
+  let dir;
+  try {
+    dir = await fs.open(directory, 'r');
+    await dir.sync();
+  } catch {
+    // Not every platform lets a directory be opened for sync; the rename is still atomic.
+  } finally {
+    await dir?.close();
+  }
+}
+
+
+module.exports = { writeTreeFile };

--- a/desktop/atomic.test.js
+++ b/desktop/atomic.test.js
@@ -1,0 +1,135 @@
+/*
+ * The last few inches, where a family tree meets a disk.
+ *
+ * Everything upstream of this has been checked in memory. What is left is the part memory cannot
+ * help with: the machine losing power, the disk filling up, or the process dying between opening
+ * a file and finishing it. The property under test is not "the bytes arrive" but **the path never
+ * holds a partial file**, which is what a rename buys and what a plain write does not.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const fssync = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { writeTreeFile } = require('./atomic');
+
+async function scratch() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ftree-atomic-'));
+}
+
+const bytes = (text) => new Uint8Array(Buffer.from(text));
+
+test('a new file is written', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'tree.ftree');
+  await writeTreeFile(target, bytes('hello'));
+  assert.strictEqual(await fs.readFile(target, 'utf8'), 'hello');
+});
+
+test('no backup is made when there was nothing to back up', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'tree.ftree');
+  await writeTreeFile(target, bytes('first'));
+  assert.ok(!fssync.existsSync(`${target}.bak`));
+});
+
+test('the previous contents are kept as .bak', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'tree.ftree');
+  await writeTreeFile(target, bytes('first'));
+  await writeTreeFile(target, bytes('second'));
+
+  assert.strictEqual(await fs.readFile(target, 'utf8'), 'second');
+  assert.strictEqual(await fs.readFile(`${target}.bak`, 'utf8'), 'first');
+});
+
+test('the backup is one step back, not a growing pile', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'tree.ftree');
+  for (const text of ['one', 'two', 'three']) await writeTreeFile(target, bytes(text));
+
+  assert.strictEqual(await fs.readFile(target, 'utf8'), 'three');
+  assert.strictEqual(await fs.readFile(`${target}.bak`, 'utf8'), 'two');
+  const left = await fs.readdir(dir);
+  assert.deepStrictEqual(left.sort(), ['tree.ftree', 'tree.ftree.bak']);
+});
+
+test('nothing temporary is left behind', async () => {
+  const dir = await scratch();
+  await writeTreeFile(path.join(dir, 'tree.ftree'), bytes('x'));
+  const left = await fs.readdir(dir);
+  assert.deepStrictEqual(left, ['tree.ftree'], `left over: ${left.join(', ')}`);
+});
+
+test('a failure leaves the original exactly as it was', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'tree.ftree');
+  await writeTreeFile(target, bytes('the good version'));
+
+  // A directory cannot be renamed over a file, so the rename fails after the temp file is
+  // written -- the window this test exists for.
+  const saboteur = path.join(dir, `.tree.ftree.saving-${process.pid}`);
+  await assert.rejects(async () => {
+    await fs.mkdir(saboteur, { recursive: true });
+    await fs.writeFile(path.join(saboteur, 'in the way'), 'blocked');
+    await writeTreeFile(target, bytes('the bad version'));
+  });
+
+  assert.strictEqual(await fs.readFile(target, 'utf8'), 'the good version',
+    'the tree on disk must survive a failed save');
+});
+
+test('a save into a directory that does not exist fails without touching anything', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'nowhere', 'tree.ftree');
+  await assert.rejects(() => writeTreeFile(target, bytes('x')));
+  assert.deepStrictEqual(await fs.readdir(dir), []);
+});
+
+test('binary content survives byte for byte', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'tree.ftree');
+  const payload = new Uint8Array(4096);
+  for (let i = 0; i < payload.length; i += 1) payload[i] = (i * 7) % 256;
+
+  await writeTreeFile(target, payload);
+  const back = new Uint8Array(await fs.readFile(target));
+  assert.deepStrictEqual(back, payload);
+});
+
+test('the target holds the old file until the moment it holds the new one', async () => {
+  /*
+   * The property a plain write cannot offer. Reading the path repeatedly while a much larger
+   * version is written must never observe a truncated or partly-written file: every read is one
+   * of the two complete versions.
+   */
+  const dir = await scratch();
+  const target = path.join(dir, 'tree.ftree');
+  const small = bytes('a'.repeat(1024));
+  const large = bytes('b'.repeat(4 * 1024 * 1024));
+  await writeTreeFile(target, small);
+
+  let observations = 0;
+  let torn = null;
+  const watching = (async () => {
+    while (torn === null && observations < 5000) {
+      const seen = await fs.readFile(target).catch(() => null);
+      if (seen === null) { torn = 'the path was empty'; break; }
+      const text = seen.toString('utf8');
+      const whole = (seen.length === small.length && text === 'a'.repeat(1024))
+        || (seen.length === large.length && text === 'b'.repeat(large.length));
+      if (!whole) { torn = `saw ${seen.length} bytes, neither version`; break; }
+      observations += 1;
+    }
+  })();
+
+  await writeTreeFile(target, large);
+  torn ??= 'done';
+  await watching;
+
+  assert.strictEqual(torn, 'done', torn);
+  assert.ok(observations > 0, 'the watcher never actually read the file');
+});

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -17,6 +17,7 @@ const os = require('node:os');
 const path = require('node:path');
 
 const { chooseUpdate } = require('./update');
+const { writeTreeFile } = require('./atomic');
 
 /*
  * A window needs somewhere to be.
@@ -67,6 +68,9 @@ if (process.env.FTREE_SMOKE) {
   app.setPath('userData', require('node:fs')
     .mkdtempSync(path.join(os.tmpdir(), 'ftree-smoke-')));
 }
+
+/** Which windows have edits that are not on disk. Keyed by window id. */
+const unsaved = new Map();
 
 const stateFile = () => path.join(app.getPath('userData'), 'session.json');
 const settingsFile = () => path.join(app.getPath('userData'), 'settings.json');
@@ -120,6 +124,24 @@ async function readTree(file) {
   const bytes = await fs.readFile(file);
   return { name: path.basename(file), path: file, bytes: bytes.buffer.slice(
     bytes.byteOffset, bytes.byteOffset + bytes.byteLength) };
+}
+
+/* ------------------------------------------------------------------ saving */
+
+async function saveInto(win, target, bytes) {
+  try {
+    await writeTreeFile(target, bytes);
+    await writeSession({ lastTree: target });
+    return { ok: true, path: target, name: path.basename(target) };
+  } catch (error) {
+    await dialog.showMessageBox(win, {
+      type: 'error',
+      message: 'That tree could not be saved.',
+      detail: `${target}\n\n${error.message}\n\nThe file on disk has not been changed.`,
+      buttons: ['OK'],
+    });
+    return { ok: false, reason: error.message };
+  }
 }
 
 let window_ = null;
@@ -368,6 +390,22 @@ function buildMenu(win) {
       label: 'File',
       submenu: [
         { label: 'Open tree…', accelerator: 'CmdOrCtrl+O', click: () => chooseInto(win) },
+        { type: 'separator' },
+        /*
+         * Saving is asked of the page, not done here. The page holds the tree, the writer and the
+         * reader it verifies itself with; this side only puts bytes on a disk. The menu therefore
+         * says "please save" and the page decides whether it can.
+         */
+        { label: 'Save', accelerator: 'CmdOrCtrl+S',
+          click: () => win.webContents.send('menu:command', 'file:save') },
+        { label: 'Save as…', accelerator: 'CmdOrCtrl+Shift+S',
+          click: () => win.webContents.send('menu:command', 'file:saveAs') },
+        { type: 'separator' },
+        { label: 'Undo', accelerator: 'CmdOrCtrl+Z',
+          click: () => win.webContents.send('menu:command', 'edit:undo') },
+        { label: 'Redo', accelerator: 'CmdOrCtrl+Shift+Z',
+          click: () => win.webContents.send('menu:command', 'edit:redo') },
+        { type: 'separator' },
         { label: 'Close tree', accelerator: 'CmdOrCtrl+W',
           click: () => { writeSession({}); win.webContents.send('menu:command', 'close'); } },
         { type: 'separator' },
@@ -492,6 +530,67 @@ function refuseTheNetwork(ses) {
     });
 }
 
+/*
+ * A window with unsaved edits does not simply vanish.
+ *
+ * The page reports whether there is unsaved work; this refuses the close while there is, and asks.
+ * "Save" hands the work back to the page, because the page is the only side that can serialise a
+ * tree and verify it -- and then waits for it to report itself clean rather than assuming it did.
+ *
+ * The wait has a deadline and the deadline has an honest ending: if the page has not saved by
+ * then, the window stays open and says so. An editor that hung on closing would be a worse bug
+ * than the one this prevents.
+ */
+function guardUnsavedWork(win) {
+  let letItGo = false;
+
+  win.on('close', (event) => {
+    if (letItGo || !unsaved.get(win.id)) return;
+    event.preventDefault();
+
+    (async () => {
+      const answer = await dialog.showMessageBox(win, {
+        type: 'warning',
+        message: 'This tree has changes you have not saved.',
+        detail: 'Closing now loses them. There is no copy of these edits anywhere else.',
+        buttons: ['Save', 'Discard the changes', 'Cancel'],
+        defaultId: 0,
+        cancelId: 2,
+      });
+
+      if (answer.response === 2) return;
+      if (answer.response === 1) { letItGo = true; win.close(); return; }
+
+      win.webContents.send('menu:command', 'file:save');
+      const saved = await waitUntilSaved(win);
+      if (!saved) {
+        await dialog.showMessageBox(win, {
+          type: 'warning',
+          message: 'The tree has not been saved.',
+          detail: 'The window has been left open so nothing is lost. Try File then Save.',
+          buttons: ['OK'],
+        });
+        return;
+      }
+      letItGo = true;
+      win.close();
+    })();
+  });
+
+  win.on('closed', () => unsaved.delete(win.id));
+}
+
+/** Polls for the page reporting itself clean. Ten seconds, then the honest answer. */
+async function waitUntilSaved(win, deadlineMs = 10_000) {
+  const until = Date.now() + deadlineMs;
+  while (Date.now() < until) {
+    if (!unsaved.get(win.id)) return true;
+    if (win.isDestroyed()) return true;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  return !unsaved.get(win.id);
+}
+
 async function createWindow() {
   const win = new BrowserWindow({
     width: 1440,
@@ -514,6 +613,7 @@ async function createWindow() {
   });
 
   win.once('ready-to-show', () => win.show());
+  guardUnsavedWork(win);
 
   refuseTheNetwork(session.fromPartition(VIEWER_PARTITION));
   await win.loadFile(VIEWER);
@@ -541,6 +641,42 @@ ipcMain.handle('tree:choose', async (event) => {
   return chooseInto(win);
 });
 ipcMain.handle('tree:forget', async () => { await writeSession({}); });
+
+/*
+ * Saving takes the bytes the page produced, never a document for this side to serialise.
+ *
+ * The page owns the format: it has the writer, the reader it verifies with, and the tree itself.
+ * Handing a document across the bridge for the main process to encode would put a second encoder
+ * in the app and give the verification something other than the real bytes to check.
+ */
+ipcMain.handle('tree:save', async (event, { bytes, path: target }) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!target) return { ok: false, reason: 'NO_PATH' };
+  return saveInto(win, target, bytes);
+});
+
+ipcMain.handle('tree:saveAs', async (event, { bytes, suggest }) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const picked = await dialog.showSaveDialog(win, {
+    title: 'Save the family tree',
+    defaultPath: suggest || 'family-tree.ftree',
+    filters: [{ name: 'f-tree export', extensions: ['ftree'] }],
+  });
+  if (picked.canceled || !picked.filePath) return { ok: false, reason: 'CANCELLED' };
+  return saveInto(win, picked.filePath, bytes);
+});
+
+/*
+ * The page tells this side when there is unsaved work, so the window can refuse to vanish with
+ * it. Kept as a plain notification rather than something to ask for: the answer has to be current
+ * at the moment of closing, and asking then would race the close.
+ */
+ipcMain.on('tree:dirty', (event, dirty) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  if (!win) return;
+  unsaved.set(win.id, Boolean(dirty));
+  win.setDocumentEdited(Boolean(dirty));
+});
 ipcMain.handle('tree:last', async () => {
   const { lastTree } = await readSession();
   if (!lastTree) return null;
@@ -596,6 +732,7 @@ async function runSmoke(win, file) {
     state: document.getElementById('viewer')?.dataset.state ?? null,
     fileName: document.getElementById('file-name')?.textContent ?? null,
     orientation: document.body.dataset.orientation ?? null,
+    bridgeNames: Object.keys(window.ftreeDesktop ?? {}).sort().join(','),
     openerError: document.getElementById('opener-error')?.textContent ?? null,
     hint: document.getElementById('hint')?.textContent ?? null,
     literata: document.fonts.check('16px Literata'),
@@ -617,6 +754,15 @@ async function runSmoke(win, file) {
    */
   check('generations run in rows, as they do on the website', seen.orientation === 'rows',
     String(seen.orientation));
+  /*
+   * The bridge is the whole surface between somebody's family and their machine. Asserting the
+   * names is not ceremony: a preload that fails to load leaves `window.ftreeDesktop` looking
+   * plausible enough for the page to run and for saving to silently do nothing.
+   */
+  for (const name of ['chooseTree', 'saveTree', 'saveTreeAs', 'setDirty']) {
+    check(`the page can ask to ${name}`, String(seen.bridgeNames).split(',').includes(name),
+      String(seen.bridgeNames));
+  }
   check('the archive was read and counted', /\d+ people/.test(seen.status ?? ''), String(seen.status));
   // Refusing the network must not quietly cost the app its typography.
   check('the bundled typefaces loaded without the network', seen.literata && seen.mono,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,8 @@
     "smoke": "electron . --no-sandbox",
     "pack:linux": "electron-builder --linux",
     "pack:win": "electron-builder --win nsis",
-    "test": "node --test update.test.js \"renderer/*.test.js\""
+    "test": "node --test update.test.js atomic.test.js \"renderer/*.test.js\"",
+    "test:package": "node --test package.test.js"
   },
   "devDependencies": {
     "electron": "^33.2.0",

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -20,6 +20,21 @@ contextBridge.exposeInMainWorld('ftreeDesktop', {
   lastTree: () => ipcRenderer.invoke('tree:last'),
   forgetTree: () => ipcRenderer.invoke('tree:forget'),
 
+  /**
+   * Saves a tree the page has already serialised and verified.
+   *
+   * Bytes, never a document: the page owns the format -- the writer, the reader it checks itself
+   * with, and the tree. Sending a document for the other side to encode would put a second
+   * encoder in the app and leave the verification checking something other than what gets
+   * written. The main process writes to a temporary file, fsyncs it, keeps the previous contents
+   * as `.bak` and renames atomically over the target.
+   */
+  saveTree: (bytes, path) => ipcRenderer.invoke('tree:save', { bytes, path }),
+  saveTreeAs: (bytes, suggest) => ipcRenderer.invoke('tree:saveAs', { bytes, suggest }),
+
+  /** Lets the window refuse to close on unsaved work, and marks the title bar as edited. */
+  setDirty: (dirty) => ipcRenderer.send('tree:dirty', dirty),
+
   /** The menu and the OS both open files; the page hears about it the same way either way. */
   onOpenTree: (handler) => ipcRenderer.on('tree:opened', (_e, tree) => handler(tree)),
   onMenuCommand: (handler) => ipcRenderer.on('menu:command', (_e, command) => handler(command)),

--- a/desktop/renderer/save.js
+++ b/desktop/renderer/save.js
@@ -1,0 +1,117 @@
+/*
+ * Turning an edited tree into bytes, and checking them before they go anywhere near the disk.
+ *
+ * The desktop app has been able to lose nothing so far, because it only ever read. This is the
+ * file where that stops being true, so it is the file that has to be careful.
+ *
+ * The guarantee is not "the writer is correct" -- it is a second implementation of a format and
+ * it can be wrong. The guarantee is that **a save that would lose something does not happen at
+ * all**. Every save is read back, in memory, through the same reader the app opens files with,
+ * and compared against the tree still held in memory -- not against the document that was handed
+ * to the writer, which would only ever catch the writer. If the count of people or relationships
+ * disagrees, or the archive will not parse, the bytes are refused and the file on disk is left
+ * exactly as it was.
+ *
+ * That is cheaper than it sounds -- a tree is a few hundred kilobytes and no disk is touched --
+ * and it turns a whole category of writer bug from "somebody's family is gone" into "f-tree
+ * would not save, and said why".
+ */
+
+import { writeTreeArchive } from '../../site/playground/write.js';
+import { openArchive, parseDocument } from '../../site/playground/archive.js';
+
+export class SaveRefused extends Error {
+  constructor(message, detail) {
+    super(message);
+    this.detail = detail;
+  }
+}
+
+/**
+ * Compares what came back against what the tree actually holds.
+ *
+ * Note the second operand: the *tree*, not the exchange document that was handed to the writer.
+ * Comparing the document against the read-back would only ever catch a bug in the writer, because
+ * a `toExchange` that quietly dropped somebody would produce a document that agrees with itself
+ * perfectly. Measuring from the tree covers the whole chain -- model, serialiser, ZIP, reader --
+ * and makes the guarantee the one worth having: what is on screen is what is in the file.
+ *
+ * Counts and ids, not deep equality: the reader is allowed to normalise (it drops edges whose ends
+ * are missing, for one), and asserting identical structures would fail on the reader doing its
+ * job. What must never differ is *who is in the file*.
+ */
+function differences(before, after) {
+  const problems = [];
+
+  if (after.people.length !== before.people.length) {
+    problems.push(`${before.people.length} people written, ${after.people.length} read back`);
+  }
+  if (after.relationships.length !== before.relationships.length) {
+    problems.push(`${before.relationships.length} relationships written, `
+      + `${after.relationships.length} read back`);
+  }
+
+  const wrote = new Set(before.people.map((p) => p.id));
+  const missing = before.people.filter((p) => !after.people.some((q) => q.id === p.id));
+  const strangers = after.people.filter((p) => !wrote.has(p.id));
+  if (missing.length) {
+    problems.push(`missing after the round trip: ${missing.slice(0, 3)
+      .map((p) => p.name ?? p.id).join(', ')}${missing.length > 3 ? ` and ${missing.length - 3} more` : ''}`);
+  }
+  if (strangers.length) problems.push(`${strangers.length} people appeared that were not written`);
+
+  return problems;
+}
+
+/**
+ * The bytes for a tree, proven readable before they are returned.
+ *
+ * @param {{toExchange: (now?: Date) => object}} tree
+ * @param {Map<string, Uint8Array>} photos entry path -> bytes
+ * @returns {Promise<{bytes: Uint8Array, people: number, relationships: number}>}
+ * @throws {SaveRefused} when the archive does not read back as what was written
+ */
+export async function bytesForTree(tree, photos = new Map(), now = new Date()) {
+  const held = { people: tree.people, relationships: tree.relationships };
+
+  let bytes;
+  try {
+    bytes = await writeTreeArchive(tree.toExchange(now), photos, now);
+  } catch (error) {
+    /*
+     * The writer refuses documents it cannot represent -- a person with no id, an edge with one
+     * end. From here that is the same outcome as a failed check and deserves the same answer:
+     * nothing was written, and here is why.
+     */
+    throw new SaveRefused('f-tree could not write your tree to a file.',
+      `${error.message}\n\nNothing has been saved and the file on disk is unchanged.`);
+  }
+
+  let read;
+  try {
+    const archive = await openArchive(
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    if (!archive.has('tree.json')) throw new Error('the archive came back without a tree.json');
+    read = parseDocument(await archive.readText('tree.json'));
+
+    for (const name of photos.keys()) {
+      if (!archive.has(name)) throw new Error(`the archive came back without ${name}`);
+    }
+  } catch (error) {
+    throw new SaveRefused('f-tree could not verify the file it was about to write.',
+      `${error.message}\n\nNothing has been saved and the file on disk is unchanged.`);
+  }
+
+  const problems = differences(held, read);
+  if (problems.length) {
+    throw new SaveRefused('f-tree would have written a file that does not match your tree.',
+      `${problems.join('\n')}\n\nNothing has been saved and the file on disk is unchanged. `
+      + 'Please report this — it is a bug in f-tree, not in your tree.');
+  }
+
+  return {
+    bytes,
+    people: read.people.length,
+    relationships: read.relationships.length,
+  };
+}

--- a/desktop/renderer/save.test.js
+++ b/desktop/renderer/save.test.js
@@ -1,0 +1,121 @@
+/*
+ * The check that stands between a writer bug and somebody's family.
+ *
+ * The interesting cases are the ones where the writer is *wrong*, so most of these hand
+ * `bytesForTree` a tree whose serialisation quietly loses something and assert that the save is
+ * refused rather than performed. A test suite that only ever exercises a correct writer proves
+ * the verification runs, not that it works.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { bytesForTree, SaveRefused } from './save.js';
+import { Tree, RelationshipType } from './document.js';
+
+const { PARENT } = RelationshipType;
+
+function family(size = 3) {
+  const tree = new Tree();
+  const ids = [];
+  for (let i = 0; i < size; i += 1) ids.push(tree.addPerson({ name: `P${i}` }).id);
+  for (let i = 1; i < size; i += 1) {
+    tree.addRelationship({ from: ids[0], to: ids[i], type: PARENT });
+  }
+  return { tree, ids };
+}
+
+test('a good tree produces bytes and reports what is in them', async () => {
+  const { tree } = family(4);
+  const saved = await bytesForTree(tree);
+  assert.ok(saved.bytes.length > 0);
+  assert.strictEqual(saved.people, 4);
+  assert.strictEqual(saved.relationships, 3);
+});
+
+test('photos are carried and checked for', async () => {
+  const { tree } = family(1);
+  const photos = new Map([['photos/a.jpg', new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])]]);
+  const saved = await bytesForTree(tree, photos);
+  assert.ok(saved.bytes.length > 0);
+});
+
+/* ---------------------------------------------------------------- when the writer is wrong */
+
+/** A tree whose serialisation is sabotaged, standing in for a writer or model bug. */
+function brokenTree(sabotage) {
+  const { tree } = family(5);
+  const honest = tree.toExchange.bind(tree);
+  tree.toExchange = (now) => sabotage(honest(now));
+  return tree;
+}
+
+test('a save that would drop somebody is refused', async () => {
+  /*
+   * The document handed to the writer keeps all five people, but one of them carries a
+   * relationship id in place of a person id, so the reader resolves fewer than were written.
+   * Whatever the mechanism, the count disagrees and that is the whole point.
+   */
+  const tree = brokenTree((doc) => ({ ...doc, people: doc.people.slice(0, 4) }));
+  await assert.rejects(() => bytesForTree(tree), (error) => {
+    assert.ok(error instanceof SaveRefused);
+    assert.match(error.detail, /5 people written, 4 read back|4 people written/);
+    assert.match(error.detail, /file on disk is unchanged/);
+    return true;
+  });
+});
+
+test('a save that would drop a relationship is refused', async () => {
+  const tree = brokenTree((doc) => ({ ...doc, relationships: doc.relationships.slice(0, 1) }));
+  await assert.rejects(() => bytesForTree(tree), (error) => {
+    assert.ok(error instanceof SaveRefused);
+    assert.match(error.detail, /relationships written/);
+    return true;
+  });
+});
+
+test('the refusal names who went missing, not just how many', async () => {
+  const tree = brokenTree((doc) => ({
+    ...doc,
+    people: doc.people.filter((p) => p.name !== 'P2'),
+  }));
+  await assert.rejects(() => bytesForTree(tree), (error) => {
+    assert.match(error.detail, /P2/);
+    return true;
+  });
+});
+
+test('an unreadable archive is refused rather than written', async () => {
+  const { tree } = family(2);
+  // A person id that is not a string breaks the writer's own contract; whatever it produces,
+  // it must not reach the disk unnoticed.
+  const honest = tree.toExchange.bind(tree);
+  tree.toExchange = (now) => {
+    const doc = honest(now);
+    doc.people[0] = { ...doc.people[0], id: undefined };
+    return doc;
+  };
+  await assert.rejects(() => bytesForTree(tree), (error) => {
+    assert.ok(error instanceof SaveRefused, `threw ${error.constructor.name}: ${error.message}`);
+    return true;
+  });
+});
+
+test('a refusal says nothing was saved, because nothing was', async () => {
+  const tree = brokenTree((doc) => ({ ...doc, people: [] }));
+  await assert.rejects(() => bytesForTree(tree), (error) => {
+    assert.match(error.message, /f-tree/);
+    assert.match(error.detail, /Nothing has been saved/);
+    return true;
+  });
+});
+
+/* ---------------------------------------------------------------- the empty tree */
+
+test('an empty tree is still written, and reads back empty', async () => {
+  // Not an error case: somebody who deleted everybody should be able to save that, and the
+  // Android importer is the thing that decides an empty file is not worth importing.
+  const saved = await bytesForTree(new Tree());
+  assert.strictEqual(saved.people, 0);
+  assert.strictEqual(saved.relationships, 0);
+});


### PR DESCRIPTION
Step 4 of #101, and the point at which the download page's claim — *this app cannot damage your
tree, because it only ever reads* — stops being true. So the care goes in **before** any edit
button does.

Three defences, none trusting the one before it.

## 1. The page checks its own bytes before they leave it

`renderer/save.js` reads every save back in memory, through the same reader the app opens files
with, and compares it against the tree still held in memory. Disagree on the count of people or
relationships, or fail to parse, and **the save does not happen**: bytes refused, file on disk
untouched, and the message names who went missing.

That is not a claim that the writer is correct — it is a second implementation of a format and it
can be wrong. It is that **a save which would lose something does not happen at all.**

**The tests caught the first version checking the wrong thing.** It compared the exchange document
against the read-back, which can only ever catch a bug in the *writer*: a `toExchange` that quietly
dropped somebody would produce a document agreeing with itself perfectly. It now measures from the
tree, covering the whole chain — model → serialiser → ZIP → reader — so the guarantee is the one
worth having: *what is on screen is what is in the file.*

## 2. The disk write cannot leave a half file

`atomic.js`: temp file in the **same directory**, fsync, rename over the target, then fsync the
directory — that last step is what makes the *rename* survive a crash, not just the bytes it points
at. Same directory on purpose: a rename across filesystems is a copy, and copies are interruptible.
Previous contents kept as `<name>.bak`, **copied not renamed**, so the path is never momentarily
empty.

**Run against a naive `fs.writeFile` to check the tests have teeth — two fail there:**

```
not ok 6 - a failure leaves the original exactly as it was
not ok 9 - the target holds the old file until the moment it holds the new one
```

Test 9 reads the path repeatedly during a 4 MB save and asserts every read is one of the two
*complete* versions.

## 3. A window will not vanish with unsaved work

The page reports dirty; close asks. **Save** hands the work back to the page — the only side that
can serialise and verify — then waits for it to report itself clean, with a deadline and an honest
ending. An editor that hung on closing would be worse than the bug being prevented.

## One design note

Saving crosses the bridge as **bytes, never a document**. The page owns the format. Sending a
document for the main process to encode would put a second encoder in the app and leave the
verification checking something other than what actually gets written.

## Also

The smoke test now asserts the bridge **by name**. A preload that fails to load leaves
`window.ftreeDesktop` looking plausible enough for the page to run and for saving to silently do
nothing.

## Checks

- 62 unit tests pass (12 update, 11 rules, 22 tree, 8 save, 9 atomic)
- 15 smoke assertions pass, including the four new bridge names
- `git status --short app/` empty: the Android app is untouched

Refs #101, #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)