### PR TITLE
The desktop app stands on its own

### DIFF
--- a/desktop/identity.js
+++ b/desktop/identity.js
@@ -1,0 +1,65 @@
+/*
+ * This installation's stable id.
+ *
+ * A port of `transfer/TreeIdentity.kt`, and the thing that lets somebody use this app having never
+ * owned the phone app.
+ *
+ * Every `.ftree` records the installation that produced it, in `sourceTreeId`. That is not
+ * bookkeeping: when a file is imported, the importer uses it to recognise people by identity
+ * rather than by comparing names --
+ *
+ *     if (document.sourceTreeId == identity.treeId) {
+ *         local.forEach { put(identity.treeId to it.id, it.id) }
+ *     }
+ *
+ * -- so two files claiming the same origin are asserting that people sharing an id are the same
+ * person. Without an id of its own, a tree created on this desktop would be written claiming the
+ * empty origin, and every desktop in the world would be claiming it too. Importing one such tree
+ * into another would then merge strangers.
+ *
+ * Which is why this exists before the editor does. A file already written with an empty origin
+ * cannot be repaired afterwards: it is on somebody's disk, claiming nothing.
+ *
+ * Note what this is *not* for. A tree that arrived from a phone keeps that phone's id when it is
+ * saved here, so the phone still recognises its own file on the way back. This id is minted only
+ * for a tree that came from nowhere -- one started on this machine.
+ */
+
+const fs = require('node:fs/promises');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const FILE = 'identity.json';
+
+/**
+ * Reads this installation's id, minting one the first time.
+ *
+ * @param {string} directory the app's userData directory
+ * @returns {Promise<string>}
+ */
+async function installationId(directory) {
+  const file = path.join(directory, FILE);
+
+  try {
+    const saved = JSON.parse(await fs.readFile(file, 'utf8'));
+    if (typeof saved?.treeId === 'string' && saved.treeId) return saved.treeId;
+  } catch {
+    // Absent on first run, which is ordinary. Unreadable is not, and is handled below the same
+    // way: there is nothing to recover, and refusing to start would be a worse answer than
+    // starting with a new identity.
+  }
+
+  const treeId = crypto.randomUUID();
+  await fs.mkdir(directory, { recursive: true });
+  /*
+   * Written the same way a tree is: to a temporary file, then renamed. An identity half-written
+   * by a crash would be read back as absent on the next launch and replaced, quietly detaching
+   * this installation from every file it had already produced.
+   */
+  const temporary = `${file}.new-${process.pid}`;
+  await fs.writeFile(temporary, `${JSON.stringify({ treeId }, null, 2)}\n`);
+  await fs.rename(temporary, file);
+  return treeId;
+}
+
+module.exports = { installationId, IDENTITY_FILE: FILE };

--- a/desktop/identity.test.js
+++ b/desktop/identity.test.js
@@ -1,0 +1,73 @@
+/*
+ * The installation id.
+ *
+ * What is being defended: two trees created on two different desktops must never claim the same
+ * origin, and one desktop must never change its mind about who it is. Both failures are silent
+ * and both merge strangers into somebody's family on the next import.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { installationId, IDENTITY_FILE } = require('./identity');
+
+const scratch = () => fs.mkdtemp(path.join(os.tmpdir(), 'ftree-identity-'));
+
+test('an id is minted on first run', async () => {
+  const dir = await scratch();
+  const id = await installationId(dir);
+  assert.match(id, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+});
+
+test('the same installation keeps the same id', async () => {
+  const dir = await scratch();
+  const first = await installationId(dir);
+  const second = await installationId(dir);
+  const third = await installationId(dir);
+  assert.strictEqual(first, second);
+  assert.strictEqual(second, third);
+});
+
+test('two installations never share an id', async () => {
+  const [a, b] = [await scratch(), await scratch()];
+  assert.notStrictEqual(await installationId(a), await installationId(b));
+});
+
+test('the id survives a restart, because it is on disk not in memory', async () => {
+  const dir = await scratch();
+  const before = await installationId(dir);
+  const written = JSON.parse(await fs.readFile(path.join(dir, IDENTITY_FILE), 'utf8'));
+  assert.strictEqual(written.treeId, before);
+});
+
+test('a directory that does not exist yet is made', async () => {
+  const dir = path.join(await scratch(), 'not', 'created', 'yet');
+  assert.ok(await installationId(dir));
+});
+
+test('an unreadable identity file is replaced rather than refusing to start', async () => {
+  // There is nothing to recover from a corrupt id, and refusing to open somebody's tree over it
+  // would be a worse answer than starting again. It is still a real loss of continuity, so this
+  // pins the behaviour rather than leaving it to chance.
+  const dir = await scratch();
+  await fs.writeFile(path.join(dir, IDENTITY_FILE), 'this is not json');
+  const id = await installationId(dir);
+  assert.ok(id);
+  assert.strictEqual(await installationId(dir), id, 'and the replacement then sticks');
+});
+
+test('an identity file with an empty id is treated as absent', async () => {
+  const dir = await scratch();
+  await fs.writeFile(path.join(dir, IDENTITY_FILE), JSON.stringify({ treeId: '' }));
+  const id = await installationId(dir);
+  assert.ok(id, 'an empty id is exactly the value that must never be written to a tree');
+});
+
+test('nothing temporary is left behind', async () => {
+  const dir = await scratch();
+  await installationId(dir);
+  assert.deepStrictEqual(await fs.readdir(dir), [IDENTITY_FILE]);
+});

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -18,6 +18,7 @@ const path = require('node:path');
 
 const { chooseUpdate } = require('./update');
 const { writeTreeFile } = require('./atomic');
+const { installationId } = require('./identity');
 
 /*
  * A window needs somewhere to be.
@@ -389,6 +390,12 @@ function buildMenu(win) {
     {
       label: 'File',
       submenu: [
+        /*
+         * First, and not as a courtesy. Somebody may have installed this having never owned the
+         * phone app, and for them "Open tree" is a dead end -- there is nothing to open.
+         */
+        { label: 'New tree', accelerator: 'CmdOrCtrl+N',
+          click: () => win.webContents.send('menu:command', 'file:new') },
         { label: 'Open tree…', accelerator: 'CmdOrCtrl+O', click: () => chooseInto(win) },
         { type: 'separator' },
         /*
@@ -475,7 +482,8 @@ function buildMenu(win) {
             type: 'info',
             message: `f-tree ${app.getVersion()}`,
             detail: 'A local-first family tree. Everything stays on this machine: no account, no '
-              + 'cloud, no backend. Open a .ftree exported from the Android app to read it here.',
+              + 'cloud, no backend. It reads and writes .ftree files, the same ones the Android '
+              + 'app uses — but it does not need it: a tree can start here.',
             buttons: ['OK'],
           }),
         },
@@ -636,6 +644,14 @@ async function createWindow() {
 }
 
 ipcMain.handle('app:version', () => app.getVersion());
+
+/*
+ * Who this installation is, for a tree started here.
+ *
+ * Minted once and never changed. The page needs it before it can create a tree, because a tree
+ * written without one claims the empty origin -- see identity.js.
+ */
+ipcMain.handle('app:installationId', () => installationId(app.getPath('userData')));
 ipcMain.handle('tree:choose', async (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   return chooseInto(win);

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -13,6 +13,14 @@ contextBridge.exposeInMainWorld('ftreeDesktop', {
   platform: process.platform,
   version: () => ipcRenderer.invoke('app:version'),
 
+  /**
+   * This installation's own id, stamped into a tree started here.
+   *
+   * Not cosmetic: a tree written with an empty origin cannot be told apart from every other
+   * desktop's, and importing two of them into one another merges strangers. See identity.js.
+   */
+  installationId: () => ipcRenderer.invoke('app:installationId'),
+
   /** Opens the system file picker and returns { name, bytes } or null if it was cancelled. */
   chooseTree: () => ipcRenderer.invoke('tree:choose'),
 

--- a/desktop/renderer/document.js
+++ b/desktop/renderer/document.js
@@ -63,11 +63,26 @@ function tidyPerson(fields) {
 export class Tree {
   /**
    * @param {object} document a document in the exchange shape, as `archive.js` returns
+   * @param {{ownTreeId?: string}} options this installation's id, for a tree that came from
+   *   nowhere. See `desktop/identity.js` for why an empty origin is not an acceptable default.
    */
-  constructor(document = {}) {
+  constructor(document = {}, { ownTreeId = '' } = {}) {
     this.state = {
       exportedAt: document.exportedAt ?? '',
-      sourceTreeId: document.sourceTreeId ?? '',
+      /*
+       * Whose tree this is, in the sense the importer means.
+       *
+       * A tree that arrived from a phone keeps that phone's id, and that is not an oversight: the
+       * importer recognises a file whose `sourceTreeId` matches its own and then matches people by
+       * id alone, with no name comparison. Rewriting it here would throw that away and send a
+       * desktop-edited tree back as a stranger.
+       *
+       * A tree that came from nowhere -- started on this machine -- takes this installation's own
+       * id instead. The empty string is the one value that must never be written: every desktop
+       * would be claiming it, and importing one such tree into another would merge people who
+       * merely share a position, not an identity.
+       */
+      sourceTreeId: document.sourceTreeId || ownTreeId || '',
       people: clone(document.people ?? []),
       relationships: clone(document.relationships ?? []),
     };

--- a/desktop/renderer/document.test.js
+++ b/desktop/renderer/document.test.js
@@ -224,8 +224,33 @@ test('an edited tree writes a file the reader accepts', async () => {
 });
 
 test('sourceTreeId is carried through, not reissued', () => {
-  const tree = new Tree({ sourceTreeId: 'the-phone', people: [{ id: 'a' }] });
+  // The importer recognises a file whose sourceTreeId matches its own and then matches people by
+  // id with no name comparison at all. Rewriting it would send a desktop-edited tree back to the
+  // phone as a stranger.
+  const tree = new Tree({ sourceTreeId: 'the-phone', people: [{ id: 'a' }] },
+    { ownTreeId: 'this-desktop' });
   assert.strictEqual(tree.toExchange().sourceTreeId, 'the-phone');
+});
+
+test('a tree that came from nowhere takes this installation id', () => {
+  const tree = new Tree({}, { ownTreeId: 'this-desktop' });
+  tree.addPerson({ name: 'The first person anybody adds here' });
+  assert.strictEqual(tree.toExchange().sourceTreeId, 'this-desktop');
+});
+
+test('a tree started here is not written claiming the empty origin', () => {
+  /*
+   * The value that must never reach a file. Every desktop would be claiming it, so importing one
+   * such tree into another would match people who share nothing but a position in a list.
+   */
+  const tree = new Tree({}, { ownTreeId: 'this-desktop' });
+  assert.notStrictEqual(tree.toExchange().sourceTreeId, '');
+});
+
+test('an empty sourceTreeId in a file is replaced, not preserved', () => {
+  // A file written by an older desktop build, before it had an identity of its own.
+  const tree = new Tree({ sourceTreeId: '', people: [{ id: 'a' }] }, { ownTreeId: 'this-desktop' });
+  assert.strictEqual(tree.toExchange().sourceTreeId, 'this-desktop');
 });
 
 test('exportedAt is stamped at save time', () => {


### PR DESCRIPTION
> i hope you're aware that someone might just use desktop app and never android! android app should
> not be a dependency for desktop app

Right, and two things assumed otherwise. One of them corrupts data rather than merely reading oddly.

## There was no way to start a tree

The app could only *open* a `.ftree`. For somebody who has never owned the phone app that is a dead
end — there is nothing to open. **File → New tree** is now the first item in the menu, above Open,
because that is the order those two matter in for somebody arriving fresh.

## There was no installation identity — the real bug

`TreeIdentity.kt` mints a `sourceTreeId` once per install and stamps every export with it. A tree
created on the desktop would have been written claiming `sourceTreeId: ""` — **and so would every
other desktop in the world.** The importer treats a shared origin as a statement of identity:

```kotlin
if (document.sourceTreeId == identity.treeId) {
    local.forEach { put(identity.treeId to it.id, it.id) }
}
// "a re-import of our own file recognises everybody without any name comparison at all"
```

So importing one such tree into another would **merge strangers**.

`identity.js` mints a UUID once and writes it through a temp file and a rename. An identity
half-written by a crash would read back as absent next launch and be replaced, quietly detaching the
installation from every file it had already produced.

**Done before the editing UI, not after**, because a file already written with an empty origin
cannot be repaired — it is on somebody's disk claiming nothing.

## What looks like the same bug and is not

A tree that *arrived* from a phone keeps that phone's `sourceTreeId` when saved here. That is what
lets the phone recognise a desktop-edited file as its own on the way back. The rule is **carry it
when there is one, mint our own when there is not** — not "stop carrying it".

## Not promised early

The download page still says building and editing a tree is the Android app's job. True until the
editing UI works; better changed then than promised now.

## Also in this branch

The About box stops describing the app as a reader for files the Android app produced.

## Checks

- 65 unit tests (12 update, 11 rules, 26 tree, 8 save, 9 atomic, 8 identity — 4 of the tree's are
  new and cover exactly the carry-vs-mint rule)
- 15 smoke assertions pass
- `git status --short app/` empty

Refs #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)