### PR TITLE
The duplicate matcher, ported with its test table

### DIFF
--- a/desktop/renderer/dates.js
+++ b/desktop/renderer/dates.js
@@ -1,0 +1,87 @@
+/*
+ * A date that may be known only to the year or the month.
+ *
+ * A port of `data/PartialDate.kt`. Family history is full of "born sometime in 1938", so a full
+ * date would force people to invent a day they do not know. Stored as a partial ISO-8601 string --
+ * `1938`, `1938-04`, `1938-04-17` -- where the precision *is* the statement about how much is
+ * known.
+ *
+ * Only the part the import needs is ported: parsing, the span a partial date covers, and whether
+ * two of them could describe the same day. Formatting already exists in `model.js` and is not
+ * duplicated here.
+ *
+ * `isCompatibleWith` is the load-bearing one. It is what stops an import merging two people called
+ * Raj Kumar born eleven years apart, which is the single most destructive thing an import could do.
+ *
+ * Dates are compared as plain integers -- `yyyymmdd` -- rather than through `Date`. The values only
+ * ever need ordering and equality, and `Date` would drag a timezone into a question that has none:
+ * "1938" is not an instant, and midnight in one place is the previous day in another.
+ */
+
+const PATTERN = /^(\d{4})(?:-(\d{2})(?:-(\d{2}))?)?$/;
+
+/** Days in a month, with the leap rule the Gregorian calendar actually uses. */
+function daysIn(year, month) {
+  if (month === 2) {
+    const leap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+    return leap ? 29 : 28;
+  }
+  return [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
+}
+
+export class PartialDate {
+  constructor(year, month = null, day = null) {
+    this.year = year;
+    this.month = month;
+    this.day = day;
+  }
+
+  /** The ISO-8601 string that gets persisted. */
+  serialize() {
+    const p = (n, w) => String(n).padStart(w, '0');
+    if (this.month == null) return p(this.year, 4);
+    if (this.day == null) return `${p(this.year, 4)}-${p(this.month, 2)}`;
+    return `${p(this.year, 4)}-${p(this.month, 2)}-${p(this.day, 2)}`;
+  }
+
+  /** Earliest day this date could refer to, as yyyymmdd. */
+  earliest() {
+    return this.year * 10000 + (this.month ?? 1) * 100 + (this.day ?? 1);
+  }
+
+  /** Latest day this date could refer to, as yyyymmdd. */
+  latest() {
+    if (this.month == null) return this.year * 10000 + 1231;
+    const day = this.day ?? daysIn(this.year, this.month);
+    return this.year * 10000 + this.month * 100 + day;
+  }
+
+  /** True when the two could describe the same day, allowing for differing precision. */
+  isCompatibleWith(other) {
+    return this.earliest() <= other.latest() && other.earliest() <= this.latest();
+  }
+
+  toString() {
+    return this.serialize();
+  }
+}
+
+/**
+ * Returns null for anything that is not a well-formed, real partial date.
+ *
+ * "Real" is doing work: `1938-02-30` matches the pattern and is not a day, and the Kotlin rejects
+ * it because constructing the date throws. Nothing throws here, so the check is explicit -- without
+ * it an impossible date would be treated as a known one and could rule out a correct match.
+ */
+export function parsePartialDate(value) {
+  const match = PATTERN.exec(String(value ?? '').trim());
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = match[2] === undefined ? null : Number(match[2]);
+  const day = match[3] === undefined ? null : Number(match[3]);
+
+  if (month != null && (month < 1 || month > 12)) return null;
+  if (day != null && (day < 1 || day > daysIn(year, month))) return null;
+  return new PartialDate(year, month, day);
+}

--- a/desktop/renderer/dates.test.js
+++ b/desktop/renderer/dates.test.js
@@ -1,0 +1,82 @@
+/*
+ * PartialDateTest.kt, for the parts the import depends on.
+ *
+ * Translated case for case where a case exists there. Formatting, ordering and `yearsBetween` are
+ * not ported -- `model.js` already formats and nothing here orders dates -- so those cases are
+ * absent rather than reimplemented.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { parsePartialDate } from './dates.js';
+
+const at = (s) => parsePartialDate(s);
+
+test('parses all three precisions', () => {
+  assert.deepStrictEqual(
+    [at('1938').year, at('1938').month, at('1938').day], [1938, null, null]);
+  assert.deepStrictEqual(
+    [at('1938-04').year, at('1938-04').month, at('1938-04').day], [1938, 4, null]);
+  assert.deepStrictEqual(
+    [at('1938-04-17').year, at('1938-04-17').month, at('1938-04-17').day], [1938, 4, 17]);
+});
+
+test('rejects malformed and impossible dates', () => {
+  for (const bad of [null, undefined, '', '38', '1938-4-17', '1938-13', '1938-02-30', 'not a date']) {
+    assert.strictEqual(at(bad), null, `expected null for ${JSON.stringify(bad)}`);
+  }
+});
+
+test('round trips through serialisation', () => {
+  for (const value of ['1938', '1938-04', '1938-04-17']) {
+    assert.strictEqual(at(value).serialize(), value);
+  }
+});
+
+test('a year spans the whole year', () => {
+  assert.strictEqual(at('1938').earliest(), 19380101);
+  assert.strictEqual(at('1938').latest(), 19381231);
+});
+
+test('a month spans that month including a leap day', () => {
+  assert.strictEqual(at('2024-02').earliest(), 20240201);
+  assert.strictEqual(at('2024-02').latest(), 20240229);
+});
+
+test('the leap rule is the real one, not every fourth year', () => {
+  // Added here. 1900 is not a leap year and 2000 is; a naive `% 4` gets 1900 wrong, which would
+  // silently accept 1900-02-29 as a real date and could rule out a correct match.
+  assert.strictEqual(at('1900-02').latest(), 19000228);
+  assert.strictEqual(at('2000-02').latest(), 20000229);
+  assert.strictEqual(at('1900-02-29'), null);
+  assert.ok(at('2000-02-29'));
+});
+
+test('dates of differing precision are compatible when they could be the same day', () => {
+  const year = at('1938');
+  const exact = at('1938-04-17');
+  const otherYear = at('1939');
+
+  assert.ok(year.isCompatibleWith(exact));
+  assert.ok(exact.isCompatibleWith(year));
+  assert.ok(!year.isCompatibleWith(otherYear));
+});
+
+test('compatibility is symmetric, in both directions, for every pair', () => {
+  // Added here. The check is used to rule a match *out*, so an asymmetry would make the answer
+  // depend on which file happened to be the one being imported.
+  const values = ['1938', '1938-04', '1938-04-17', '1939', '1938-05', '2024-02-29'];
+  for (const a of values) {
+    for (const b of values) {
+      assert.strictEqual(
+        at(a).isCompatibleWith(at(b)), at(b).isCompatibleWith(at(a)),
+        `${a} vs ${b} disagreed depending on the order`);
+    }
+  }
+});
+
+test('a day inside a month is compatible with that month, and outside it is not', () => {
+  assert.ok(at('1938-04').isCompatibleWith(at('1938-04-17')));
+  assert.ok(!at('1938-04').isCompatibleWith(at('1938-05-17')));
+});

--- a/desktop/renderer/matching.js
+++ b/desktop/renderer/matching.js
@@ -1,0 +1,245 @@
+/*
+ * Deciding which people in an imported file are already in the tree.
+ *
+ * A port of `transfer/DuplicateMatcher.kt` and `transfer/NameKey.kt`. This is the most dangerous
+ * code in either app, and the asymmetry that shapes it is worth stating before anything else:
+ *
+ *     wrongly keeping two records apart is a tidy-up somebody can fix in a minute.
+ *     wrongly merging two records destroys data that cannot be recovered.
+ *
+ * So nothing here guesses. Only a *provable* match -- the file says where a person came from and
+ * it is somebody we hold -- merges without asking. A strong match is proposed and can be refused.
+ * A weak one is proposed as separate and has to be asked for.
+ *
+ * Pure, and handed both sides as plain data, so every rule is testable without a file or a
+ * database. `matching.test.js` is the Kotlin's own test table.
+ */
+
+import { parsePartialDate } from './dates.js';
+
+/** How confident we are that an imported person is somebody already here. */
+export const MatchTier = Object.freeze({
+  /** Provably the same person: the file says where they came from and it is someone we hold. */
+  CERTAIN: 'CERTAIN',
+  /** Same name, dates that agree, and at least one relative in common. */
+  STRONG: 'STRONG',
+  /** Same name and nothing that contradicts it. Could easily be a different person. */
+  WEAK: 'WEAK',
+  /** Nobody here looks like them. */
+  NONE: 'NONE',
+});
+
+const MAX_PASSES = 5;
+
+/**
+ * A name reduced to what two spellings of the same person have in common.
+ *
+ * Accents, capitalisation, punctuation and stray spacing all differ between people typing the same
+ * name into two different phones, and none of those differences mean it is a different person.
+ *
+ * Deliberately conservative: it normalises *form*, never content. "Raj Kumar" and "R. Kumar" stay
+ * different, because guessing they are the same is how a merge quietly destroys somebody's data.
+ *
+ * `NFD` then stripping combining marks is the same normalisation the Kotlin does with
+ * `java.text.Normalizer`; the `\p{L}\p{N}` classes need the `u` flag in JavaScript to mean what
+ * they mean in Java.
+ */
+export function nameKey(name) {
+  const trimmed = String(name ?? '').trim();
+  if (!trimmed) return null;
+  const key = trimmed
+    .normalize('NFD')
+    .replace(/\p{Mn}+/gu, '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+  return key || null;
+}
+
+/** Whether the app merges this match without asking. */
+export function mergesByDefault(match) {
+  return match.tier === MatchTier.CERTAIN || match.tier === MatchTier.STRONG;
+}
+
+export function needsReview(match) {
+  return match.tier === MatchTier.STRONG || match.tier === MatchTier.WEAK;
+}
+
+const evidence = ({ sameName = false, datesAgree = false, sharedRelatives = 0,
+  fromSameTree = false } = {}) => ({ sameName, datesAgree, sharedRelatives, fromSameTree });
+
+/**
+ * Evidence for one candidate pairing, or null when something rules it out.
+ *
+ * Conflicting dates rule it out outright. Two people called Raj Kumar born eleven years apart are
+ * two people, and merging them would be the worst thing an import could do.
+ *
+ * Note what is *not* required: that either date is present. Refusing to match two people who
+ * plainly are the same because nobody wrote down when they were born would be its own kind of
+ * wrong. Dates only ever veto here; they never qualify.
+ */
+function score(record, candidate, importedGraph, localGraph, settled) {
+  const importedBirth = parsePartialDate(record.birthDate);
+  const localBirth = parsePartialDate(candidate.birthDate);
+  const bothKnown = Boolean(importedBirth && localBirth);
+  if (bothKnown && !importedBirth.isCompatibleWith(localBirth)) return null;
+
+  const importedDeath = parsePartialDate(record.deathDate);
+  const localDeath = parsePartialDate(candidate.deathDate);
+  if (importedDeath && localDeath && !importedDeath.isCompatibleWith(localDeath)) return null;
+
+  const localNeighbours = localGraph.get(candidate.id) ?? new Set();
+  let shared = 0;
+  for (const neighbour of importedGraph.get(record.id) ?? new Set()) {
+    const matchedLocal = settled.get(neighbour)?.localId;
+    if (matchedLocal != null && localNeighbours.has(matchedLocal)) shared += 1;
+  }
+
+  return evidence({
+    sameName: true,
+    // Only claim the dates agree when there were dates to agree. This is shown to somebody as
+    // reasoning, so it must not overstate what is known.
+    datesAgree: bothKnown,
+    sharedRelatives: shared,
+  });
+}
+
+/**
+ * Matches an imported file against the tree already open.
+ *
+ * Runs in passes. Provable matches settle first, and those confirmed matches then become evidence
+ * for their relatives: two people with the same name are far likelier to be the same person once
+ * their father has already matched. Passes repeat until nothing new is confirmed, bounded so a
+ * strange file cannot make this run long.
+ *
+ * @param {object} args
+ * @param {Array} args.imported   people from the file, in the exchange shape
+ * @param {Map<string, Set<string>>} args.importedGraph  id to everyone directly connected
+ * @param {Array} args.local      people already here
+ * @param {Map<string, Set<string>>} args.localGraph
+ * @param {Map<string, string>} args.originIndex  "treeId\\u0000personId" to the local person id
+ * @param {string} args.sourceTreeId  the origin the file claims
+ * @returns {Array<{importedId, localId, tier, evidence}>} one entry per imported person
+ */
+export function matchPeople({ imported, importedGraph, local, localGraph, originIndex,
+  sourceTreeId }) {
+  const localById = new Map(local.map((p) => [p.id, p]));
+  const localByName = new Map();
+  for (const person of local) {
+    const key = nameKey(person.name);
+    if (!key) continue;
+    if (!localByName.has(key)) localByName.set(key, []);
+    localByName.get(key).push(person);
+  }
+
+  const settled = new Map();
+  const claimed = new Set();
+
+  /*
+   * Pass 0: provable identity.
+   *
+   * The file records where each person came from, so this is a lookup rather than a judgement --
+   * the only kind of match trusted enough to merge without asking anybody.
+   */
+  for (const record of imported) {
+    const keys = [originKey(sourceTreeId, record.id)];
+    for (const origin of record.origins ?? []) keys.push(originKey(origin.treeId, origin.personId));
+
+    const localId = keys.map((k) => originIndex.get(k)).find((v) => v != null);
+    if (localId != null && localById.has(localId) && !claimed.has(localId)) {
+      claimed.add(localId);
+      settled.set(record.id, {
+        importedId: record.id,
+        localId,
+        tier: MatchTier.CERTAIN,
+        evidence: evidence({ fromSameTree: true }),
+      });
+    }
+  }
+
+  // Later passes: name plus corroboration, with confirmed matches feeding the next round.
+  let pass = 0;
+  let changed = true;
+  while (changed && pass < MAX_PASSES) {
+    pass += 1;
+    changed = false;
+
+    for (const record of imported) {
+      if (settled.has(record.id)) continue;
+      const key = nameKey(record.name);
+      if (!key) continue;
+
+      const candidates = (localByName.get(key) ?? []).filter((c) => !claimed.has(c.id));
+      if (!candidates.length) continue;
+
+      const scored = candidates
+        .map((candidate) => ({
+          candidate,
+          found: score(record, candidate, importedGraph, localGraph, settled),
+        }))
+        .filter((s) => s.found !== null)
+        .sort((a, b) => b.found.sharedRelatives - a.found.sharedRelatives);
+
+      const best = scored[0];
+      if (!best) continue;
+
+      /*
+       * Two local people with the same name and nothing to tell them apart. Proposing either
+       * would be a coin toss, so neither is proposed.
+       */
+      const ambiguous = scored.length > 1
+        && scored[1].found.sharedRelatives === best.found.sharedRelatives
+        && best.found.sharedRelatives === 0;
+
+      if (best.found.sharedRelatives > 0) {
+        settled.set(record.id, {
+          importedId: record.id,
+          localId: best.candidate.id,
+          tier: MatchTier.STRONG,
+          evidence: best.found,
+        });
+        claimed.add(best.candidate.id);
+        changed = true;
+      } else if (!ambiguous) {
+        settled.set(record.id, {
+          importedId: record.id,
+          localId: best.candidate.id,
+          tier: MatchTier.WEAK,
+          evidence: best.found,
+        });
+        // A weak match does not claim the local person: a better candidate may still turn up.
+      }
+    }
+  }
+
+  return imported.map((record) => settled.get(record.id) ?? ({
+    importedId: record.id,
+    localId: null,
+    tier: MatchTier.NONE,
+    evidence: evidence(),
+  }));
+}
+
+/**
+ * The key an origin is looked up by.
+ *
+ * A NUL separator rather than a colon or a dash, because a tree id is arbitrary text and any
+ * printable separator could appear inside one -- at which point two different origins collide and
+ * the import merges two people on the strength of a punctuation mark. The Kotlin uses a `Pair` and
+ * has no such problem; JavaScript's Map needs the key flattened, so the separator has to be one
+ * that cannot occur.
+ */
+export function originKey(treeId, personId) {
+  return `${treeId}\u0000${personId}`;
+}
+
+/** Builds the neighbour map both sides are matched through. */
+export function graphOf(edges) {
+  const neighbours = new Map();
+  const link = (a, b) => {
+    if (!neighbours.has(a)) neighbours.set(a, new Set());
+    neighbours.get(a).add(b);
+  };
+  for (const [from, to] of edges) { link(from, to); link(to, from); }
+  return neighbours;
+}

--- a/desktop/renderer/matching.test.js
+++ b/desktop/renderer/matching.test.js
@@ -1,0 +1,304 @@
+/*
+ * DuplicateMatcherTest.kt, case for case.
+ *
+ * The rules that decide whether two records are the same person, and the most dangerous rules in
+ * either app: a wrong merge destroys information that may exist nowhere else, while a wrong split
+ * is a tidy-up. The tests are written to hold that asymmetry, and are kept in the Kotlin's order
+ * with the Kotlin's names so the two files can be read side by side.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import {
+  MatchTier, matchPeople, mergesByDefault, needsReview, nameKey, originKey, graphOf,
+} from './matching.js';
+
+/** The Kotlin's `graph(...)` helper. */
+const graph = (...edges) => graphOf(edges);
+
+/** The Kotlin's `match(...)` helper: results keyed by imported id. */
+function match({
+  imported, local, importedGraph = new Map(), localGraph = new Map(),
+  origins = [], sourceTreeId = 'their-tree',
+}) {
+  const originIndex = new Map(origins.map(([treeId, personId, localId]) => (
+    [originKey(treeId, personId), localId])));
+  const results = matchPeople({
+    imported, importedGraph, local, localGraph, originIndex, sourceTreeId,
+  });
+  return new Map(results.map((r) => [r.importedId, r]));
+}
+
+test('a person nobody here resembles is new', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Priya Sharma' }],
+    local: [{ id: 'l1', name: 'Ankit Kumar' }],
+  });
+  assert.strictEqual(result.get('i1').tier, MatchTier.NONE);
+  assert.strictEqual(result.get('i1').localId, null);
+});
+
+test('a person we already imported from this tree is a certain match', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Ankit Kumar' }],
+    local: [{ id: 'l1', name: 'Ankit Kumar' }],
+    origins: [['their-tree', 'i1', 'l1']],
+  });
+  const single = result.get('i1');
+  assert.strictEqual(single.tier, MatchTier.CERTAIN);
+  assert.strictEqual(single.localId, 'l1');
+  assert.ok(mergesByDefault(single));
+});
+
+test('an inherited origin also proves identity', () => {
+  // Their file came from a tree that had already merged ours, so the person carries our id.
+  const result = match({
+    imported: [{
+      id: 'i1',
+      name: 'Totally Different Spelling',
+      origins: [{ treeId: 'original-tree', personId: 'old-7' }],
+    }],
+    local: [{ id: 'l1', name: 'Ankit Kumar' }],
+    origins: [['original-tree', 'old-7', 'l1']],
+  });
+  assert.strictEqual(result.get('i1').tier, MatchTier.CERTAIN);
+});
+
+test('the same name with a relative in common is a strong match', () => {
+  const result = match({
+    imported: [{ id: 'iFather', name: 'Raj Kumar' }, { id: 'iMe', name: 'Ankit Kumar' }],
+    local: [{ id: 'lFather', name: 'Raj Kumar' }, { id: 'lMe', name: 'Ankit Kumar' }],
+    importedGraph: graph(['iFather', 'iMe']),
+    localGraph: graph(['lFather', 'lMe']),
+    origins: [['their-tree', 'iMe', 'lMe']],
+  });
+
+  // "Ankit Kumar" is provable; that makes his father's name far more than a coincidence.
+  assert.strictEqual(result.get('iMe').tier, MatchTier.CERTAIN);
+  const father = result.get('iFather');
+  assert.strictEqual(father.tier, MatchTier.STRONG);
+  assert.strictEqual(father.evidence.sharedRelatives, 1);
+  assert.ok(mergesByDefault(father));
+});
+
+test('a shared relative is enough even when nobody recorded any dates', () => {
+  const result = match({
+    imported: [{ id: 'iFather', name: 'Raj Kumar' }, { id: 'iMe', name: 'Ankit Kumar' }],
+    local: [{ id: 'lFather', name: 'Raj Kumar' }, { id: 'lMe', name: 'Ankit Kumar' }],
+    importedGraph: graph(['iFather', 'iMe']),
+    localGraph: graph(['lFather', 'lMe']),
+    origins: [['their-tree', 'iMe', 'lMe']],
+  });
+  // Refusing to match for want of a birth date nobody ever wrote down would be absurd.
+  assert.strictEqual(result.get('iFather').tier, MatchTier.STRONG);
+});
+
+test('the same name alone is only a weak match and stays separate by default', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Ankit Kumar' }],
+    local: [{ id: 'l1', name: 'Ankit Kumar' }],
+  });
+  const single = result.get('i1');
+  assert.strictEqual(single.tier, MatchTier.WEAK);
+  assert.strictEqual(single.localId, 'l1');
+  assert.ok(!mergesByDefault(single), 'a coincidence of names must not merge on its own');
+  assert.ok(needsReview(single));
+});
+
+test('birth dates that cannot both be true rule out a match entirely', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Ankit Kumar', birthDate: '1990' }],
+    local: [{ id: 'l1', name: 'Ankit Kumar', birthDate: '1962' }],
+  });
+  // Two people with one name born decades apart are two people.
+  assert.strictEqual(result.get('i1').tier, MatchTier.NONE);
+  assert.strictEqual(result.get('i1').localId, null);
+});
+
+test('dates of differing precision still agree', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Ankit Kumar', birthDate: '1990' }],
+    local: [{ id: 'l1', name: 'Ankit Kumar', birthDate: '1990-05-01' }],
+  });
+  assert.strictEqual(result.get('i1').tier, MatchTier.WEAK);
+});
+
+test('conflicting death dates also rule out a match', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Raj Kumar', birthDate: '1938', deathDate: '2010' }],
+    local: [{ id: 'l1', name: 'Raj Kumar', birthDate: '1938', deathDate: '1999' }],
+  });
+  assert.strictEqual(result.get('i1').tier, MatchTier.NONE);
+});
+
+test('names are compared past accents punctuation and spacing', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: "  josé   O'BRIEN " }],
+    local: [{ id: 'l1', name: 'Jose O Brien' }],
+  });
+  assert.strictEqual(result.get('i1').tier, MatchTier.WEAK);
+});
+
+test('an abbreviated name is not treated as the same person', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'R. Kumar' }],
+    local: [{ id: 'l1', name: 'Raj Kumar' }],
+  });
+  // Guessing here is how a merge quietly destroys someone's data.
+  assert.strictEqual(result.get('i1').tier, MatchTier.NONE);
+});
+
+test('an unnamed person is never matched to anybody', () => {
+  const result = match({
+    imported: [{ id: 'i1' }],
+    local: [{ id: 'l1' }, { id: 'l2', name: 'Ankit' }],
+  });
+  // Every unknown person would otherwise collapse into one.
+  assert.strictEqual(result.get('i1').tier, MatchTier.NONE);
+});
+
+test('two local people with the same name and nothing to separate them are not guessed at', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Ankit Kumar' }],
+    local: [{ id: 'l1', name: 'Ankit Kumar' }, { id: 'l2', name: 'Ankit Kumar' }],
+  });
+  assert.strictEqual(result.get('i1').tier, MatchTier.NONE);
+});
+
+test('one local person is never claimed by two imported people', () => {
+  const result = match({
+    imported: [{ id: 'i1', name: 'Ankit Kumar' }, { id: 'i2', name: 'Ankit Kumar' }],
+    local: [{ id: 'l1', name: 'Ankit Kumar' }],
+    origins: [['their-tree', 'i1', 'l1']],
+  });
+  assert.strictEqual(result.get('i1').localId, 'l1');
+  assert.strictEqual(result.get('i2').localId, null, 'l1 is already taken');
+});
+
+test('matching the same file twice is stable', () => {
+  const args = {
+    imported: [
+      { id: 'i1', name: 'Ankit Kumar', birthDate: '1990' },
+      { id: 'i2', name: 'Raj Kumar', birthDate: '1938' },
+    ],
+    local: [
+      { id: 'l1', name: 'Ankit Kumar', birthDate: '1990' },
+      { id: 'l2', name: 'Raj Kumar', birthDate: '1938' },
+    ],
+    origins: [['their-tree', 'i1', 'l1'], ['their-tree', 'i2', 'l2']],
+  };
+  const first = match(args);
+  const second = match(args);
+
+  assert.deepStrictEqual(
+    [...first].map(([k, v]) => [k, v.tier]),
+    [...second].map(([k, v]) => [k, v.tier]));
+  assert.ok([...first.values()].every((m) => m.tier === MatchTier.CERTAIN));
+});
+
+/* ---------------------------------------------------------------- beyond the Kotlin's table */
+
+/*
+ * Added here. The Kotlin keys its origin index on a `Pair`, which cannot be confused; JavaScript's
+ * Map needs the key flattened into a string, and that flattening is a place to introduce a bug the
+ * Kotlin cannot have.
+ */
+test('two origins cannot collide through the separator used to key them', () => {
+  // Ids chosen so a naive `${treeId}-${personId}` or `${treeId}:${personId}` would produce the
+  // same string for both, and merge two people who share nothing but punctuation.
+  assert.notStrictEqual(originKey('tree-a', 'b-1'), originKey('tree', 'a-b-1'));
+  assert.notStrictEqual(originKey('a:b', 'c'), originKey('a', 'b:c'));
+  assert.notStrictEqual(originKey('a b', 'c'), originKey('a', 'b c'));
+});
+
+test('a name is reduced to form, never to content', () => {
+  assert.strictEqual(nameKey("  jos\u00e9   O'BRIEN "), nameKey('Jose O Brien'));
+  assert.strictEqual(nameKey('Raj  Kumar'), 'raj kumar');
+  assert.notStrictEqual(nameKey('R. Kumar'), nameKey('Raj Kumar'));
+  assert.strictEqual(nameKey(''), null);
+  assert.strictEqual(nameKey('   '), null);
+  assert.strictEqual(nameKey(null), null);
+});
+
+/*
+ * Devanagari, pinned as it actually behaves rather than as it ought to.
+ *
+ * `[^\p{L}\p{N}]+` replaces everything that is not a letter or a number with a space, and a
+ * Devanagari vowel sign is category Mc -- a mark, not a letter. So the matras are stripped and
+ * "\u0930\u093e\u092e" reduces to "\u0930 \u092e". Distinct names then collide: see #113.
+ *
+ * This is not a bug introduced by the port. The Kotlin does exactly the same thing, verified by
+ * running `java.text.Normalizer` over the same inputs and comparing output character for
+ * character. These assertions therefore pin the *shared* behaviour: if either side is fixed, this
+ * fails and forces the other to be fixed with it, rather than the two silently drifting apart on
+ * the question of who is the same person.
+ */
+test('Devanagari keys match the Kotlin exactly, including where that is lossy', () => {
+  // Verified against java.text.Normalizer under JDK 25; these are its outputs.
+  const asKotlin = {
+    '\u0936\u094d\u092f\u093e\u092e': '\u0936\u092f \u092e',
+    '\u0936\u092f\u093e\u092e': '\u0936\u092f \u092e',
+    '\u0930\u093e\u092e \u0915\u0941\u092e\u093e\u0930': '\u0930 \u092e \u0915\u092e \u0930',
+    '\u0936\u094d\u092f\u093e\u092e \u0915\u0941\u092e\u093e\u0930': '\u0936\u092f \u092e \u0915\u092e \u0930',
+  };
+  for (const [name, expected] of Object.entries(asKotlin)) {
+    assert.strictEqual(nameKey(name), expected, `${name} keyed differently from the Kotlin`);
+  }
+});
+
+test('a Devanagari collision can only ever be a weak match on its own', () => {
+  /*
+   * The mitigation, and the reason #113 is a defect rather than an emergency. Two distinct names
+   * that key alike are still only "the same name and nothing contradicting it", which does not
+   * merge by default and has to be asked for.
+   *
+   * It stops being a mitigation as soon as a relative matches -- see the next case.
+   */
+  const result = match({
+    imported: [{ id: 'i1', name: '\u0930\u093e\u092e' }],       // Ram
+    local: [{ id: 'l1', name: '\u0930\u093e\u092e\u093e' }],   // Rama, a different name
+  });
+  assert.strictEqual(nameKey('\u0930\u093e\u092e'), nameKey('\u0930\u093e\u092e\u093e'),
+    'the premise of this test is that these two collide');
+  assert.strictEqual(result.get('i1').tier, MatchTier.WEAK);
+  assert.ok(!mergesByDefault(result.get('i1')));
+});
+
+test('but a Devanagari collision with a shared relative would merge by default', () => {
+  // The case that makes #113 worth fixing rather than noting. Nothing here is wrong per the
+  // rules; the rules are being fed two names that are not the same name.
+  const result = match({
+    imported: [{ id: 'iA', name: '\u0930\u093e\u092e' }, { id: 'iKid', name: 'Shared Child' }],
+    local: [{ id: 'lA', name: '\u0930\u093e\u092e\u093e' }, { id: 'lKid', name: 'Shared Child' }],
+    importedGraph: graph(['iA', 'iKid']),
+    localGraph: graph(['lA', 'lKid']),
+    origins: [['their-tree', 'iKid', 'lKid']],
+  });
+  assert.strictEqual(result.get('iA').tier, MatchTier.STRONG);
+  assert.ok(mergesByDefault(result.get('iA')),
+    'two different Hindi names would merge without being asked about');
+});
+
+test('a strange file cannot make the matcher run long', () => {
+  // Every person shares a name and a relative with every other, which is the shape that would
+  // make an unbounded pass loop keep finding "new" evidence.
+  const n = 300;
+  const imported = [];
+  const local = [];
+  const edges = [];
+  for (let i = 0; i < n; i += 1) {
+    imported.push({ id: `i${i}`, name: 'Same Name' });
+    local.push({ id: `l${i}`, name: 'Same Name' });
+    if (i > 0) edges.push([`i${i - 1}`, `i${i}`]);
+  }
+  const started = Date.now();
+  const result = match({
+    imported,
+    local,
+    importedGraph: graphOf(edges),
+    localGraph: graphOf(edges.map(([a, b]) => [a.replace('i', 'l'), b.replace('i', 'l')])),
+  });
+  assert.strictEqual(result.size, n);
+  assert.ok(Date.now() - started < 5000, `took ${Date.now() - started}ms`);
+});


### PR DESCRIPTION
The half of *"not dependent on Android"* that was still missing. A tree can be built here and sent
to the phone; a relative's file cannot yet be merged into a tree open here. This is the logic that
decides which people in an incoming file are already present — ported and tested, with the interface
still to come.

- `matching.js` — `DuplicateMatcher.kt` + `NameKey.kt`
- `dates.js` — the part of `PartialDate.kt` the matcher needs
- `matching.test.js` — **the Kotlin's own table**, all fifteen cases in its order and under its names

The asymmetry it encodes is worth restating, because it shapes every rule: **wrongly keeping two
records apart is a tidy-up; wrongly merging them destroys information that may exist nowhere else.**

Dates compare as plain `yyyymmdd` integers rather than through `Date`. They only need ordering, and
`Date` would drag a timezone into a question that has none — "1938" is not an instant.

## Three cases added, each covering something the Kotlin cannot get wrong but a port can

| | why |
|---|---|
| origin keys cannot collide through their separator | Kotlin keys on a `Pair`; JS has to flatten to a string, and a bad separator merges two people on the strength of punctuation |
| a 300-person file where everyone shares a name and a relative | asserts the pass bound actually bounds |
| `nameKey` reduces form, never content | "R. Kumar" must stay separate from "Raj Kumar" |

## Found while porting → #113, raised not fixed

`nameKey` **strips Devanagari vowel signs.** A matra is category `Mc`, and the expression keeps only
`\p{L}` and `\p{N}`:

| | key |
|---|---|
| राम / रामा | `र म` |
| कुमार / कमार | `कम र` |
| श्याम / शयाम | `शय म` |

Three collisions in a sample of eighteen common Hindi names. Stripping an accent is right for Latin
— *José* and *Jose* are one person. A matra is not an accent on a letter; it is part of which letter
it is.

**Blast radius, precisely:** on its own a collision is only `WEAK`, which does not merge by default.
With one matched relative it is `STRONG`, which does — two different Hindi names merging without
anybody being asked.

**This is the Android app's behaviour, not something the port introduced.** `java.text.Normalizer`
under JDK 25 and this code produce character-for-character identical output on every input above. So
`matching.test.js` pins the Kotlin's exact results *including the lossy ones*, and asserts the
undesirable merge explicitly — a fix on either side fails these tests and forces the other to be
fixed with it, rather than the two drifting apart on who is the same person.

The fix is one line in a file with live users. That is Ankit's call, not a side effect of desktop
work.

## Checks

- 95 tests pass (12 update, 11 rules, 26 tree, 8 save, 9 atomic, 8 identity, 9 dates, 21 matching)
- `git status --short app/` empty

Refs #89, #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)