### PR TITLE
The editor: a tree can be built on the desktop, not only read

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -78,6 +78,10 @@ jobs:
           # Asserts the updater is not blocked by the page's own network refusal - the regression
           # that shipped in 0.2.0 and reported itself as ERR_BLOCKED_BY_CLIENT.
           FTREE_SMOKE_NETWORK: '1'
+          # Setting this turns on the second half of the smoke test: starting a tree from nothing,
+          # naming somebody, adding a child, being refused a contradictory relationship, saving to
+          # this path and reading it back. Everything but the native save dialog is the real path.
+          FTREE_SMOKE_SAVE_TO: ${{ runner.temp }}/built-here.ftree
         run: xvfb-run -a npx electron . --no-sandbox
 
   package:

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -41,9 +41,22 @@ if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND
  * index, the search and the relation finder - a fix to any of them is a fix in both places rather
  * than a fix and a note to remember the other one.
  */
+/*
+ * The page this shell shows.
+ *
+ * The desktop app's own, not the website's viewer: that one reads a tree and stays a reader, and
+ * this one builds and changes one. They share the engine underneath -- reader, writer, model,
+ * layout, chart -- which `renderer/index.html` imports from `../../site/playground/`.
+ *
+ * That relative path is why packaging reproduces the repository's shape rather than flattening it:
+ * in development the import already resolves against the working tree, so there is no assembly
+ * step to keep in step with anything. The staged directory is called `page` and not `app` on
+ * purpose -- `resources/app` is where Electron looks for an unpacked application, and putting a
+ * package.json there would make it try to run this as one.
+ */
 const VIEWER = app.isPackaged
-  ? path.join(process.resourcesPath, 'viewer', 'index.html')
-  : path.join(__dirname, '..', 'site', 'playground', 'index.html');
+  ? path.join(process.resourcesPath, 'page', 'renderer', 'index.html')
+  : path.join(__dirname, 'renderer', 'index.html');
 
 /*
  * Where the app remembers what it was reading.
@@ -673,6 +686,19 @@ ipcMain.handle('tree:save', async (event, { bytes, path: target }) => {
 
 ipcMain.handle('tree:saveAs', async (event, { bytes, suggest }) => {
   const win = BrowserWindow.fromWebContents(event.sender);
+
+  /*
+   * The one seam the smoke test needs, and it is deliberately narrow.
+   *
+   * A native save dialog cannot be driven from a test, and stubbing the whole save would leave
+   * the part that actually writes to a disk unexercised -- which is the part worth exercising.
+   * So the destination is supplied and everything after it is the real code path. Guarded on
+   * FTREE_SMOKE, so it cannot be reached in a build somebody is using.
+   */
+  if (process.env.FTREE_SMOKE && process.env.FTREE_SMOKE_SAVE_TO) {
+    return saveInto(win, process.env.FTREE_SMOKE_SAVE_TO, bytes);
+  }
+
   const picked = await dialog.showSaveDialog(win, {
     title: 'Save the family tree',
     defaultPath: suggest || 'family-tree.ftree',
@@ -715,6 +741,118 @@ ipcMain.handle('tree:last', async () => {
  * would actually be broken if the wiring came apart: the bridge is reachable, the tree arrived,
  * every person was drawn, and the layout ran.
  */
+/*
+ * Building a tree from nothing, the way somebody who has never owned the phone app would.
+ *
+ * The assertions above prove the app can read. These prove it can do the thing it exists for, and
+ * they use the real path all the way down: the real buttons, the real relationship rules, the real
+ * writer, the real atomic save onto a real disk, and then the file read back. Nothing is stubbed
+ * but the native save dialog, which cannot be clicked from here.
+ *
+ * The order matters. Each step depends on the one before, so a failure early stops the rest rather
+ * than reporting six confusing consequences of one cause.
+ */
+async function runEditSmoke(win, check) {
+  const page = (fn, ...args) => win.webContents.executeJavaScript(
+    `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
+  const settle = (ms = 350) => new Promise((r) => setTimeout(r, ms));
+
+  console.log('\n  -- building a tree from nothing --');
+
+  await page(() => document.getElementById('start-new').click());
+  await settle();
+
+  let seen = await page(() => ({
+    counts: document.getElementById('counts')?.textContent ?? '',
+    panelOpen: document.getElementById('panel')?.hidden === false,
+    nameField: Boolean(document.getElementById('f-name')),
+  }));
+  check('a new tree starts with somebody to name', seen.panelOpen && seen.nameField,
+    seen.counts);
+
+  // Typing a name and leaving the field: one edit, one undo step.
+  await page(() => {
+    const input = document.getElementById('f-name');
+    input.value = 'Shyam Lal';
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await settle();
+
+  // Add a child, by name, as a new person.
+  await page(() => {
+    [...document.querySelectorAll('.kinds button')].find((b) => b.textContent === 'Child').click();
+  });
+  await settle(200);
+  await page(() => {
+    document.getElementById('add-name').value = 'Ravi';
+    [...document.querySelectorAll('.add-rel .btn')].find((b) => b.textContent.includes('new person')).click();
+  });
+  await settle();
+
+  seen = await page(() => ({
+    counts: document.getElementById('counts')?.textContent ?? '',
+    unsaved: document.getElementById('unsaved')?.hidden === false,
+    canUndo: document.getElementById('undo')?.disabled === false,
+  }));
+  check('a person and a child are recorded', /2 people/.test(seen.counts) && /1 connection/.test(seen.counts),
+    seen.counts);
+  check('the window knows there is work not on disk', seen.unsaved === true);
+  check('there is something to undo', seen.canUndo === true);
+
+  // The rules, through the interface rather than around it: a child cannot also be a partner.
+  await page(() => {
+    [...document.querySelectorAll('.kinds button')].find((b) => b.textContent === 'Partner').click();
+  });
+  await settle(200);
+  const refused = await page(() => {
+    const list = [...document.querySelectorAll('.add-rel .search-results li button')];
+    document.getElementById('add-name').value = 'Ravi';
+    document.getElementById('add-name').dispatchEvent(new Event('input', { bubbles: true }));
+    return list.length;
+  });
+  await settle(200);
+  await page(() => {
+    const first = document.querySelector('.add-rel .search-results li button');
+    if (first) first.click();
+  });
+  await settle();
+  seen = await page(() => ({
+    counts: document.getElementById('counts')?.textContent ?? '',
+    toast: document.getElementById('toast')?.hidden === false
+      ? document.getElementById('toast').textContent : null,
+  }));
+  check('the rules refuse a partner who is already a child, and say why',
+    /1 connection/.test(seen.counts) && /already parent and child/i.test(seen.toast ?? ''),
+    `${seen.counts} — ${seen.toast}`);
+
+  // Save, through the real writer and the real atomic write.
+  await page(() => document.getElementById('save').click());
+  await settle(1200);
+
+  const target = process.env.FTREE_SMOKE_SAVE_TO;
+  const wrote = await fs.stat(target).then((s) => s.size, () => 0);
+  check('the tree was written to disk', wrote > 0, `${wrote} bytes at ${target}`);
+
+  seen = await page(() => ({
+    unsaved: document.getElementById('unsaved')?.hidden === false,
+    toast: document.getElementById('toast')?.textContent ?? '',
+  }));
+  check('saving clears the unsaved mark', seen.unsaved === false, seen.toast);
+
+  /*
+   * Read back through the app itself. A file the writer can produce and the reader cannot open
+   * would pass every check above and be useless.
+   */
+  await openInto(win, target);
+  await settle(900);
+  seen = await page(() => ({
+    counts: document.getElementById('counts')?.textContent ?? '',
+    names: [...document.querySelectorAll('.rel-go')].map((b) => b.textContent).join(','),
+  }));
+  check('the saved file reopens with both people and the connection',
+    /2 people/.test(seen.counts) && /1 connection/.test(seen.counts), seen.counts);
+}
+
 async function runSmoke(win, file) {
   const failures = [];
   const iconExists = await fs.access(ICON_FOR_WINDOW).then(() => true, () => false);
@@ -738,6 +876,17 @@ async function runSmoke(win, file) {
     return;
   }
 
+  /*
+   * The page's own errors, in this log.
+   *
+   * Without this a thrown exception in the renderer is invisible from here: the assertions simply
+   * report the consequence -- a panel that did not open, a count that did not change -- and the
+   * cause stays in a console nobody is looking at. It cost an afternoon once.
+   */
+  win.webContents.on('console-message', (_event, level, message, line, source) => {
+    if (level >= 2) console.log(`       page: ${message}  (${source}:${line})`);
+  });
+
   await openInto(win, file);
   // The page reads the file, lays it out and paints; give it room on a slow runner.
   await new Promise((r) => setTimeout(r, 2500));
@@ -753,8 +902,11 @@ async function runSmoke(win, file) {
     hint: document.getElementById('hint')?.textContent ?? null,
     literata: document.fonts.check('16px Literata'),
     mono: document.fonts.check('13px "JetBrains Mono"'),
-    people: document.querySelectorAll('#index-list li, #index-list button, #index-list tr').length,
-    status: document.querySelector('#status')?.textContent?.trim().slice(0, 90) ?? null,
+    counts: document.getElementById('counts')?.textContent?.trim() ?? null,
+    // The editor's own surface. A page that reads a tree but cannot change one is not this app.
+    canEdit: Boolean(document.getElementById('add-person') && document.getElementById('save')),
+    undoPresent: Boolean(document.getElementById('undo') && document.getElementById('redo')),
+    panelExists: Boolean(document.getElementById('panel')),
   })).toString()})()`);
 
   check('the preload bridge is reachable from the page', seen.bridge === true);
@@ -779,7 +931,10 @@ async function runSmoke(win, file) {
     check(`the page can ask to ${name}`, String(seen.bridgeNames).split(',').includes(name),
       String(seen.bridgeNames));
   }
-  check('the archive was read and counted', /\d+ people/.test(seen.status ?? ''), String(seen.status));
+  check('the archive was read and counted', /\d+ people/.test(seen.counts ?? ''), String(seen.counts));
+  check('the page can change a tree, not only read one', seen.canEdit === true);
+  check('undo and redo are there', seen.undoPresent === true);
+  check('a person can be opened for editing', seen.panelExists === true);
   // Refusing the network must not quietly cost the app its typography.
   check('the bundled typefaces loaded without the network', seen.literata && seen.mono,
     `Literata ${seen.literata}, JetBrains Mono ${seen.mono}`);
@@ -815,6 +970,8 @@ async function runSmoke(win, file) {
     }
     check('the updater can reach GitHub through the page-level refusal', reachable, detail);
   }
+
+  if (process.env.FTREE_SMOKE_SAVE_TO) await runEditSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_SHOT) {
     const image = await win.webContents.capturePage();

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -40,9 +40,17 @@
     "extraResources": [
       {
         "from": "../site/playground",
-        "to": "viewer",
+        "to": "page/site/playground",
         "filter": [
           "**/*"
+        ]
+      },
+      {
+        "from": "renderer",
+        "to": "page/renderer",
+        "filter": [
+          "**/*",
+          "!*.test.js"
         ]
       },
       {

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -1,0 +1,778 @@
+/*
+ * The desktop app.
+ *
+ * The website's viewer reads a tree; this one builds and changes one, so it has its own controller
+ * rather than the viewer's with editing bolted on. What the two share is the engine underneath --
+ * the ZIP reader and writer, the graph model, the layout and the canvas -- imported from
+ * site/playground/ so a fix to how a family is drawn lands in both.
+ *
+ * Three rules run through everything below.
+ *
+ * **Nothing changes the tree except through `Tree`.** It is the only thing that applies the
+ * relationship rules, and the only thing that can put a change back. A field that wrote to a person
+ * directly would edit somebody's family with no rule check, no undo and no unsaved mark.
+ *
+ * **One edit is one undo step.** Form fields commit on `change`, not on `input`, so typing a name
+ * is one step rather than one per keystroke -- which would make undo useless exactly when it
+ * matters.
+ *
+ * **A refusal is an explanation.** The rules say no for reasons a person can understand, so the
+ * interface says the reason and not "invalid".
+ */
+
+import { openArchive, parseDocument, ArchiveError } from '../../site/playground/archive.js';
+import { buildGraph, displayName, lifespan, relationsOf } from '../../site/playground/model.js';
+import { layoutArchive } from '../../site/playground/layout.js';
+import { Chart } from '../../site/playground/chart.js';
+
+import { Tree, RelationshipType, Rejection } from './document.js';
+import { bytesForTree, SaveRefused } from './save.js';
+
+const { PARENT, SPOUSE, SIBLING } = RelationshipType;
+
+const $ = (id) => document.getElementById(id);
+const shell = globalThis.ftreeDesktop ?? null;
+
+const state = {
+  tree: null,
+  graph: null,
+  layout: null,
+  /** Photo bytes by entry path, carried from the opened file and written back out. */
+  photos: new Map(),
+  path: null,
+  name: null,
+  ownTreeId: '',
+  selected: null,
+  /** Which kind of relative the "add" form is currently offering. */
+  adding: null,
+  saving: false,
+};
+
+let chart = null;
+
+/* ------------------------------------------------------------------ chrome */
+
+function setState(value) {
+  $('viewer').dataset.state = value;
+}
+
+let toastTimer = null;
+function toast(message, tone = 'good') {
+  const box = $('toast');
+  box.textContent = message;
+  box.dataset.tone = tone;
+  box.hidden = false;
+  clearTimeout(toastTimer);
+  // A refusal is longer and worth reading twice; a confirmation is not.
+  toastTimer = setTimeout(() => { box.hidden = true; }, tone === 'bad' ? 9000 : 2600);
+}
+
+/** Keeps the window, the menu and the dot in step with whether there is work not on disk. */
+function reflectDirty() {
+  const dirty = Boolean(state.tree?.isDirty);
+  $('unsaved').hidden = !dirty;
+  $('save').dataset.dirty = String(dirty);
+  $('undo').disabled = !state.tree?.canUndo;
+  $('redo').disabled = !state.tree?.canRedo;
+  $('undo').title = state.tree?.undoLabel ? `Undo: ${state.tree.undoLabel}` : 'Undo';
+  $('redo').title = state.tree?.redoLabel ? `Redo: ${state.tree.redoLabel}` : 'Redo';
+  shell?.setDirty(dirty);
+}
+
+/* ------------------------------------------------------------------ drawing */
+
+/*
+ * Rebuilds the graph, the layout and the chart from the tree.
+ *
+ * Run after every change, which sounds expensive and is not: a few hundred people lay out in
+ * single-digit milliseconds, and the alternative -- patching the layout in place -- is a second
+ * implementation of the layout rules that would drift from the first.
+ *
+ * The selection is restored deliberately. `chart.load` clears it, and losing the person you were
+ * editing every time you typed their name would be its own bug.
+ */
+function rebuild({ refit = false } = {}) {
+  const doc = state.tree.toExchange();
+  state.graph = buildGraph(doc);
+  state.layout = layoutArchive(state.graph, { orientation: 'rows' });
+
+  chart.load(state.graph, state.layout, archiveShim());
+  chart.selected = state.selected && state.graph.people.has(state.selected)
+    ? state.selected
+    : null;
+  state.selected = chart.selected;
+  chart.invalidate();
+  if (refit) chart.fit();
+
+  document.body.dataset.orientation = state.layout.orientation;
+  renderCounts();
+  renderPanel();
+  renderEmptyInvitation();
+  reflectDirty();
+  updateZoom();
+}
+
+/**
+ * What the chart asks for when it wants a photograph.
+ *
+ * The chart expects something archive-shaped. Photos live in memory here because the file is
+ * rewritten on save, so this hands them over from the map rather than re-reading a ZIP.
+ */
+function archiveShim() {
+  return {
+    has: (name) => state.photos.has(name),
+    read: async (name) => state.photos.get(name),
+  };
+}
+
+/** One person, two people; one connection, two connections. Said properly, everywhere. */
+function count(n, one, many) {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
+function renderCounts() {
+  const people = state.tree.people.length;
+  $('counts').textContent = people === 0
+    ? 'Nobody yet'
+    : `${count(people, 'person', 'people')}·`
+      + `${count(state.tree.relationships.length, 'connection', 'connections')}`;
+}
+
+/** A tree with nobody in it is where every tree starts, so it gets an invitation, not an error. */
+function renderEmptyInvitation() {
+  const existing = document.querySelector('.first-person');
+  if (state.tree.people.length > 0) {
+    existing?.remove();
+    return;
+  }
+  if (existing) return;
+  const box = document.createElement('div');
+  box.className = 'first-person';
+  box.innerHTML = '<p>Nobody in this tree yet.</p>';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'btn primary';
+  button.textContent = 'Add the first person';
+  button.addEventListener('click', () => addPerson());
+  box.append(button);
+  $('stage').append(box);
+}
+
+function updateZoom() {
+  $('zoom-level').textContent = `${Math.round((chart?.scale ?? 1) * 100)}%`;
+}
+
+/* ------------------------------------------------------------------ the person panel */
+
+const GENDERS = [
+  ['', 'Not recorded'],
+  ['MALE', 'Male'],
+  ['FEMALE', 'Female'],
+  ['OTHER', 'Other'],
+];
+
+const KINDS = [
+  ['parent', 'Parent'],
+  ['child', 'Child'],
+  ['spouse', 'Partner'],
+  ['sibling', 'Sibling'],
+];
+
+/** Why the rules said no, in words that name what is being protected. */
+const REFUSALS = {
+  [Rejection.SELF_REFERENCE]: 'Somebody cannot be their own relative.',
+  [Rejection.DUPLICATE]: 'That connection is already recorded.',
+  [Rejection.ANCESTOR_CYCLE]:
+    'That would make somebody their own ancestor — the line would run in a circle.',
+  [Rejection.CONTRADICTS_EXISTING]:
+    'These two are already parent and child, so they cannot also be partners or siblings.',
+  NO_SUCH_PERSON: 'That person is no longer in the tree.',
+  DUPLICATE_ID: 'Somebody with that id is already here.',
+};
+
+function renderPanel() {
+  const panel = $('panel');
+  const id = state.selected;
+  if (!id) {
+    panel.hidden = true;
+    return;
+  }
+  const person = state.tree.person(id);
+  if (!person) {
+    panel.hidden = true;
+    return;
+  }
+  panel.hidden = false;
+
+  const body = $('panel-body');
+  body.replaceChildren();
+  body.append(personForm(person), relativesSection(person), dangerRow(person));
+}
+
+function field({ label, id, value = '', type = 'text', wide = false, hint = null }) {
+  const wrap = document.createElement('div');
+  wrap.className = wide ? 'field wide' : 'field';
+  const lab = document.createElement('label');
+  lab.textContent = label;
+  lab.htmlFor = id;
+  const input = type === 'textarea'
+    ? document.createElement('textarea')
+    : document.createElement('input');
+  if (type !== 'textarea') input.type = 'text';
+  input.id = id;
+  input.value = value ?? '';
+  wrap.append(lab, input);
+  if (hint) {
+    const note = document.createElement('p');
+    note.className = 'field-hint';
+    note.textContent = hint;
+    wrap.append(note);
+  }
+  return wrap;
+}
+
+function personForm(person) {
+  const form = document.createElement('div');
+  form.className = 'form-grid';
+
+  form.append(field({
+    label: 'Name', id: 'f-name', value: person.name ?? '', wide: true,
+  }));
+
+  const gender = document.createElement('div');
+  gender.className = 'field';
+  const gl = document.createElement('label');
+  gl.textContent = 'Gender';
+  gl.htmlFor = 'f-gender';
+  const select = document.createElement('select');
+  select.id = 'f-gender';
+  for (const [value, text] of GENDERS) {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = text;
+    if ((person.gender ?? '') === value) option.selected = true;
+    select.append(option);
+  }
+  gender.append(gl, select);
+  form.append(gender);
+
+  form.append(field({
+    label: 'Born', id: 'f-birth', value: person.birthDate ?? '', hint: 'A year alone is fine',
+  }));
+  form.append(field({ label: 'Died', id: 'f-death', value: person.deathDate ?? '' }));
+
+  const check = document.createElement('label');
+  check.className = 'check';
+  const box = document.createElement('input');
+  box.type = 'checkbox';
+  box.id = 'f-deceased';
+  box.checked = Boolean(person.deceased);
+  check.append(box, document.createTextNode('No longer living'));
+  form.append(check);
+
+  form.append(field({
+    label: 'Notes', id: 'f-notes', value: person.notes ?? '', type: 'textarea', wide: true,
+  }));
+
+  /*
+   * Committed on `change`, never on `input`.
+   *
+   * `input` fires per keystroke, which would put eleven undo steps behind a name like
+   * "Shyam Sundar" and make undo useless at the moment somebody actually needs it.
+   */
+  form.addEventListener('change', () => {
+    const result = state.tree.updatePerson(person.id, {
+      name: $('f-name').value,
+      gender: $('f-gender').value || null,
+      birthDate: $('f-birth').value,
+      deathDate: $('f-death').value,
+      deceased: $('f-deceased').checked,
+      notes: $('f-notes').value,
+    });
+    if (!result.ok) { toast(REFUSALS[result.reason] ?? 'That change was not made.', 'bad'); return; }
+    rebuild();
+  });
+
+  return form;
+}
+
+/*
+ * Everybody this person is connected to, grouped as the app groups them.
+ *
+ * `relationsOf` returns `[{heading, items}]` with each item already carrying the word the app
+ * would use -- Father, Wife, Younger brother -- so the naming stays in one place rather than
+ * being invented again here. Siblings in that list may be *derived* from shared parents rather
+ * than recorded, which is why disconnecting handles the no-edge case explicitly.
+ */
+function relativesSection(person) {
+  const box = document.createElement('div');
+  const groups = relationsOf(state.graph, person.id);
+
+  const heading = document.createElement('div');
+  heading.className = 'rel-heading';
+  const h3 = document.createElement('h3');
+  h3.textContent = 'Family';
+  heading.append(h3);
+  box.append(heading);
+
+  if (!groups.length) {
+    const empty = document.createElement('p');
+    empty.className = 'rel-empty';
+    empty.textContent = 'Nobody connected yet.';
+    box.append(empty);
+  }
+
+  for (const group of groups) {
+    const list = document.createElement('ul');
+    list.className = 'rel-list';
+    for (const item of group.items) {
+      const other = state.tree.person(item.id);
+      if (!other) continue;
+
+      const li = document.createElement('li');
+
+      const go = document.createElement('button');
+      go.type = 'button';
+      go.className = 'rel-go';
+      go.textContent = displayName(other);
+      go.addEventListener('click', () => select(item.id));
+
+      const role = document.createElement('span');
+      role.className = 'rel-role';
+      role.textContent = item.label;
+
+      const cut = document.createElement('button');
+      cut.type = 'button';
+      cut.className = 'rel-cut';
+      cut.textContent = '\u00d7';
+      /*
+       * Disconnecting is not deleting, and the wording has to keep the two apart: this removes a
+       * relationship and leaves both people exactly where they were.
+       */
+      cut.title = `Disconnect ${displayName(other)}`;
+      cut.setAttribute('aria-label', cut.title);
+      cut.addEventListener('click', () => disconnect(person.id, item.id));
+
+      li.append(go, role, cut);
+      list.append(li);
+    }
+    if (list.childElementCount) box.append(list);
+  }
+
+  box.append(addRelativeForm(person));
+  return box;
+}
+
+function addRelativeForm(person) {
+  const box = document.createElement('div');
+  box.className = 'add-rel';
+
+  const kinds = document.createElement('div');
+  kinds.className = 'kinds';
+  for (const [kind, label] of KINDS) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = label;
+    button.setAttribute('aria-pressed', String(state.adding === kind));
+    button.addEventListener('click', () => {
+      state.adding = state.adding === kind ? null : kind;
+      renderPanel();
+      if (state.adding) $('add-name')?.focus();
+    });
+    kinds.append(button);
+  }
+  box.append(kinds);
+
+  if (!state.adding) return box;
+
+  const name = field({
+    label: `Name of the ${KINDS.find(([k]) => k === state.adding)[1].toLowerCase()}`,
+    id: 'add-name',
+    wide: true,
+  });
+  box.append(name);
+
+  const input = name.querySelector('input');
+  const results = document.createElement('ul');
+  results.className = 'search-results';
+  results.hidden = true;
+  box.append(results);
+
+  const create = document.createElement('button');
+  create.type = 'button';
+  create.className = 'btn primary';
+  create.textContent = 'Add as a new person';
+  create.addEventListener('click', () => addRelative(person.id, state.adding, input.value.trim()));
+  box.append(create);
+
+  /*
+   * Somebody who is already in the tree should be connected, not duplicated.
+   *
+   * So typing offers the people already recorded before it offers to make another one. This is the
+   * cheapest place to prevent the commonest way a family tree goes wrong.
+   */
+  input.addEventListener('input', () => {
+    const term = input.value.trim().toLowerCase();
+    results.replaceChildren();
+    if (term.length < 2) { results.hidden = true; return; }
+    const found = state.tree.people
+      .filter((p) => p.id !== person.id && (p.name ?? '').toLowerCase().includes(term))
+      .slice(0, 6);
+    if (!found.length) { results.hidden = true; return; }
+    for (const candidate of found) {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.innerHTML = `<span>${escapeHtml(displayName(candidate))}</span>`
+        + `<small>${escapeHtml(lifespan(candidate) || 'already in this tree')}</small>`;
+      button.addEventListener('click', () => connect(person.id, state.adding, candidate.id));
+      li.append(button);
+      results.append(li);
+    }
+    results.hidden = false;
+  });
+
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') { event.preventDefault(); create.click(); }
+  });
+
+  return box;
+}
+
+function dangerRow(person) {
+  const row = document.createElement('div');
+  row.className = 'danger-row';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'btn-danger';
+  button.textContent = 'Delete this person';
+  button.addEventListener('click', () => removePerson(person.id));
+  row.append(button);
+  return row;
+}
+
+function escapeHtml(text) {
+  return String(text).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+/* ------------------------------------------------------------------ editing */
+
+function select(id) {
+  state.selected = id;
+  state.adding = null;
+  chart.selected = id;
+  chart.invalidate();
+  renderPanel();
+}
+
+function addPerson() {
+  const result = state.tree.addPerson({ name: '' });
+  if (!result.ok) { toast(REFUSALS[result.reason] ?? 'Could not add anybody.', 'bad'); return; }
+  state.selected = result.id;
+  state.adding = null;
+  rebuild({ refit: state.tree.people.length <= 1 });
+  $('f-name')?.focus();
+}
+
+/** The four kinds, as the graph actually records them. */
+function edgeFor(kind, subject, other) {
+  if (kind === 'parent') return { from: other, to: subject, type: PARENT };
+  if (kind === 'child') return { from: subject, to: other, type: PARENT };
+  if (kind === 'spouse') return { from: subject, to: other, type: SPOUSE };
+  return { from: subject, to: other, type: SIBLING };
+}
+
+function connect(subjectId, kind, otherId) {
+  const result = state.tree.addRelationship(edgeFor(kind, subjectId, otherId));
+  if (!result.ok) {
+    toast(REFUSALS[result.reason] ?? 'That connection was not made.', 'bad');
+    return;
+  }
+  state.adding = null;
+  rebuild();
+}
+
+function addRelative(subjectId, kind, name) {
+  const added = state.tree.addPerson({ name });
+  if (!added.ok) { toast(REFUSALS[added.reason] ?? 'Could not add anybody.', 'bad'); return; }
+
+  const result = state.tree.addRelationship(edgeFor(kind, subjectId, added.id));
+  if (!result.ok) {
+    /*
+     * The person was added and the connection refused, which would leave a stranger floating in
+     * the tree that nobody asked for. Undo takes back the whole step, so what the reader sees is
+     * simply that nothing happened, and why.
+     */
+    state.tree.undo();
+    toast(REFUSALS[result.reason] ?? 'That connection was not made.', 'bad');
+    rebuild();
+    return;
+  }
+  state.adding = null;
+  rebuild();
+}
+
+function disconnect(subjectId, otherId) {
+  const edge = state.tree.relationships.find((r) => (
+    (r.from === subjectId && r.to === otherId) || (r.from === otherId && r.to === subjectId)));
+  if (!edge) {
+    /*
+     * Siblings are usually *derived* from shared parents rather than recorded, so there is often
+     * no edge between two people the panel lists as siblings. Removing their parents is the real
+     * answer, and saying so beats a button that silently does nothing.
+     */
+    toast('These two are connected through their parents, not directly. '
+      + 'Change a parent to separate them.', 'bad');
+    return;
+  }
+  const result = state.tree.removeRelationship(edge.id);
+  if (!result.ok) { toast('That connection was not removed.', 'bad'); return; }
+  rebuild();
+}
+
+function removePerson(id) {
+  const person = state.tree.person(id);
+  const name = displayName(person ?? {});
+  const result = state.tree.removePerson(id);
+  if (!result.ok) { toast(REFUSALS[result.reason] ?? 'Nobody was deleted.', 'bad'); return; }
+  state.selected = null;
+  rebuild();
+  toast(result.removedEdges
+    ? `Deleted ${name} and ${count(result.removedEdges, 'connection', 'connections')}. `
+      + 'Undo with Ctrl+Z.'
+    : `Deleted ${name}. Undo with Ctrl+Z.`);
+}
+
+function undo() {
+  const result = state.tree?.undo();
+  if (!result?.ok) return;
+  rebuild();
+  toast(`Undid: ${result.label}`);
+}
+
+function redo() {
+  const result = state.tree?.redo();
+  if (!result?.ok) return;
+  rebuild();
+  toast(`Redid: ${result.label}`);
+}
+
+/* ------------------------------------------------------------------ files */
+
+function startNewTree() {
+  state.tree = new Tree({}, { ownTreeId: state.ownTreeId });
+  state.photos = new Map();
+  state.path = null;
+  state.name = 'Untitled tree';
+  state.selected = null;
+  $('file-name').textContent = state.name;
+  setState('loaded');
+  chart.resize();
+  rebuild({ refit: true });
+  addPerson();
+}
+
+async function openBytes(bytes, name, filePath) {
+  $('busy').hidden = false;
+  try {
+    const buffer = bytes instanceof ArrayBuffer ? bytes : bytes.buffer.slice(
+      bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+    const archive = await openArchive(buffer);
+    if (!archive.has('tree.json')) {
+      throw new ArchiveError('That ZIP has no tree.json, so it is not a .ftree export.');
+    }
+    const doc = parseDocument(await archive.readText('tree.json'));
+
+    // Held in memory because saving rewrites the whole archive; there is no file to re-read from.
+    const photos = new Map();
+    for (const entry of archive.names()) {
+      if (entry.startsWith('photos/') && !entry.endsWith('/')) {
+        photos.set(entry, await archive.read(entry));
+      }
+    }
+
+    state.tree = new Tree(doc, { ownTreeId: state.ownTreeId });
+    state.tree.markSaved();
+    state.photos = photos;
+    state.path = filePath ?? null;
+    state.name = name;
+    state.selected = null;
+    $('file-name').textContent = name;
+    setState('loaded');
+    chart.resize();
+    rebuild({ refit: true });
+  } catch (error) {
+    const message = error instanceof ArchiveError ? error.message : `That file could not be read. ${error.message}`;
+    const box = $('opener-error');
+    box.textContent = message;
+    box.hidden = false;
+    toast(message, 'bad');
+  } finally {
+    $('busy').hidden = true;
+  }
+}
+
+/**
+ * Only the photos somebody is still referenced by.
+ *
+ * A deleted person's photograph would otherwise ride along in every future save, growing the file
+ * with pictures of nobody.
+ */
+function photosStillUsed() {
+  const wanted = new Set(state.tree.people.map((p) => p.photo).filter(Boolean));
+  const kept = new Map();
+  for (const [name, bytes] of state.photos) if (wanted.has(name)) kept.set(name, bytes);
+  return kept;
+}
+
+async function save({ as = false } = {}) {
+  if (!state.tree || state.saving) return;
+  state.saving = true;
+  try {
+    let made;
+    try {
+      made = await bytesForTree(state.tree, photosStillUsed());
+    } catch (error) {
+      if (error instanceof SaveRefused) {
+        toast(`${error.message}\n\n${error.detail}`, 'bad');
+        return;
+      }
+      throw error;
+    }
+
+    const suggested = state.name?.endsWith('.ftree') ? state.name : `${state.name || 'family-tree'}.ftree`;
+    const result = (as || !state.path)
+      ? await shell.saveTreeAs(made.bytes, suggested)
+      : await shell.saveTree(made.bytes, state.path);
+
+    if (!result?.ok) {
+      if (result?.reason !== 'CANCELLED') toast('That tree was not saved.', 'bad');
+      return;
+    }
+
+    state.path = result.path;
+    state.name = result.name;
+    $('file-name').textContent = result.name;
+    state.tree.markSaved();
+    reflectDirty();
+    toast(`Saved ${count(made.people, 'person', 'people')} and `
+      + `${count(made.relationships, 'connection', 'connections')}.`);
+  } finally {
+    state.saving = false;
+  }
+}
+
+/* ------------------------------------------------------------------ wiring */
+
+function wireChrome() {
+  $('start-new').addEventListener('click', startNewTree);
+  $('choose').addEventListener('click', () => shell?.chooseTree());
+  $('add-person').addEventListener('click', addPerson);
+  $('save').addEventListener('click', () => save());
+  $('undo').addEventListener('click', undo);
+  $('redo').addEventListener('click', redo);
+  $('panel-close').addEventListener('click', () => select(null));
+
+  $('zoom-in').addEventListener('click', () => { chart.zoomBy(1.25); updateZoom(); });
+  $('zoom-out').addEventListener('click', () => { chart.zoomBy(0.8); updateZoom(); });
+  $('fit').addEventListener('click', () => { chart.fit(); updateZoom(); });
+
+  $('theme-btn').addEventListener('click', () => {
+    const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    chart.setTheme(next);
+    try { localStorage.setItem('ftree.desktop', JSON.stringify({ theme: next })); } catch { /* fine */ }
+  });
+
+  const search = $('search');
+  const results = $('search-results');
+  search.addEventListener('input', () => {
+    const term = search.value.trim().toLowerCase();
+    results.replaceChildren();
+    if (!state.tree || term.length < 2) { results.hidden = true; return; }
+    const found = state.tree.people
+      .filter((p) => (p.name ?? '').toLowerCase().includes(term)).slice(0, 8);
+    for (const person of found) {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.innerHTML = `<span>${escapeHtml(displayName(person))}</span>`
+        + `<small>${escapeHtml(lifespan(person) || '')}</small>`;
+      button.addEventListener('click', () => {
+        select(person.id);
+        chart.centreOn(person.id);
+        search.value = '';
+        results.hidden = true;
+      });
+      li.append(button);
+      results.append(li);
+    }
+    results.hidden = !found.length;
+  });
+}
+
+function wireShell() {
+  if (!shell) return;
+
+  shell.onOpenTree((tree) => openBytes(tree.bytes, tree.name, tree.path));
+
+  shell.onMenuCommand((command) => {
+    if (command === 'file:new') { startNewTree(); return; }
+    if (command === 'file:save') { save(); return; }
+    if (command === 'file:saveAs') { save({ as: true }); return; }
+    if (command === 'edit:undo') { undo(); return; }
+    if (command === 'edit:redo') { redo(); return; }
+    if (command === 'zoom:in') { chart.zoomBy(1.25); updateZoom(); return; }
+    if (command === 'zoom:out') { chart.zoomBy(0.8); updateZoom(); return; }
+    if (command === 'zoom:fit') { chart.fit(); updateZoom(); return; }
+    if (command === 'search') { $('search').focus(); return; }
+    if (command === 'theme') { $('theme-btn').click(); return; }
+    if (command === 'close') {
+      state.tree = null;
+      state.selected = null;
+      setState('empty');
+      shell.setDirty(false);
+    }
+  });
+}
+
+function wireKeys() {
+  document.addEventListener('keydown', (event) => {
+    const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(event.target.tagName);
+    if (event.key === 'Escape') {
+      if (state.adding) { state.adding = null; renderPanel(); return; }
+      if (state.selected) select(null);
+      return;
+    }
+    if (typing) return;
+    if (event.key === '/') { event.preventDefault(); $('search').focus(); }
+    if (event.key === 'f' || event.key === 'F') { chart.fit(); updateZoom(); }
+  });
+}
+
+async function boot() {
+  chart = new Chart($('canvas'), {
+    onSelect: (id) => select(id),
+    onViewChange: updateZoom,
+  });
+  chart.setTheme(document.documentElement.getAttribute('data-theme') ?? 'light');
+
+  wireChrome();
+  wireShell();
+  wireKeys();
+
+  if (shell) {
+    document.body.dataset.shell = 'desktop';
+    /*
+     * Fetched before anything can be created. A tree written without it claims the empty origin,
+     * which every other desktop also claims -- see desktop/identity.js.
+     */
+    state.ownTreeId = await shell.installationId();
+
+    const last = await shell.lastTree();
+    if (last) await openBytes(last.bytes, last.name, last.path);
+  }
+}
+
+boot();

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -1,0 +1,368 @@
+/*
+ * What the desktop app adds to the viewer's look.
+ *
+ * playground.css carries the shared visual language -- the bar, the canvas, the panel, the palette,
+ * the type. This file is only the parts that exist because this app can change a tree: the form,
+ * the relatives list, the refusal messages, and the quiet mark that says there is work not on disk.
+ *
+ * Everything here is scoped under `.editor` so nothing can leak back into the website's viewer if
+ * the two stylesheets are ever loaded together.
+ */
+
+/* ------------------------------------------------------------------ the bar */
+
+.editor .wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+
+/*
+ * Unsaved work, said with a dot.
+ *
+ * The alternative -- a word, or an asterisk on the file name -- is louder than the fact deserves.
+ * Somebody mid-edit knows they are mid-edit; the dot is for coming back to a window after lunch.
+ */
+.editor .unsaved {
+  color: var(--accent, #c56a3a);
+  font-size: 20px;
+  line-height: 1;
+  margin-left: 2px;
+}
+
+.editor .undo-pair {
+  display: inline-flex;
+  gap: 2px;
+}
+
+.editor .icon[disabled] {
+  opacity: 0.32;
+  cursor: default;
+}
+
+.editor .primary-tool {
+  font-weight: 600;
+}
+
+.editor .save-btn[data-dirty='true'] {
+  font-weight: 600;
+}
+
+/* ------------------------------------------------------------------ the person form */
+
+.editor .edit-panel {
+  --field-gap: 12px;
+}
+
+.editor .form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--field-gap);
+  margin: 16px 0 4px;
+}
+
+.editor .field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+/* A name deserves the whole width; two dates sit happily side by side. */
+.editor .field.wide {
+  grid-column: 1 / -1;
+}
+
+.editor .field > label {
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  opacity: 0.68;
+}
+
+.editor .field input[type='text'],
+.editor .field select,
+.editor .field textarea {
+  font: inherit;
+  font-size: 13.5px;
+  color: inherit;
+  background: var(--sunk, rgba(0, 0, 0, 0.04));
+  border: 1px solid var(--rule, rgba(0, 0, 0, 0.14));
+  border-radius: 8px;
+  padding: 7px 9px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.editor .field textarea {
+  resize: vertical;
+  min-height: 62px;
+  line-height: 1.45;
+}
+
+.editor .field input:focus-visible,
+.editor .field select:focus-visible,
+.editor .field textarea:focus-visible {
+  outline: 2px solid var(--accent, #c56a3a);
+  outline-offset: 1px;
+}
+
+/*
+ * A hint under a date field, because "1962" is a perfectly good answer.
+ *
+ * The format takes partial dates on purpose -- a year alone, or a year and month -- and somebody
+ * who does not know the day should not be made to invent one.
+ */
+.editor .field-hint {
+  font-size: 11px;
+  opacity: 0.55;
+}
+
+.editor .check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  grid-column: 1 / -1;
+}
+
+.editor .check input {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--accent, #c56a3a);
+}
+
+/* ------------------------------------------------------------------ relatives */
+
+.editor .rel-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  margin: 22px 0 8px;
+}
+
+.editor .rel-heading h3 {
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  opacity: 0.7;
+  margin: 0;
+}
+
+.editor .rel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.editor .rel-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 6px 5px 8px;
+  border-radius: 8px;
+}
+
+.editor .rel-list li:hover {
+  background: var(--sunk, rgba(0, 0, 0, 0.04));
+}
+
+.editor .rel-go {
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  font: inherit;
+  font-size: 13.5px;
+  color: inherit;
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.editor .rel-role {
+  font-size: 11.5px;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+/*
+ * Removing a relationship is not removing a person, and the two must never be confused. This is
+ * the quieter of the two controls and says what it does when hovered.
+ */
+.editor .rel-cut {
+  flex-shrink: 0;
+  font: inherit;
+  font-size: 15px;
+  line-height: 1;
+  color: inherit;
+  opacity: 0;
+  background: none;
+  border: 0;
+  border-radius: 6px;
+  padding: 2px 5px;
+  cursor: pointer;
+}
+
+.editor .rel-list li:hover .rel-cut,
+.editor .rel-cut:focus-visible {
+  opacity: 0.65;
+}
+
+.editor .rel-cut:hover {
+  opacity: 1;
+  color: var(--danger, #b3402f);
+}
+
+.editor .rel-empty {
+  font-size: 13px;
+  opacity: 0.6;
+  margin: 4px 0 0;
+}
+
+/* ------------------------------------------------------------------ adding a relative */
+
+.editor .add-rel {
+  margin-top: 10px;
+  border: 1px dashed var(--rule, rgba(0, 0, 0, 0.18));
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.editor .kinds {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+  margin-bottom: 10px;
+}
+
+.editor .kinds button {
+  font: inherit;
+  font-size: 12.5px;
+  color: inherit;
+  background: var(--sunk, rgba(0, 0, 0, 0.04));
+  border: 1px solid transparent;
+  border-radius: 7px;
+  padding: 6px 4px;
+  cursor: pointer;
+}
+
+.editor .kinds button[aria-pressed='true'] {
+  border-color: var(--accent, #c56a3a);
+  font-weight: 600;
+}
+
+.editor .add-rel .search-results {
+  position: static;
+  margin-top: 6px;
+  max-height: 168px;
+}
+
+/* ------------------------------------------------------------------ saying no */
+
+/*
+ * A refusal from the relationship rules.
+ *
+ * It appears where the action was, not in a dialog: the person is mid-thought and the answer is
+ * one sentence. It also says what the rule is protecting rather than only that something failed,
+ * because "that would make him his own grandfather" is the useful half.
+ */
+.editor .refusal {
+  margin: 10px 0 0;
+  padding: 9px 11px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--danger, #b3402f) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger, #b3402f) 34%, transparent);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.editor .danger-row {
+  margin-top: 26px;
+  padding-top: 14px;
+  border-top: 1px solid var(--rule, rgba(0, 0, 0, 0.12));
+}
+
+.editor .btn-danger {
+  font: inherit;
+  font-size: 12.5px;
+  color: var(--danger, #b3402f);
+  background: none;
+  border: 1px solid color-mix(in srgb, var(--danger, #b3402f) 40%, transparent);
+  border-radius: 8px;
+  padding: 6px 11px;
+  cursor: pointer;
+}
+
+.editor .btn-danger:hover {
+  background: color-mix(in srgb, var(--danger, #b3402f) 12%, transparent);
+}
+
+/* ------------------------------------------------------------------ toast */
+
+.editor .toast {
+  position: fixed;
+  left: 50%;
+  bottom: 62px;
+  transform: translateX(-50%);
+  z-index: 40;
+  max-width: min(560px, 88vw);
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: var(--ink, #1b1f1a);
+  color: var(--paper, #f7f6f1);
+  font-size: 13px;
+  box-shadow: 0 6px 26px rgba(0, 0, 0, 0.22);
+}
+
+.editor .toast[data-tone='bad'] {
+  background: var(--danger, #b3402f);
+  border-radius: 12px;
+  white-space: pre-line;
+  text-align: left;
+  line-height: 1.5;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .editor .toast { animation: toast-in 160ms ease-out; }
+  @keyframes toast-in {
+    from { opacity: 0; transform: translate(-50%, 6px); }
+    to   { opacity: 1; transform: translate(-50%, 0); }
+  }
+}
+
+/* ------------------------------------------------------------------ the empty tree */
+
+/*
+ * A tree with nobody in it is a real state, not an error: it is where every tree starts. It gets
+ * an invitation rather than the "nothing loaded" screen, which would be a lie -- a file is open.
+ */
+.editor .first-person {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  gap: 14px;
+  padding: 24px;
+  pointer-events: none;
+}
+
+.editor .first-person p {
+  margin: 0;
+  font-size: 15px;
+  opacity: 0.72;
+}
+
+.editor .first-person .btn {
+  pointer-events: auto;
+  justify-self: center;
+}

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -1,0 +1,156 @@
+<meta charset="utf-8">
+<title>f-tree</title>
+
+<!--
+  The desktop app's own page.
+
+  Not the website's viewer. That is a reader and stays one; this builds and changes a tree, and the
+  two want different chrome for the same canvas. What they share is the engine underneath -- the
+  reader, the writer, the graph model, the layout and the chart -- imported from site/playground/
+  rather than copied, so a fix to how a family is drawn lands in both.
+
+  No <link> to Google Fonts, unlike the viewer. The shell refuses this window the network outright
+  and injects the same two typefaces from disk, so asking would only produce a refused request in
+  the log. Nothing here reaches outside the machine.
+-->
+<link rel="stylesheet" href="../../site/playground/playground.css">
+<link rel="stylesheet" href="editor.css">
+
+<script>
+/*
+ * The theme, before the first paint. app.js is a module and therefore deferred, so leaving this
+ * to it would flash a bone-white screen at somebody who asked for dark.
+ */
+(function () {
+  var theme = null;
+  try { theme = (JSON.parse(localStorage.getItem('ftree.desktop') || '{}') || {}).theme; }
+  catch (e) { /* blocked storage lands here; the system decides */ }
+  if (theme !== 'dark' && theme !== 'light') {
+    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  document.documentElement.setAttribute('data-theme', theme);
+})();
+</script>
+
+<div class="viewer editor" id="viewer" data-state="empty">
+
+  <header class="bar">
+    <span class="wordmark" title="f-tree">
+      <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <rect x="3" y="3" width="18" height="18" rx="5"/>
+        <circle cx="9" cy="9" r="1.9"/><circle cx="15" cy="9" r="1.9"/><circle cx="12" cy="16" r="1.9"/>
+        <path d="M9 11v1.6h6V11M12 12.6V14"/>
+      </svg>
+      <b>f-tree</b>
+    </span>
+
+    <div class="bar-file" data-when="loaded">
+      <span class="file-name" id="file-name"></span>
+      <!-- Shown only while there is work not on disk. Quiet, and never a nag. -->
+      <span class="unsaved" id="unsaved" hidden title="Not saved yet">&bull;</span>
+    </div>
+
+    <div class="bar-spacer"></div>
+
+    <button type="button" class="icon theme-btn" id="theme-btn" aria-label="Switch theme">
+      <svg class="i-moon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M20.5 14.3A8.5 8.5 0 0 1 9.7 3.5a8.5 8.5 0 1 0 10.8 10.8z"/>
+      </svg>
+      <svg class="i-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="12" cy="12" r="4.1"/>
+        <path d="M12 2.6v2.2M12 19.2v2.2M4.35 4.35l1.55 1.55M18.1 18.1l1.55 1.55M2.6 12h2.2M19.2 12h2.2M4.35 19.65 5.9 18.1M18.1 5.9l1.55-1.55"/>
+      </svg>
+    </button>
+
+    <div class="bar-tools" data-when="loaded">
+      <div class="search" role="search">
+        <label class="sr-only" for="search">Search people</label>
+        <input type="search" id="search" placeholder="Search people" autocomplete="off"
+               spellcheck="false" aria-expanded="false" aria-controls="search-results">
+        <ul class="search-results" id="search-results" role="listbox" hidden></ul>
+      </div>
+
+      <button type="button" class="tool primary-tool" id="add-person">Add a person</button>
+
+      <div class="undo-pair" role="group" aria-label="Undo and redo">
+        <button type="button" class="icon" id="undo" aria-label="Undo" disabled>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M9 7 4 12l5 5"/><path d="M4 12h9a6 6 0 0 1 0 12h-1"/>
+          </svg>
+        </button>
+        <button type="button" class="icon" id="redo" aria-label="Redo" disabled>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="m15 7 5 5-5 5"/><path d="M20 12h-9a6 6 0 0 0 0 12h1"/>
+          </svg>
+        </button>
+      </div>
+
+      <div class="zoom">
+        <button type="button" class="icon" id="zoom-out" aria-label="Zoom out">&minus;</button>
+        <output class="zoom-level" id="zoom-level" aria-live="off">100%</output>
+        <button type="button" class="icon" id="zoom-in" aria-label="Zoom in">+</button>
+        <button type="button" class="tool" id="fit">Fit</button>
+      </div>
+
+      <button type="button" class="tool save-btn" id="save">Save</button>
+    </div>
+  </header>
+
+  <main class="stage" id="stage">
+
+    <!-- ------------------------------------------------------------ nothing open yet -->
+    <section class="opener" id="opener" data-when="empty">
+      <div class="opener-inner">
+        <h1>A family tree, on this machine.</h1>
+        <p class="lede">
+          Start one here and build it person by person, or open a <b>.ftree</b> you already have.
+          Nothing is uploaded, there is nothing to sign into, and it works with the network off.
+        </p>
+
+        <div class="drop" id="drop">
+          <input type="file" id="file" accept=".ftree,.zip,.json" hidden>
+          <!--
+            New first, and not out of politeness. Somebody may have installed this having never
+            owned the phone app, and for them "open a file" is a dead end.
+          -->
+          <button type="button" class="btn primary" id="start-new">Start a new tree</button>
+          <p class="drop-or">or</p>
+          <button type="button" class="btn quiet" id="choose">Open a .ftree file</button>
+        </div>
+
+        <p class="opener-error" id="opener-error" hidden role="alert"></p>
+      </div>
+    </section>
+
+    <!-- ------------------------------------------------------------ the chart -->
+    <canvas id="canvas" tabindex="0" role="img"
+            aria-label="Family chart. Select a person to edit them."></canvas>
+
+    <p class="hint" id="hint" hidden></p>
+
+    <!-- ------------------------------------------------------------ one person, editable -->
+    <aside class="panel edit-panel" id="panel" hidden aria-label="Edit this person">
+      <button type="button" class="panel-close" id="panel-close" aria-label="Close">&times;</button>
+      <div class="panel-body" id="panel-body"></div>
+    </aside>
+
+    <div class="busy" id="busy" hidden><span></span> Reading the file&hellip;</div>
+  </main>
+
+  <footer class="status" data-when="loaded">
+    <div class="counts" id="counts"></div>
+    <div class="legend" aria-hidden="true">
+      <span class="key"><i class="k-unknown"></i>name not known</span>
+      <span class="key"><i class="k-couple"></i>partners</span>
+      <span class="key"><i class="k-descent"></i>parent to child</span>
+      <span class="key"><i class="k-died"></i>no longer living</span>
+      <span class="key"><i class="k-sib"></i>siblings, parents unknown</span>
+      <span class="key"><i class="k-alone"></i>no recorded relatives</span>
+    </div>
+  </footer>
+
+  <!-- Said once, where the eye already is, and gone again. Never a dialog for a saved file. -->
+  <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
+</div>
+
+<script type="module" src="app.js"></script>


### PR DESCRIPTION
The desktop app gets **its own page**. The website's viewer reads a tree and stays a reader; this
one builds and changes one, so it has its own controller rather than the viewer's with editing
bolted on.

What they share is the engine — ZIP reader and writer, graph model, layout, canvas — imported from
`site/playground/` rather than copied, so a fix to how a family is drawn still lands in both.

**No assembly step.** `renderer/index.html` imports `../../site/playground/*.js`, which already
resolves against the working tree in development, so packaging only has to reproduce the
repository's shape. The staged directory is called `page`, not `app`, on purpose: `resources/app` is
where Electron looks for an unpacked application, and a `package.json` there would make it try to
run this as one.

## What it does

Add a person, edit their fields, delete them. Add a parent, child, partner or sibling — either by
connecting somebody already recorded or by creating them. Remove a connection. Undo, redo. Save.

## Three decisions

**Nothing changes the tree except through `Tree`.** It is the only thing that applies the
relationship rules and the only thing that can put a change back. A field writing to a person
directly would edit somebody's family with no rule check, no undo, and no unsaved mark.

**One edit is one undo step.** Fields commit on `change`, never on `input`. Per-keystroke undo would
put eleven steps behind a name like "Shyam Sundar" and make undo useless at the moment it is wanted.

**A refusal explains.** The interface says *"these two are already parent and child, so they cannot
also be partners or siblings"*, not "invalid". And typing a name offers the people **already in the
tree** before it offers to make another one — the cheapest place to prevent the commonest way a
family tree goes wrong.

Adding a relative the rules then refuse undoes the *person* too, so what somebody sees is that
nothing happened and why — rather than a stranger left floating in their tree.

## The smoke test now builds a tree from nothing

```
-- building a tree from nothing --
  ok   a new tree starts with somebody to name           1 person·0 connections
  ok   a person and a child are recorded                 2 people·1 connection
  ok   the window knows there is work not on disk
  ok   there is something to undo
  ok   the rules refuse a partner who is already a child, and say why
  ok   the tree was written to disk                      378 bytes
  ok   saving clears the unsaved mark
  ok   the saved file reopens with both people and the connection
```

The only thing stubbed is the native save dialog, which cannot be clicked from a test. Everything
after it is the real writer, the real verification and the real atomic write.

It also **forwards the page's own errors into the log**. Without that a renderer exception is
invisible from the shell and the assertions report only its consequences — which is exactly how
`relationsOf` returning `[{heading, items}]` rather than the object this code assumed showed up as
*"the panel did not open"*. I had guessed the shape instead of reading it.

## Verified past CI

A tree **created here** — carrying its own installation id rather than an empty origin — imports
into the Android app on the emulator:

```
Added 2 people and 1 connection.

sqlite> select sourceTreeId, count(*) from person_origins group by 1;
3a959ba8-4f8d-485e-bf91-a3482753c08c | 2
```

That is the path #108 exists for, and the one still unproven when it merged.

## Checks

- 65 unit tests, 26 smoke assertions
- `git status --short app/` empty

Refs #101, #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)