### PR TITLE
Package the app, and prove the package starts

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -11,8 +11,9 @@ name: Desktop
 # phone will never be offered an .AppImage, because there are live users on the app.
 #
 # The pre-release flag now carries a second meaning as well: the desktop app stays a pre-release
-# until issue #89 is finished. Until then it reads a tree and does not build one, and calling any
-# build of it a stable release would claim a completeness it does not have.
+# until issue #89 is finished. It builds a tree as well as reading one now, but the parity that
+# issue asks for is not there yet, so calling any build of it a stable release would claim a
+# completeness it does not have.
 #
 # Worth keeping straight, because the two senses of "beta" are not the same mechanism:
 #
@@ -118,6 +119,26 @@ jobs:
         working-directory: desktop
         run: node --test package.test.js
 
+      # The smoke job above starts `electron .` from the checkout, where every source file is
+      # present by definition -- so it cannot see a packaging mistake, and for 0.4.0 it did not.
+      # Two of them shipped in a release every test called green: `atomic.js` and `identity.js`
+      # were never packaged, and the renderer was staged a directory too shallow for its own
+      # imports to resolve. The app threw before drawing a window.
+      #
+      # So the same harness runs a second time here, against the binary that is about to be
+      # uploaded, reading the asar and the staged page that users will actually get. Building a
+      # tree and saving it is part of it: a package can start and still be missing the half of
+      # itself that only a real edit touches.
+      - name: Start the packaged app and build a tree in it
+        if: matrix.os == 'ubuntu-latest'
+        working-directory: desktop
+        env:
+          FTREE_SMOKE: ${{ runner.temp }}/fixtures/sample-family.ftree
+          FTREE_SMOKE_SAVE_TO: ${{ runner.temp }}/built-in-the-package.ftree
+        run: |
+          python3 ../tools/make_sample_tree.py "$RUNNER_TEMP/fixtures"
+          xvfb-run -a ./dist/linux-unpacked/f-tree-desktop --no-sandbox
+
       - uses: actions/upload-artifact@v4
         with:
           name: installers-${{ matrix.os }}
@@ -161,5 +182,5 @@ jobs:
 
           Marked a pre-release on purpose, for two reasons. It keeps the Android app's update
           channel pointing at Android releases; and the desktop app stays a pre-release until
-          [#89](https://github.com/thisisankit27/f-tree/issues/89) is done, because it reads a
-          tree today and does not yet build one."
+          [#89](https://github.com/thisisankit27/f-tree/issues/89) is done: it builds a tree as
+          well as reading one now, but it is not yet the equal of the phone app."

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -53,9 +53,16 @@ if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND
  * step to keep in step with anything. The staged directory is called `page` and not `app` on
  * purpose -- `resources/app` is where Electron looks for an unpacked application, and putting a
  * package.json there would make it try to run this as one.
+ *
+ * Reproducing the shape means reproducing the *depth*, and 0.4.0 did not. It staged the renderer
+ * at `page/renderer`, one level shallower than `desktop/renderer` sits in the repository, so
+ * `../../site/playground/` climbed out of `page` entirely and every module the window imports
+ * 404'd. The browser reports that to a console nobody opens, so it presents as a blank window.
+ * The `desktop` level below is load-bearing: it is what makes one set of relative specifiers
+ * correct both in a checkout and in a package. `package.test.js` walks these imports for real.
  */
 const VIEWER = app.isPackaged
-  ? path.join(process.resourcesPath, 'page', 'renderer', 'index.html')
+  ? path.join(process.resourcesPath, 'page', 'desktop', 'renderer', 'index.html')
   : path.join(__dirname, 'renderer', 'index.html');
 
 /*

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "f-tree-desktop",
   "productName": "f-tree",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A local-first family tree, on your own machine",
   "author": {
     "name": "thisisankit27",
@@ -31,10 +31,11 @@
       "output": "dist"
     },
     "files": [
-      "main.js",
-      "preload.js",
-      "update.js",
-      "package.json",
+      "**/*",
+      "!**/*.test.js",
+      "!test-fixtures${/*}",
+      "!renderer${/*}",
+      "!package-lock.json",
       "build/icons/*.png"
     ],
     "extraResources": [
@@ -47,7 +48,7 @@
       },
       {
         "from": "renderer",
-        "to": "page/renderer",
+        "to": "page/desktop/renderer",
         "filter": [
           "**/*",
           "!*.test.js"

--- a/desktop/package.test.js
+++ b/desktop/package.test.js
@@ -102,3 +102,129 @@ test('these assertions reject the postinst that actually shipped broken', () => 
       + 'if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then',
   ]);
 });
+
+/*
+ * ---------------------------------------------------------------------------------------------
+ * Whether the package contains the app.
+ *
+ * 0.4.0 shipped dead. `main.js` requires `./atomic` and `./identity`; the `files` list in
+ * package.json was an allowlist of four filenames written before either existed, so neither was
+ * packaged, and the app threw `Cannot find module './atomic'` before it drew a window.
+ *
+ * Every test in this repo was green. The smoke test starts `npx electron .` from a checkout,
+ * where every file is present by definition -- it can never see a packaging mistake. The tests
+ * above read the built deb but only ever asked about the postinst. Nothing asked the one
+ * question that mattered: does the thing we are about to upload contain its own source.
+ *
+ * So these walk the require graph from the entry point recorded in the packaged package.json and
+ * insist every relative specifier resolves *inside the archive*. The `files` list is now an
+ * exclusion list rather than an allowlist -- forgetting an exclusion wastes a few KB, forgetting
+ * an inclusion bricks the release -- and this is what holds that decision in place.
+ *
+ * These read `linux-unpacked`, which every `--linux` build writes, and which holds the same
+ * `resources/` the deb, the tarball and the AppImage are each built from.
+ */
+
+const asar = require('@electron/asar');
+
+// Defaults to the build just made, but can be pointed at any installed copy -- an unpacked deb,
+// or /opt/f-tree itself. That is not test scaffolding: it is how these assertions were shown to
+// reject the 0.4.0 that shipped, rather than only to accept the build that replaced it.
+const RESOURCES = process.env.FTREE_PACKAGE_UNDER_TEST
+  || path.join(DIST, 'linux-unpacked', 'resources');
+const ARCHIVE = path.join(RESOURCES, 'app.asar');
+const noPackage = fs.existsSync(ARCHIVE)
+  ? false
+  : 'no dist/linux-unpacked -- run `npx electron-builder --linux` first';
+
+// Node's own resolution order for a relative specifier, which is what `require` will do at run
+// time. Checking only for the literal path would miss `require('./atomic')` finding `atomic.js`.
+function resolveIn(files, fromDir, specifier) {
+  const base = path.posix.normalize(path.posix.join(fromDir, specifier));
+  const candidates = [base, `${base}.js`, `${base}.json`, path.posix.join(base, 'index.js')];
+  return candidates.find((c) => files.has(c)) || null;
+}
+
+const RELATIVE_REQUIRE = /\brequire\(\s*['"](\.[^'"]+)['"]\s*\)/g;
+
+test('every module the main process requires is inside the package', { skip: noPackage }, () => {
+  const files = new Set(
+    asar.listPackage(ARCHIVE).map((f) => f.replace(/^[/\\]/, '').split(path.sep).join('/')));
+  const read = (f) => asar.extractFile(ARCHIVE, f).toString('utf8');
+
+  const entry = JSON.parse(read('package.json')).main;
+  assert.ok(files.has(entry), `package.json names "${entry}" as main and it is not packaged`);
+
+  const missing = [];
+  const seen = new Set();
+  const queue = [entry];
+
+  while (queue.length) {
+    const file = queue.shift();
+    if (seen.has(file) || !file.endsWith('.js')) continue;
+    seen.add(file);
+
+    const dir = path.posix.dirname(file);
+    for (const [, specifier] of read(file).matchAll(RELATIVE_REQUIRE)) {
+      const target = resolveIn(files, dir, specifier);
+      if (target) queue.push(target);
+      else missing.push(`${file} requires '${specifier}', which is not in the package`);
+    }
+  }
+
+  assert.deepStrictEqual(missing, []);
+  // A graph that walked nowhere would pass the assertion above while proving nothing.
+  assert.ok(seen.size > 1, `only reached ${seen.size} file(s) from ${entry}; the walk found nothing`);
+});
+
+/*
+ * The other half of the app, which does not travel in the asar at all.
+ *
+ * The window's page ships through `extraResources`, and its modules import across a directory
+ * boundary that only exists once packaged: the renderer sits at `page/renderer` and reaches the
+ * viewer engine at `page/site/playground` through `../../site/playground/`. That works in a
+ * checkout for a different reason than it works in a package, so a wrong `to:` in extraResources
+ * would leave the window blank with the failure visible only in a devtools console nobody opens.
+ *
+ * Browsers resolve module specifiers literally, so unlike require there is no extension guessing.
+ */
+test('the window\'s page and every module it imports are packaged', { skip: noPackage }, () => {
+  const main = asar.extractFile(ARCHIVE, 'main.js').toString('utf8');
+  const viewer = main.match(/process\.resourcesPath\s*,\s*((?:\s*'[^']+'\s*,?)+)\)/);
+  assert.ok(viewer, 'main.js no longer builds the packaged page path in a readable way');
+
+  // Read the path out of main.js rather than restating it here. A test that hard-codes the
+  // layout agrees with itself when the layout is what moved.
+  const entry = path.posix.join(...[...viewer[1].matchAll(/'([^']+)'/g)].map((m) => m[1]));
+  const abs = (f) => path.join(RESOURCES, f);
+  assert.ok(fs.existsSync(abs(entry)), `main.js loads ${entry} and it is not packaged`);
+
+  const html = fs.readFileSync(abs(entry), 'utf8');
+  const scripts = [...html.matchAll(/<script[^>]*\bsrc=['"]([^'"]+)['"]/g)].map((m) => m[1]);
+  assert.ok(scripts.length, `${entry} loads no scripts; this test would prove nothing`);
+
+  const missing = [];
+  const seen = new Set();
+  const queue = scripts.map((s) => path.posix.join(path.posix.dirname(entry), s));
+
+  while (queue.length) {
+    const file = queue.shift();
+    if (seen.has(file)) continue;
+    seen.add(file);
+    if (!fs.existsSync(abs(file))) {
+      missing.push(`${file} is imported and not packaged`);
+      continue;
+    }
+    const source = fs.readFileSync(abs(file), 'utf8');
+    const specifiers = [
+      ...[...source.matchAll(/\bfrom\s*['"](\.[^'"]+)['"]/g)].map((m) => m[1]),
+      ...[...source.matchAll(/\bimport\s*\(?\s*['"](\.[^'"]+)['"]/g)].map((m) => m[1]),
+    ];
+    for (const specifier of specifiers) {
+      queue.push(path.posix.normalize(path.posix.join(path.posix.dirname(file), specifier)));
+    }
+  }
+
+  assert.deepStrictEqual(missing, []);
+  assert.ok(seen.size > 1, `only reached ${seen.size} module(s) from ${entry}`);
+});


### PR DESCRIPTION
0.4.0 shipped dead. `/opt/f-tree/f-tree-desktop` threw `Cannot find module './atomic'` before it drew a window.

## Two faults, either enough on its own

**1. Modules that were never packaged.** `files` was an allowlist of four filenames, written before `atomic.js` and `identity.js` existed. Neither was included, so the first `require` in `main.js` threw.

**2. A blank window waiting behind it.** The renderer was staged at `page/renderer`, one directory shallower than `desktop/renderer` sits in the repository, so its `../../site/playground/` imports climbed out of the staged tree entirely. Every module the window loads would have 404'd — reported to a devtools console nobody opens.

Both were verified by reading the installed 0.4.0, not by re-reading the sources.

## The more important defect: every test was green

The smoke job starts `electron .` **from the checkout**, where every file is present by definition. It cannot structurally see a packaging mistake. `package.test.js` did open the built `.deb`, but only ever asked about the postinst. Nothing asked whether the artifact about to be uploaded contained its own source.

## Changes

- **`files` becomes an exclusion list.** Forgetting an exclusion wastes a few KB; forgetting an inclusion bricks the release. It should fail toward a working app.
- **The staged layout reproduces the repository's depth**, so one set of relative specifiers is correct both in a checkout and in a package.
- **CI runs the smoke harness a second time against the packaged binary**, building and saving a tree in it. A package can start and still be missing the half of itself that only a real edit touches.
- **Two new tests** walk the main process's require graph and the window's import graph, insisting every specifier resolves inside the package.

## Teeth

Pointed at the installed 0.4.0, the new tests reproduce the reported error and the second bug:

```
not ok 4 - every module the main process requires is inside the package
    "main.js requires './atomic', which is not in the package"
    "main.js requires './identity', which is not in the package"
not ok 5 - the window's page and every module it imports are packaged
    'site/playground/archive.js is imported and not packaged'
    ... and four more
```

Against this build, both pass. `FTREE_PACKAGE_UNDER_TEST` is what allowed them to be aimed at the broken artifact, so it is kept.

## Verification

Ran the full harness against the binary unpacked from the built `.deb` — 26 checks including building a tree from nothing, being refused a contradictory relationship, saving, and reading it back. 100 tests pass. `git status --short app/` is empty.

Also corrects two release-notes claims that 0.4.0 made stale ("reads a tree and does not build one").

🤖 Generated with [Claude Code](https://claude.com/claude-code)