### PR TITLE
Say that the desktop app writes now, and cut 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ package name and signing certificate before it installs anything. See
 ### On a laptop — Windows and Ubuntu
 
 The **[desktop app](https://ftree.vibethroughcode.com/desktop/)**
-opens an exported `.ftree` on a big screen, laid out for the screen it is on: a generation is a
-row, ancestors at the top, the tree running across the width. Windows gets an installer; on Linux
-take the `.deb`.
+builds a family tree on a laptop, or opens a `.ftree` you already have: add people, connect them,
+edit and delete, undo, and save back to the same file. A generation is a row, ancestors at the top.
+Windows gets an installer; on Linux take the `.deb`. It does not need the Android app — a tree can
+start here.
 
-It reads a tree today — editing, settings and the updater are
-[being built](https://github.com/thisisankit27/f-tree/issues/89). Nothing leaves the machine.
+Editing and the updater work; the people list, the compact and everyone views, importing, photos
+and Hindi kinship are [still being built](https://github.com/thisisankit27/f-tree/issues/89).
+Nothing leaves the machine.
 
 ### Try it without installing anything
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "f-tree-desktop",
   "productName": "f-tree",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "A local-first family tree, on your own machine",
   "author": {
     "name": "thisisankit27",

--- a/site/app.js
+++ b/site/app.js
@@ -552,9 +552,10 @@
           + '<b>Run anyway</b>. That is the whole of it — there is nothing else unusual about the file.'],
         ['Choose where it goes', 'It installs for your account only, so it never asks for an '
           + 'administrator password and writes nothing outside that folder and your own app data.'],
-        ['Open your tree', 'Export a <code>.ftree</code> from the phone — <b>Settings → Export your '
-          + 'tree</b> — get it onto the laptop, and open it with <b>File → Open tree</b>. It reopens '
-          + 'that file by itself next time.']
+        ['Start a tree, or open one', 'Choose <b>Start a new tree</b> and add people, or open a '
+          + '<code>.ftree</code> you already have with <b>File → Open tree</b> — including one '
+          + 'exported from the Android app under <b>Settings → Export your tree</b>. It reopens the '
+          + 'last file by itself next time.']
       ]
     };
     if (id === 'deb') return {
@@ -565,7 +566,7 @@
         ['Install it', 'The leading <code>./</code> matters — without it apt goes looking for a '
           + 'package by that name instead of your file.<br>' + copyable('sudo apt install ./' + name)],
         ['Launch it', 'From the applications menu, or run <code>/opt/f-tree/f-tree-desktop</code>. '
-          + 'Then open a <code>.ftree</code> exported from the phone with <b>File → Open tree</b>.']
+          + 'Then choose <b>Start a new tree</b>, or open a <code>.ftree</code> you already have.']
       ]
     };
     if (id === 'tar') {
@@ -584,8 +585,8 @@
               + folder + '/chrome-sandbox')],
           ['Run it', 'Straight out of the folder it unpacked into.<br>'
             + copyable('./' + folder + '/f-tree-desktop')],
-          ['Open your tree', 'Export a <code>.ftree</code> from the phone — <b>Settings → Export '
-            + 'your tree</b> — and open it with <b>File → Open tree</b>.']
+          ['Start a tree, or open one', 'Choose <b>Start a new tree</b>, or open a '
+            + '<code>.ftree</code> you already have with <b>File → Open tree</b>.']
         ],
         caution: '<strong>If you would rather not type any of that,</strong> the '
           + '<a href="../">.deb</a> does the same thing for you and needs no follow-up.'

--- a/site/desktop/index.html
+++ b/site/desktop/index.html
@@ -75,9 +75,9 @@
       f-tree on Windows and Ubuntu.
     </h1>
     <p class="lede" style="max-width:38em">
-      Opens a <code>.ftree</code> exported from the phone and lays it out for the screen it is
-      on — a generation is a row, ancestors at the top, the tree running across the width. Free,
-      open source, no account.
+      Build a family tree on your laptop, or open a <code>.ftree</code> you already have.
+      Generations run as rows, ancestors at the top, the tree across the width. Free, open
+      source, no account, and it works with the network off.
     </p>
 
     <div class="beta-note">
@@ -85,9 +85,11 @@
       <span>
         <strong>This is an early build and it will have rough edges.</strong> It is new, it has been
         tested by very few people, and it may misbehave — expect that rather than a finished app.
-        The one thing it cannot do is damage your family tree: it only ever <em>reads</em> the
-        <code>.ftree</code> you open, and never writes to it. Building and editing a tree is still
-        the <a href="../thanks/">Android app's</a> job.
+        <strong>It now writes to your file as well as reading it</strong>, which this page used to
+        promise it would not, so the honest advice has changed with it: keep a copy of anything you
+        care about before editing. Every save writes to a temporary file first and only then
+        replaces yours, and the previous version is kept beside it as <code>.bak</code> — but a
+        second copy somewhere else is still worth more than either.
       </span>
     </div>
 


### PR DESCRIPTION
The download page said this:

> The one thing it cannot do is damage your family tree: it only ever *reads* the `.ftree` you open,
> and never writes to it.

**That stopped being true when the editor merged.** Changing it is the first thing to do — before a
build that writes goes in front of anybody, not after.

What replaces it is not a softer version of the same promise:

> **It now writes to your file as well as reading it**, which this page used to promise it would
> not, so the honest advice has changed with it: keep a copy of anything you care about before
> editing. Every save writes to a temporary file first and only then replaces yours, and the
> previous version is kept beside it as `.bak` — but a second copy somewhere else is still worth
> more than either.

The protections are described because they are real (`atomic.js`), and immediately qualified,
because somebody deciding whether to trust a beta with their grandmother's name deserves to be told
that a copy elsewhere beats both.

## Also

The lede and the per-platform install steps stop offering "export from the phone" as the *only* way
to get a tree — it isn't any more. README says what works and what is still being built.

Version → **0.4.0**. Editing is a feature release, and 0.3.4 is what is published today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)