### PR TITLE
The people list

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -903,6 +903,11 @@ async function runSmoke(win, file) {
     literata: document.fonts.check('16px Literata'),
     mono: document.fonts.check('13px "JetBrains Mono"'),
     counts: document.getElementById('counts')?.textContent?.trim() ?? null,
+    peopleRows: (() => {
+      document.querySelector('[data-view="index"]')?.click();
+      return document.querySelectorAll('#index-list .index-row').length;
+    })(),
+    peopleNote: document.getElementById('index-note')?.textContent ?? null,
     // The editor's own surface. A page that reads a tree but cannot change one is not this app.
     canEdit: Boolean(document.getElementById('add-person') && document.getElementById('save')),
     undoPresent: Boolean(document.getElementById('undo') && document.getElementById('redo')),
@@ -935,6 +940,13 @@ async function runSmoke(win, file) {
   check('the page can change a tree, not only read one', seen.canEdit === true);
   check('undo and redo are there', seen.undoPresent === true);
   check('a person can be opened for editing', seen.panelExists === true);
+  /*
+   * The list is not a second opinion on the chart. At the zoom that fits a large family on one
+   * screen no name is readable, so this is the only way to find somebody by name -- and the only
+   * place a person with no relatives is as visible as everybody else.
+   */
+  check('everybody in the file is listed by name', seen.peopleRows === 23,
+    `${seen.peopleRows} rows — ${seen.peopleNote}`);
   // Refusing the network must not quietly cost the app its typography.
   check('the bundled typefaces loaded without the network', seen.literata && seen.mono,
     `Literata ${seen.literata}, JetBrains Mono ${seen.mono}`);

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -45,6 +45,10 @@ const state = {
   selected: null,
   /** Which kind of relative the "add" form is currently offering. */
   adding: null,
+  /** 'chart' or 'index'. */
+  view: 'chart',
+  /** 'all' or 'living' -- the same filter the phone's people list offers. */
+  who: 'all',
   saving: false,
 };
 
@@ -106,6 +110,7 @@ function rebuild({ refit = false } = {}) {
 
   document.body.dataset.orientation = state.layout.orientation;
   renderCounts();
+  renderPeople();
   renderPanel();
   renderEmptyInvitation();
   reflectDirty();
@@ -136,6 +141,94 @@ function renderCounts() {
     ? 'Nobody yet'
     : `${count(people, 'person', 'people')}·`
       + `${count(state.tree.relationships.length, 'connection', 'connections')}`;
+}
+
+/* ------------------------------------------------------------------ everyone, as a list */
+
+function setView(view) {
+  state.view = view;
+  $('viewer').dataset.view = view;
+  for (const button of document.querySelectorAll('[data-view]')) {
+    button.setAttribute('aria-pressed', String(button.dataset.view === view));
+  }
+  $('index').hidden = view !== 'index';
+  if (view === 'chart') chart.resize();
+  else renderPeople();
+}
+
+/**
+ * Everyone, grouped as the chart groups them and sorted by name.
+ *
+ * Grouped rather than one flat list because the grouping carries information the chart shows and
+ * a list normally loses: which people form a family, and which are connected to nobody at all.
+ * That last group is the reason this view exists on the website too -- somebody with no recorded
+ * relatives is invisible in a family chart and perfectly visible here.
+ */
+function renderPeople() {
+  if (!state.graph || !state.layout) return;
+  const list = $('index-list');
+  const query = $('search').value.trim().toLowerCase();
+
+  const wanted = (person) => {
+    if (state.who === 'living' && person.deceased) return false;
+    if (!query) return true;
+    return (person.name ?? 'unknown').toLowerCase().includes(query)
+      || (person.birthDate ?? '').includes(query);
+  };
+
+  list.replaceChildren();
+  let shown = 0;
+
+  for (const group of state.layout.groups) {
+    const members = group.members
+      .map((id) => state.graph.people.get(id))
+      .filter(Boolean)
+      .filter(wanted)
+      .sort((a, b) => (a.name ?? '\uffff').localeCompare(b.name ?? '\uffff'));
+    if (!members.length) continue;
+
+    const heading = document.createElement('li');
+    heading.className = 'index-group';
+    heading.textContent = group.kind === 'isolated'
+      ? `Not connected to anyone · ${count(group.count, 'person', 'people')}`
+      : `A family of ${group.count} · ${count(group.generations, 'generation', 'generations')}`;
+    list.append(heading);
+
+    for (const person of members) {
+      shown += 1;
+      const li = document.createElement('li');
+      const row = document.createElement('button');
+      row.type = 'button';
+      row.className = 'index-row';
+      if (person.id === state.selected) row.setAttribute('aria-current', 'true');
+
+      const left = document.createElement('span');
+      const who = document.createElement('span');
+      who.className = 'who';
+      who.textContent = displayName(person);
+      const when = document.createElement('span');
+      when.className = 'when';
+      when.textContent = lifespan(person) || '\u00a0';
+      left.append(who, document.createElement('br'), when);
+
+      const how = document.createElement('span');
+      how.className = 'how';
+      const groups = relationsOf(state.graph, person.id);
+      how.textContent = groups.length
+        ? groups.map((g) => count(g.items.length, ...RELATION_WORDS[g.heading])).join(' · ')
+        : 'No recorded relatives';
+
+      row.append(left, how);
+      row.addEventListener('click', () => select(person.id));
+      li.append(row);
+      list.append(li);
+    }
+  }
+
+  const total = state.tree.people.length;
+  $('index-note').textContent = shown === total
+    ? `${count(total, 'person', 'people')}, sorted by name within each family.`
+    : `${shown} of ${count(total, 'person', 'people')} shown.`;
 }
 
 /** A tree with nobody in it is where every tree starts, so it gets an invitation, not an error. */
@@ -170,6 +263,20 @@ const GENDERS = [
   ['FEMALE', 'Female'],
   ['OTHER', 'Other'],
 ];
+
+/*
+ * The headings `relationsOf` groups by, with a singular for each.
+ *
+ * Lowercasing the heading and printing it beside a number is what produces "1 parents" and, worse,
+ * "1 childrens" for anyone who reaches for a naive de-pluraliser. English does not have a rule
+ * here, so the words are simply listed.
+ */
+const RELATION_WORDS = {
+  Parents: ['parent', 'parents'],
+  Partners: ['partner', 'partners'],
+  Siblings: ['sibling', 'siblings'],
+  Children: ['child', 'children'],
+};
 
 const KINDS = [
   ['parent', 'Parent'],
@@ -464,6 +571,8 @@ function select(id) {
   chart.selected = id;
   chart.invalidate();
   renderPanel();
+  // The list marks who is being edited, so it has to hear about a selection made on the chart.
+  if (state.view === 'index') renderPeople();
 }
 
 function addPerson() {
@@ -674,6 +783,19 @@ function wireChrome() {
   $('redo').addEventListener('click', redo);
   $('panel-close').addEventListener('click', () => select(null));
 
+  for (const button of document.querySelectorAll('[data-view]')) {
+    button.addEventListener('click', () => setView(button.dataset.view));
+  }
+  for (const button of document.querySelectorAll('[data-who]')) {
+    button.addEventListener('click', () => {
+      state.who = button.dataset.who;
+      for (const other of document.querySelectorAll('[data-who]')) {
+        other.setAttribute('aria-pressed', String(other.dataset.who === state.who));
+      }
+      renderPeople();
+    });
+  }
+
   $('zoom-in').addEventListener('click', () => { chart.zoomBy(1.25); updateZoom(); });
   $('zoom-out').addEventListener('click', () => { chart.zoomBy(0.8); updateZoom(); });
   $('fit').addEventListener('click', () => { chart.fit(); updateZoom(); });
@@ -688,6 +810,9 @@ function wireChrome() {
   const search = $('search');
   const results = $('search-results');
   search.addEventListener('input', () => {
+    // In the list the search filters in place; a dropdown over a filtered list would be two
+    // answers to one question.
+    if (state.view === 'index') { results.hidden = true; renderPeople(); return; }
     const term = search.value.trim().toLowerCase();
     results.replaceChildren();
     if (!state.tree || term.length < 2) { results.hidden = true; return; }
@@ -726,6 +851,8 @@ function wireShell() {
     if (command === 'zoom:in') { chart.zoomBy(1.25); updateZoom(); return; }
     if (command === 'zoom:out') { chart.zoomBy(0.8); updateZoom(); return; }
     if (command === 'zoom:fit') { chart.fit(); updateZoom(); return; }
+    if (command === 'view:chart') { setView('chart'); return; }
+    if (command === 'view:index') { setView('index'); return; }
     if (command === 'search') { $('search').focus(); return; }
     if (command === 'theme') { $('theme-btn').click(); return; }
     if (command === 'close') {
@@ -747,6 +874,9 @@ function wireKeys() {
     }
     if (typing) return;
     if (event.key === '/') { event.preventDefault(); $('search').focus(); }
+    if (event.key === 'i' || event.key === 'I') {
+      setView(state.view === 'index' ? 'chart' : 'index');
+    }
     if (event.key === 'f' || event.key === 'F') { chart.fit(); updateZoom(); }
   });
 }

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -366,3 +366,35 @@
   pointer-events: auto;
   justify-self: center;
 }
+
+/* ------------------------------------------------------------------ the people list */
+
+.editor .index-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.editor .segmented.small button {
+  font-size: 12px;
+  padding: 4px 10px;
+}
+
+/* Which person the panel is currently editing, marked where the eye already is. */
+.editor .index-row[aria-current='true'] {
+  outline: 2px solid var(--accent, #c56a3a);
+  outline-offset: -2px;
+  border-radius: 8px;
+}
+
+/*
+ * The list scrolls under the panel rather than beside it.
+ *
+ * A two-column layout would give the list a third of the width on a laptop and make the names --
+ * the whole reason for this view -- the first thing to be truncated.
+ */
+.editor .index {
+  overflow-y: auto;
+}

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -70,6 +70,11 @@
         <ul class="search-results" id="search-results" role="listbox" hidden></ul>
       </div>
 
+      <div class="segmented" role="group" aria-label="View">
+        <button type="button" data-view="chart" aria-pressed="true">Chart</button>
+        <button type="button" data-view="index" aria-pressed="false">People</button>
+      </div>
+
       <button type="button" class="tool primary-tool" id="add-person">Add a person</button>
 
       <div class="undo-pair" role="group" aria-label="Undo and redo">
@@ -123,10 +128,31 @@
     </section>
 
     <!-- ------------------------------------------------------------ the chart -->
-    <canvas id="canvas" tabindex="0" role="img"
+    <canvas id="canvas" data-when="chart" tabindex="0" role="img"
             aria-label="Family chart. Select a person to edit them."></canvas>
 
-    <p class="hint" id="hint" hidden></p>
+    <p class="hint" id="hint" data-when="chart" hidden></p>
+
+    <!-- ------------------------------------------------------------ everyone, as a list -->
+    <!--
+      The chart cannot be read at the zoom that fits a large family on one screen, so this is not
+      a second opinion on the same information: it is the only way to find somebody by name in a
+      tree of any size, and the only place a person with no relatives is as visible as anybody
+      else.
+    -->
+    <section class="index" id="index" data-when="index" hidden>
+      <div class="index-inner">
+        <div class="index-head">
+          <h2 class="index-heading">Everyone in this tree</h2>
+          <div class="segmented small" role="group" aria-label="Who to show">
+            <button type="button" data-who="all" aria-pressed="true">Everyone</button>
+            <button type="button" data-who="living" aria-pressed="false">Living</button>
+          </div>
+        </div>
+        <p class="index-note" id="index-note"></p>
+        <ol class="index-list" id="index-list"></ol>
+      </div>
+    </section>
 
     <!-- ------------------------------------------------------------ one person, editable -->
     <aside class="panel edit-panel" id="panel" hidden aria-label="Edit this person">


### PR DESCRIPTION
The chart cannot be read at the zoom that fits a large family on one screen — 148 people fit at
about a third of legible size. So until now there was **no way to find somebody by name** in a tree
of any size. This is that way.

It is also the only place a person with **no recorded relatives** is as visible as everybody else; a
family chart hides them by construction.

## Decisions

**Grouped as the chart groups them, not flattened.** The grouping carries what a list normally
loses: which people form a family, and who is connected to nobody at all.

**The search box filters in place** rather than opening its dropdown. A dropdown over an already
filtered list is two answers to one question.

**Living / Everyone**, the same filter the phone's people list offers.

**The row being edited is marked**, so the list and the panel agree about who is being worked on —
selecting on the chart updates the list and vice versa.

## Two wording bugs the screenshot caught

Both the same mistake: printing a lowercased group heading beside a number gives **"1 parents"** and
**"1 children"**. English has no rule that fixes that, so the singulars are listed explicitly.

## Checks

- Smoke: 27 assertions, including a new one that every person in the file appears as a row (23 of
  23) — the assertion that would catch a filter quietly hiding somebody
- 65 unit tests
- `git status --short app/` empty

Refs #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)