### PR TITLE
Import a relative's tree, with the merge shown before it happens

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -83,6 +83,10 @@ jobs:
           # naming somebody, adding a child, being refused a contradictory relationship, saving to
           # this path and reading it back. Everything but the native save dialog is the real path.
           FTREE_SMOKE_SAVE_TO: ${{ runner.temp }}/built-here.ftree
+          # And the third: merging a relative's file into the tree just built. The matcher is
+          # unit-tested, but the thing that must not regress is that it *asks* -- a strong match
+          # merges unless it is refused, and a merge is the one act here nobody can undo by hand.
+          FTREE_SMOKE_IMPORT: ${{ runner.temp }}/fixtures/a-cousins-tree.ftree
         run: xvfb-run -a npx electron . --no-sandbox
 
   package:
@@ -135,6 +139,7 @@ jobs:
         env:
           FTREE_SMOKE: ${{ runner.temp }}/fixtures/sample-family.ftree
           FTREE_SMOKE_SAVE_TO: ${{ runner.temp }}/built-in-the-package.ftree
+          FTREE_SMOKE_IMPORT: ${{ runner.temp }}/fixtures/a-cousins-tree.ftree
         run: |
           python3 ../tools/make_sample_tree.py "$RUNNER_TEMP/fixtures"
           xvfb-run -a ./dist/linux-unpacked/f-tree-desktop --no-sandbox

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -417,6 +417,8 @@ function buildMenu(win) {
         { label: 'New tree', accelerator: 'CmdOrCtrl+N',
           click: () => win.webContents.send('menu:command', 'file:new') },
         { label: 'Open tree…', accelerator: 'CmdOrCtrl+O', click: () => chooseInto(win) },
+      { label: 'Import into this tree…', accelerator: 'CmdOrCtrl+I',
+        click: () => win.webContents.send('menu:command', 'file:import') },
         { type: 'separator' },
         /*
          * Saving is asked of the page, not done here. The page holds the tree, the writer and the
@@ -676,6 +678,47 @@ ipcMain.handle('tree:choose', async (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   return chooseInto(win);
 });
+/*
+ * A file to merge in, which is not the same act as opening one.
+ *
+ * Deliberately does not touch the session: the tree being edited is still the tree that was
+ * opened, and recording a cousin's file as "the last tree" would reopen theirs on the next launch.
+ * Nothing is decided here either -- the page reads the archive, works out what the merge would
+ * mean, and shows it before a single person is changed.
+ */
+ipcMain.handle('tree:chooseImport', async (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+
+  // The same narrow seam the save test uses, and gated the same way: a native picker cannot be
+  // clicked from a test, and stubbing the import itself would leave the real path unexercised.
+  if (process.env.FTREE_SMOKE && process.env.FTREE_SMOKE_IMPORT) {
+    const { name, bytes } = await readTree(path.resolve(process.env.FTREE_SMOKE_IMPORT));
+    return { name, bytes };
+  }
+
+  const picked = await dialog.showOpenDialog(win, {
+    title: 'Choose a family tree to import',
+    buttonLabel: 'Import',
+    filters: [{ name: 'f-tree export', extensions: ['ftree'] },
+      { name: 'All files', extensions: ['*'] }],
+    properties: ['openFile'],
+  });
+  if (picked.canceled || !picked.filePaths.length) return null;
+
+  try {
+    const { name, bytes } = await readTree(picked.filePaths[0]);
+    return { name, bytes };
+  } catch (error) {
+    await dialog.showMessageBox(win, {
+      type: 'warning',
+      message: 'That file could not be read.',
+      detail: `${picked.filePaths[0]}\n\n${error.message}`,
+      buttons: ['OK'],
+    });
+    return null;
+  }
+});
+
 ipcMain.handle('tree:forget', async () => { await writeSession({}); });
 
 /*
@@ -785,6 +828,17 @@ async function runEditSmoke(win, check) {
   });
   await settle();
 
+  // A date and a note as well as a name. The import step later needs two records that agree on
+  // enough to be a candidate and disagree on something that cannot rule the pairing out.
+  await page(() => {
+    for (const [id, value] of [['f-birth', '1938'], ['f-notes', 'Grandfather. Born in Ballia.']]) {
+      const input = document.getElementById(id);
+      input.value = value;
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+  });
+  await settle();
+
   // Add a child, by name, as a new person.
   await page(() => {
     [...document.querySelectorAll('.kinds button')].find((b) => b.textContent === 'Child').click();
@@ -858,6 +912,87 @@ async function runEditSmoke(win, check) {
   }));
   check('the saved file reopens with both people and the connection',
     /2 people/.test(seen.counts) && /1 connection/.test(seen.counts), seen.counts);
+}
+
+/*
+ * Merging a second file into the tree on screen.
+ *
+ * The review dialog is the one screen where confirming does something that cannot be put right by
+ * hand, so what is asserted here is not "it worked" but "it asked first": the dialog opens, it
+ * names the evidence, and the tree is untouched until the button is pressed.
+ */
+async function runImportSmoke(win, check) {
+  const page = (fn, ...args) => win.webContents.executeJavaScript(
+    `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
+  const settle = (ms = 400) => new Promise((r) => setTimeout(r, ms));
+
+  console.log('\n  -- merging in a second file --');
+
+  const before = await page(() => ({
+    people: window.__ftreePeopleCount?.() ?? document.getElementById('counts').textContent,
+  }));
+
+  win.webContents.send('menu:command', 'file:import');
+  await settle(900);
+
+  const asked = await page(() => {
+    const dialog = document.getElementById('review');
+    const cards = [...dialog.querySelectorAll('.pair')];
+    return {
+      open: dialog.open === true,
+      title: document.getElementById('review-title').textContent,
+      lead: document.getElementById('review-lead').textContent,
+      outcome: document.getElementById('review-outcome').textContent,
+      confirm: document.getElementById('review-confirm').textContent,
+      cards: cards.length,
+      why: cards[0]?.querySelector('.pair-why')?.textContent ?? '',
+      sides: cards[0]?.querySelectorAll('.side').length ?? 0,
+      counts: document.getElementById('counts').textContent,
+    };
+  });
+
+  check('importing asks before it merges', asked.open, asked.title);
+  check('the button says exactly what pressing it will do',
+    /^(Add|Merge) \d+ /.test(asked.confirm), asked.confirm);
+  check('the dialog says the work is not on disk yet', /until you save/.test(asked.outcome),
+    asked.outcome);
+  check('the tree is untouched while the question is open', asked.counts === before.people,
+    asked.counts);
+
+  if (asked.cards) {
+    check('a proposed match shows both records side by side', asked.sides === 2,
+      `${asked.sides} sides`);
+    check('a proposed match says why it thinks so', asked.why.length > 0, asked.why.trim());
+  }
+
+  // Both themes, because this screen is read in whichever one somebody happens to use and a
+  // token that only exists in one of them looks fine right up until it does not.
+  if (process.env.FTREE_SMOKE_SHOT_REVIEW) {
+    const shot = process.env.FTREE_SMOKE_SHOT_REVIEW;
+    await fs.writeFile(shot, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${shot}`);
+
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(300);
+    const other = shot.replace(/(\.png)?$/, '-other-theme.png');
+    await fs.writeFile(other, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${other}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(200);
+  }
+
+  await page(() => document.getElementById('review-confirm').click());
+  await settle(600);
+
+  const after = await page(() => ({
+    counts: document.getElementById('counts').textContent,
+    open: document.getElementById('review').open === true,
+    undo: document.getElementById('undo')?.disabled === false,
+  }));
+
+  check('confirming closes the question', !after.open, String(after.open));
+  check('the tree grew once it was confirmed', after.counts !== before.people, after.counts);
+  check('the whole import can be undone', after.undo, 'undo is available');
 }
 
 async function runSmoke(win, file) {
@@ -991,6 +1126,8 @@ async function runSmoke(win, file) {
   }
 
   if (process.env.FTREE_SMOKE_SAVE_TO) await runEditSmoke(win, check);
+
+  if (process.env.FTREE_SMOKE_IMPORT) await runImportSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_SHOT) {
     const image = await win.webContents.capturePage();

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -24,6 +24,14 @@ contextBridge.exposeInMainWorld('ftreeDesktop', {
   /** Opens the system file picker and returns { name, bytes } or null if it was cancelled. */
   chooseTree: () => ipcRenderer.invoke('tree:choose'),
 
+  /**
+   * Picks a second tree to merge into the one already open.
+   *
+   * Separate from `chooseTree` because the two are different acts: opening replaces what is on
+   * screen, importing adds to it, and only opening should be remembered for next launch.
+   */
+  chooseImportTree: () => ipcRenderer.invoke('tree:chooseImport'),
+
   /** The tree opened last time, reopened on launch so the app starts where it was left. */
   lastTree: () => ipcRenderer.invoke('tree:last'),
   forgetTree: () => ipcRenderer.invoke('tree:forget'),

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -27,6 +27,8 @@ import { Chart } from '../../site/playground/chart.js';
 
 import { Tree, RelationshipType, Rejection } from './document.js';
 import { bytesForTree, SaveRefused } from './save.js';
+import { planImport, applyImport, ImportRefused } from './import.js';
+import { MatchTier } from './matching.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
 
@@ -68,7 +70,8 @@ function toast(message, tone = 'good') {
   box.hidden = false;
   clearTimeout(toastTimer);
   // A refusal is longer and worth reading twice; a confirmation is not.
-  toastTimer = setTimeout(() => { box.hidden = true; }, tone === 'bad' ? 9000 : 2600);
+  const linger = { bad: 9000, warn: 9000 }[tone] ?? 2600;
+  toastTimer = setTimeout(() => { box.hidden = true; }, linger);
 }
 
 /** Keeps the window, the menu and the dot in step with whether there is work not on disk. */
@@ -722,6 +725,223 @@ async function openBytes(bytes, name, filePath) {
   }
 }
 
+/* ------------------------------------------------------------------ importing */
+
+/**
+ * Merging somebody else's file into this tree.
+ *
+ * Nothing is decided here. The file is read, the matcher works out what it would mean, and the
+ * review dialog asks -- because a strong match merges unless it is refused, and a merge is the one
+ * act in this app that cannot be put right by hand afterwards.
+ */
+async function importTree() {
+  if (!shell) return;
+
+  // With nothing open there is no tree to import into, and opening the file is plainly what was
+  // meant. Refusing on a technicality would be correct and useless.
+  if (!state.tree) { await shell.chooseTree(); return; }
+
+  const chosen = await shell.chooseImportTree();
+  if (!chosen) return;
+
+  $('busy').hidden = false;
+  try {
+    const buffer = chosen.bytes instanceof ArrayBuffer ? chosen.bytes : chosen.bytes.buffer;
+    const archive = await openArchive(buffer);
+    if (!archive.has('tree.json')) {
+      throw new ArchiveError('That ZIP has no tree.json, so it is not a .ftree export.');
+    }
+    const doc = parseDocument(await archive.readText('tree.json'));
+
+    const importedPhotos = new Map();
+    for (const entry of archive.names()) {
+      if (entry.startsWith('photos/') && !entry.endsWith('/')) {
+        importedPhotos.set(entry, await archive.read(entry));
+      }
+    }
+
+    openReview(planImport({ document: doc, tree: state.tree, ownTreeId: state.ownTreeId }),
+      chosen.name, importedPhotos);
+  } catch (error) {
+    const known = error instanceof ArchiveError || error instanceof ImportRefused;
+    toast(known ? error.message : `That file could not be read. ${error.message}`, 'bad');
+  } finally {
+    $('busy').hidden = true;
+  }
+}
+
+const RELATIVE_LIST = (names) => {
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} and ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')} and ${names.at(-1)}`;
+};
+
+/** The case for a proposed match, in words somebody can agree or disagree with. */
+function whyMatched(match) {
+  const parts = ['The name is the same'];
+  if (match.evidence.datesAgree) parts.push('the dates fit');
+  if (match.shared.length) {
+    parts.push(`you both have ${RELATIVE_LIST(match.shared.slice(0, 3))}`
+      + (match.shared.length > 3 ? ` and ${match.shared.length - 3} more` : ''));
+  }
+  const sentence = parts.length === 1
+    ? parts[0]
+    : `${parts.slice(0, -1).join(', ')}, and ${parts.at(-1)}`;
+  return match.shared.length
+    ? `${sentence}.`
+    : `${sentence} — but nothing else here says they are the same person.`;
+}
+
+const FIELDS = [['birthDate', 'Born'], ['deathDate', 'Died'], ['notes', 'Notes']];
+
+function sideOf(heading, person, other, fields) {
+  if (!fields.length) {
+    return `<div class="side"><p class="side-of">${heading}</p>`
+      + '<p class="side-bare">Only a name recorded.</p></div>';
+  }
+  const rows = fields.map(([key, label]) => {
+    const mine = person?.[key];
+    const theirs = other?.[key];
+    if (!mine) return `<dt>${label}</dt><dd class="empty">not recorded</dd>`;
+    // Marked where the two disagree: a merge keeps what is already here, so this is also the only
+    // place somebody is told which of theirs is about to be set aside.
+    const differs = theirs && String(theirs) !== String(mine) ? 'differs' : '';
+    return `<dt>${label}</dt><dd class="${differs}">${escapeHtml(String(mine))}</dd>`;
+  }).join('');
+  return `<div class="side"><p class="side-of">${heading}</p><dl>${rows}</dl></div>`;
+}
+
+function pairCard(match) {
+  const name = escapeHtml(match.theirs?.name ?? 'Someone unnamed');
+  const tier = match.tier === MatchTier.STRONG ? 'Likely the same person' : 'Possibly the same person';
+  const merging = match.tier === MatchTier.STRONG;
+  // A row neither record has says nothing twice, and pushes the evidence below the fold.
+  const fields = FIELDS.filter(([key]) => match.theirs?.[key] || match.mine?.[key]);
+  return `
+    <article class="pair" data-id="${escapeHtml(match.importedId)}" data-tier="${match.tier}">
+      <div class="pair-head">
+        <h3 class="pair-name">${name}</h3>
+        <span class="pair-tier">${tier}</span>
+      </div>
+      <div class="pair-sides">
+        ${sideOf('In their file', match.theirs, match.mine, fields)}
+        ${sideOf('In your tree', match.mine, match.theirs, fields)}
+      </div>
+      <p class="pair-why">${escapeHtml(whyMatched(match))}</p>
+      <div class="pair-choice" role="group" aria-label="Is this the same person?">
+        <button type="button" data-merge="yes" aria-pressed="${merging}">Same person</button>
+        <button type="button" data-merge="no" aria-pressed="${!merging}">Two different people</button>
+      </div>
+    </article>`;
+}
+
+function openReview(plan, fileName, importedPhotos) {
+  const decisions = new Map(plan.defaultDecisions);
+  const dialog = $('review');
+  const total = plan.matches.length;
+  const asked = plan.reviewable;
+
+  $('review-title').textContent = fileName;
+  $('review-lead').textContent = asked.length
+    ? `Their file has ${count(total, 'person', 'people')}. `
+      + `${asked.length} of them ${asked.length === 1 ? 'looks' : 'look'} like someone already in `
+      + 'your tree, so they are worth a look before anything is joined up.'
+    : `Their file has ${count(total, 'person', 'people')}, and none of them need a decision.`;
+
+  const settled = plan.certainMatches
+    ? `<p class="review-settled">${count(plan.certainMatches, 'person is', 'people are')} `
+      + 'recognised outright — their file records where they came from, and it is somebody you '
+      + 'already hold. Those are matched without asking.</p>'
+    : '';
+
+  // Strong first: those merge unless refused, so they are the ones worth reading.
+  const order = { [MatchTier.STRONG]: 0, [MatchTier.WEAK]: 1 };
+  const cards = [...asked]
+    .sort((a, b) => order[a.tier] - order[b.tier])
+    .map(pairCard).join('');
+
+  $('review-body').innerHTML = settled + cards;
+
+  const outcome = () => {
+    const { added, merged } = plan.outcomeUnder(decisions);
+    const parts = [];
+    if (added) parts.push(`add ${count(added, 'person', 'people')}`);
+    if (merged) parts.push(`merge ${count(merged, 'person', 'people')}`);
+    const said = parts.length ? parts.join(' and ') : 'change nothing';
+    $('review-confirm').textContent = parts.length
+      ? said.charAt(0).toUpperCase() + said.slice(1)
+      : 'Close';
+  };
+
+  $('review-body').onclick = (event) => {
+    const button = event.target.closest('button[data-merge]');
+    if (!button) return;
+    const card = button.closest('.pair');
+    const merge = button.dataset.merge === 'yes';
+    decisions.set(card.dataset.id, merge);
+    for (const other of card.querySelectorAll('button[data-merge]')) {
+      other.setAttribute('aria-pressed', String((other.dataset.merge === 'yes') === merge));
+    }
+    outcome();
+  };
+
+  outcome();
+
+  const close = () => { $('review-body').onclick = null; dialog.close(); };
+  $('review-cancel').onclick = close;
+  $('review-confirm').onclick = () => {
+    close();
+    commitImport(plan, decisions, importedPhotos, fileName);
+  };
+
+  $('review-outcome').textContent =
+    'Nothing is written to your file until you save. Undo puts all of it back.';
+
+  dialog.showModal();
+  /*
+   * A dialog focuses its first focusable child, which here is a button inside the first card --
+   * and the browser scrolls it into view, opening the screen already scrolled past the name of
+   * the person being asked about. Focus the heading instead, and start at the top.
+   */
+  $('review-body').scrollTop = 0;
+  $('review-head').focus();
+}
+
+function commitImport(plan, decisions, importedPhotos, fileName) {
+  const result = applyImport({
+    tree: state.tree,
+    plan,
+    decisions,
+    photos: state.photos,
+    importedPhotos,
+    label: `Import ${fileName}`,
+  });
+
+  rebuild({ refit: true });
+  renderPanel();
+
+  const said = [];
+  if (result.peopleAdded) said.push(`Added ${count(result.peopleAdded, 'person', 'people')}`);
+  if (result.peopleMerged) said.push(`merged ${count(result.peopleMerged, 'person', 'people')}`);
+  if (result.relationshipsAdded) {
+    said.push(`added ${count(result.relationshipsAdded, 'connection', 'connections')}`);
+  }
+  if (!said.length) said.push('Nothing changed — everything in that file was already here');
+
+  // Conflicts are not a failure, but they are the one thing somebody might want to go and look
+  // at, so they are said plainly rather than buried in a count.
+  const extra = result.conflicts.length
+    ? `\n${count(result.conflicts.length, 'detail', 'details')} differed and yours were kept.`
+    : '';
+  const refused = result.relationshipsRefused.length
+    ? `\n${count(result.relationshipsRefused.length, 'connection', 'connections')} could not be `
+      + 'added without contradicting your tree.'
+    : '';
+
+  toast(`${said.join(', ')}.${extra}${refused}\nUndo puts this back.`,
+    result.conflicts.length || result.relationshipsRefused.length ? 'warn' : 'good');
+}
+
 /**
  * Only the photos somebody is still referenced by.
  *
@@ -844,6 +1064,7 @@ function wireShell() {
 
   shell.onMenuCommand((command) => {
     if (command === 'file:new') { startNewTree(); return; }
+    if (command === 'file:import') { importTree(); return; }
     if (command === 'file:save') { save(); return; }
     if (command === 'file:saveAs') { save({ as: true }); return; }
     if (command === 'edit:undo') { undo(); return; }

--- a/desktop/renderer/document.js
+++ b/desktop/renderer/document.js
@@ -102,6 +102,11 @@ export class Tree {
     return this.state.relationships.map((r) => Object.freeze({ ...r }));
   }
 
+  /** The tree this file claims to be, in the sense the importer means. See the constructor. */
+  get sourceTreeId() {
+    return this.state.sourceTreeId;
+  }
+
   person(id) {
     const found = this.state.people.find((p) => p.id === id);
     return found ? Object.freeze({ ...found }) : null;
@@ -164,11 +169,15 @@ export class Tree {
    * The snapshot is taken before and only kept if something actually changed, so an edit that
    * sets a name to the name it already had does not put a no-op on the undo stack for somebody
    * to wonder about later.
+   *
+   * `change` is handed the live state as well as closing over it. The methods here predate that
+   * and reach through `this`; an import is written in another file and would otherwise have to
+   * reach into these internals to say what it changed.
    */
   edit(label, change) {
     const before = clone(this.state);
     const beforeSignature = this.signature();
-    const result = change();
+    const result = change(this.state);
     if (result?.ok === false) {
       this.state = before;
       return result;

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -398,3 +398,255 @@
 .editor .index {
   overflow-y: auto;
 }
+
+/* ------------------------------------------------------------------ the import review
+
+   The one screen in the app where confirming does something a person cannot put right by hand.
+   Two records merge into one and the fact that they were ever two is gone, so the design's whole
+   job is to make the judgement checkable before it is taken.
+
+   Hence the card is a *comparison*, not a checkbox beside a name. The decision being asked is
+   "are these two the same person", so the two records are set side by side and the fields that
+   disagree are marked. A list of ticked names would be asking the same question while hiding
+   the evidence needed to answer it. */
+
+.editor .review {
+  width: min(760px, calc(100vw - 48px));
+  max-height: min(84vh, 760px);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  color: var(--ink);
+  background: var(--raised);
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  box-shadow: var(--shadow);
+}
+
+/* One wash, literal rather than tokenised, because it is doing the same job in both themes: it
+   is not the surface's colour, it is the distance between this question and the tree behind it.
+   (Note for anyone checking this in a screenshot: capturePage does not composite the top layer,
+   so the backdrop is absent from captures while being present on screen.) */
+.editor .review::backdrop {
+  background: rgba(10, 28, 18, 0.58);
+  backdrop-filter: blur(2px);
+}
+
+.editor .review-head {
+  padding: 22px 26px 16px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.editor .review-title {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.editor .review-lead {
+  margin: 7px 0 0;
+  max-width: 62ch;
+  font-size: 13.5px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+
+.editor .review-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 18px 26px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+/* A flex child shrinks to fit before its container will scroll, which sliced every card off
+   mid-row -- the evidence and the choice both below the cut. Cards keep their height; the body
+   scrolls instead. */
+.editor .review-body > * { flex: 0 0 auto; }
+
+/* A settled fact, stated once. Not a question, so it does not get a card. */
+.editor .review-settled {
+  margin: 0;
+  padding: 11px 14px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  background: var(--sage-container);
+  border-radius: 9px;
+}
+
+.editor .pair {
+  border: 1px solid var(--rule);
+  border-radius: 11px;
+  overflow: hidden;
+}
+
+/* Strong matches merge unless refused, so they carry the weight the default deserves. */
+.editor .pair[data-tier='STRONG'] { border-color: var(--rule-strong); }
+
+.editor .pair-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 13px 16px 11px;
+  background: var(--bone-dim);
+  border-bottom: 1px solid var(--rule);
+}
+
+.editor .pair-name {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: 17px;
+  font-weight: 600;
+}
+
+.editor .pair-tier {
+  font-size: 12px;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.editor .pair-sides {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--rule);
+}
+
+.editor .side {
+  padding: 13px 16px 14px;
+  background: var(--raised);
+  min-width: 0;
+}
+
+.editor .side-of {
+  margin: 0 0 9px;
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  color: var(--ink-faint);
+}
+
+.editor .side dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 4px 12px;
+  font-size: 13px;
+}
+
+.editor .side dt { color: var(--ink-faint); }
+.editor .side dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.editor .side dd.empty { color: var(--ink-faint); font-style: italic; }
+
+/* Where the two records disagree. Marked because it is the reason to look twice, and because a
+   merge keeps the local value -- so this is also the only warning that theirs will be set aside. */
+.editor .side dd.differs {
+  color: var(--brass);
+  font-weight: 600;
+}
+
+.editor .pair-why {
+  margin: 0;
+  padding: 11px 16px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--ink-soft);
+  background: var(--raised);
+  border-top: 1px solid var(--rule);
+}
+
+.editor .pair-choice {
+  display: flex;
+  gap: 8px;
+  padding: 0 16px 14px;
+  background: var(--raised);
+}
+
+.editor .pair-choice button {
+  font: inherit;
+  font-size: 13px;
+  padding: 7px 14px;
+  color: var(--ink-soft);
+  background: none;
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.editor .pair-choice button:hover { background: var(--bone-dim); }
+
+.editor .pair-choice button[aria-pressed='true'] {
+  color: var(--on-forest);
+  background: var(--forest);
+  border-color: var(--forest);
+}
+
+.editor .pair-choice button:focus-visible {
+  outline: 2px solid var(--accent, #c56a3a);
+  outline-offset: 2px;
+}
+
+.editor .review-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 26px;
+  border-top: 1px solid var(--rule);
+  background: var(--bone-dim);
+  border-radius: 0 0 13px 13px;
+}
+
+/* What the button is about to do, in the same words the button uses. */
+.editor .review-outcome {
+  margin: 0;
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.editor .review-actions { display: flex; gap: 10px; }
+
+@media (max-width: 620px) {
+  .editor .pair-sides { grid-template-columns: 1fr; }
+  .editor .review-foot { flex-direction: column; align-items: stretch; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .editor .review[open] { animation: review-in 140ms ease-out; }
+}
+
+@keyframes review-in {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: none; }
+}
+
+/* Something worth reading, that is not a failure. An import whose details disagreed did the job
+   it was asked to do, so it is told in brass rather than in the colour of a refusal. */
+.editor .toast[data-tone='warn'] {
+  color: var(--ink);
+  background: var(--brass-surface);
+  border: 1px solid var(--brass);
+  border-radius: 12px;
+  white-space: pre-line;
+  text-align: left;
+  line-height: 1.5;
+}
+
+/* Mono is right for the chrome's short labels -- Fit, Save, 100% -- and wrong for a button that
+   states a sentence. These two say what is about to happen, so they are set in the reading face. */
+.editor .review-actions .btn { font-family: inherit; font-size: 13.5px; padding: 11px 20px; }
+
+.editor .review-head:focus-visible { outline: none; }
+
+.editor .side-bare { margin: 0; font-size: 13px; color: var(--ink-faint); font-style: italic; }
+
+/* The platform scrollbar sits on top of the cards and is heavier than anything else on screen. */
+.editor .review-body {
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule-strong) transparent;
+}

--- a/desktop/renderer/import.js
+++ b/desktop/renderer/import.js
@@ -1,0 +1,373 @@
+/*
+ * Reading somebody else's `.ftree` into the tree that is already open.
+ *
+ * A port of `transfer/TreeImporter.kt`, and it keeps that file's governing rule exactly:
+ *
+ *     an import adds, it never replaces.
+ *
+ * Nothing already here is deleted and no value already written is overwritten. The worst this can
+ * do is add people who turn out to be duplicates, which somebody can then merge by hand. The
+ * opposite mistake -- silently collapsing two real people into one -- cannot be undone by hand,
+ * because the information that they were ever two people is gone.
+ *
+ * Two halves, and the split is the whole safety story: `planImport` reads and judges and changes
+ * nothing, `applyImport` writes, once, using decisions somebody has actually seen.
+ *
+ * Where this deliberately differs from the phone: the Android importer writes a backup file first,
+ * because it commits into a database the moment it is told to. Here the tree is in memory and no
+ * file is touched until somebody saves, so the import goes through `tree.edit` as a single
+ * undoable step. Ctrl+Z puts the tree back exactly as it was, and closing without saving leaves
+ * the file on disk untouched. That is a stronger promise than a backup, and a cheaper one.
+ */
+
+import { matchPeople, graphOf, originKey, MatchTier, mergesByDefault, needsReview }
+  from './matching.js';
+import { RelationshipType, Rejection, checkRelationship, relationshipTypeFrom } from './rules.js';
+
+/** A file that cannot be imported, with a reason worth showing somebody. */
+export class ImportRefused extends Error {}
+
+const isBlank = (value) => value == null || String(value).trim() === '';
+
+/**
+ * What importing this document *would* do. Writes nothing, changes nothing.
+ *
+ * @param {object} args
+ * @param {object} args.document  the parsed exchange document, as `archive.js` returns it
+ * @param {import('./document.js').Tree} args.tree  the tree currently open
+ * @param {string} args.ownTreeId  this installation's id
+ */
+export function planImport({ document, tree, ownTreeId = '' }) {
+  // `parseDocument` has already refused the wrong format and a version from the future, which are
+  // the two refusals that must happen before anything here trusts a field. This adds the third.
+  if (!document.people?.length) {
+    throw new ImportRefused('That file has nobody in it, so there is nothing to import.');
+  }
+
+  const local = tree.people;
+
+  /*
+   * Where each local person has been known by before.
+   *
+   * Two sources. Origins recorded by previous imports are the ordinary one. The second is the
+   * identity rule: a file exported by *this* installation names its people by ids this tree still
+   * uses, so re-importing our own export recognises everybody outright, with no name comparison
+   * at all. Getting that wrong in the safe direction merely proposes duplicates; getting it wrong
+   * in the unsafe direction would merge strangers, so it is keyed on an id, never on a name.
+   */
+  const originIndex = new Map();
+  for (const person of local) {
+    for (const origin of person.origins ?? []) {
+      originIndex.set(originKey(origin.treeId, origin.personId), person.id);
+    }
+  }
+  if (ownTreeId && document.sourceTreeId === ownTreeId) {
+    for (const person of local) originIndex.set(originKey(ownTreeId, person.id), person.id);
+  }
+
+  const importedGraph = graphOf((document.relationships ?? []).map((r) => [r.from, r.to]));
+  const localGraph = graphOf(tree.relationships.map((r) => [r.from, r.to]));
+
+  const found = matchPeople({
+    imported: document.people,
+    importedGraph,
+    local,
+    localGraph,
+    originIndex,
+    sourceTreeId: document.sourceTreeId ?? '',
+  });
+
+  /*
+   * The evidence, in the terms somebody deciding would use.
+   *
+   * `sharedRelatives` counts; this names them. A strong match merges by default, so the screen
+   * that says so has to be able to answer "why do you think that?" with something checkable --
+   * "you both have Priya and Sunita" is an argument a person can agree or disagree with, where
+   * "2 relatives in common" is only an assertion.
+   */
+  const localById = new Map(local.map((p) => [p.id, p]));
+  const importedById = new Map(document.people.map((p) => [p.id, p]));
+  const settledLocal = new Map(
+    found.filter((m) => m.localId != null).map((m) => [m.importedId, m.localId]));
+
+  const matches = found.map((match) => {
+    if (match.localId == null) return { ...match, shared: [], theirs: importedById.get(match.importedId) ?? null, mine: null };
+    const neighbours = localGraph.get(match.localId) ?? new Set();
+    const shared = [];
+    for (const neighbour of importedGraph.get(match.importedId) ?? new Set()) {
+      const asLocal = settledLocal.get(neighbour);
+      if (asLocal != null && neighbours.has(asLocal)) {
+        shared.push(localById.get(asLocal)?.name ?? 'someone unnamed');
+      }
+    }
+    return {
+      ...match,
+      shared,
+      theirs: importedById.get(match.importedId) ?? null,
+      mine: localById.get(match.localId) ?? null,
+    };
+  });
+
+  const byImportedId = new Map(matches.map((m) => [m.importedId, m]));
+
+  return {
+    document,
+    matches,
+    matchFor: (importedId) => byImportedId.get(importedId) ?? null,
+
+    /** The ones worth interrupting somebody for. A provable match is not a question. */
+    reviewable: matches.filter(needsReview),
+    certainMatches: matches.filter((m) => m.tier === MatchTier.CERTAIN).length,
+
+    /** What happens if nobody touches anything. */
+    defaultDecisions: new Map(
+      matches.filter((m) => m.localId != null).map((m) => [m.importedId, mergesByDefault(m)])),
+
+    /** So the confirm button can say what it is about to do, before it does it. */
+    outcomeUnder(decisions) {
+      let merged = 0;
+      for (const match of matches) if (decisions.get(match.importedId) === true) merged += 1;
+      return { added: matches.length - merged, merged };
+    },
+  };
+}
+
+/**
+ * Fills one person's gaps from an imported record.
+ *
+ * Never overwrites. An empty field takes the imported value; a field that already says something
+ * keeps saying it; a disagreement is reported rather than resolved. The person at this machine is
+ * the authority on their own family, and a file from a cousin is not grounds for overruling them.
+ */
+function filledFrom(mine, record, photoEntry) {
+  const conflicts = [];
+  const filled = { ...mine };
+
+  const pick = (field, label) => {
+    const ours = mine[field];
+    const theirs = record[field];
+    if (isBlank(ours)) { if (!isBlank(theirs)) filled[field] = theirs; return; }
+    if (isBlank(theirs) || String(ours) === String(theirs)) return;
+    conflicts.push({ person: mine.name ?? record.name ?? null, field: label, kept: String(ours), ignored: String(theirs) });
+  };
+
+  pick('name', 'name');
+  pick('birthDate', 'born');
+  pick('deathDate', 'died');
+  pick('notes', 'notes');
+
+  // Not run through `pick`: an unset gender is written as a value rather than left absent, so
+  // "nobody said" and "somebody said unspecified" look identical here and neither is a conflict.
+  if (isBlank(mine.gender) || mine.gender === 'UNSPECIFIED') {
+    if (!isBlank(record.gender)) filled.gender = record.gender;
+  }
+
+  /*
+   * Once true, stays true -- nobody stops being dead because a second file forgot to say so.
+   *
+   * Only written when it becomes true. Assigning `false` to somebody who simply never had the
+   * field adds a key, which changes the tree's signature, which makes a re-import of an unchanged
+   * file report unsaved work and ask to save a file identical to the one on disk.
+   */
+  if (Boolean(record.deceased) && !mine.deceased) filled.deceased = true;
+
+  if (isBlank(mine.photo) && photoEntry) filled.photo = photoEntry;
+
+  return { filled, conflicts };
+}
+
+/** An archive entry name that is not already taken, keeping the original where it is free. */
+function freePhotoName(taken, entry) {
+  if (!taken.has(entry)) return entry;
+  const match = /^(photos\/)(.*?)(\.[^.]*)?$/.exec(entry) ?? [];
+  const [, dir = 'photos/', stem = 'photo', extension = ''] = match;
+  for (let n = 2; ; n += 1) {
+    const candidate = `${dir}${stem}-${n}${extension}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * Applies a reviewed plan, as one undoable edit.
+ *
+ * @param {object} args
+ * @param {import('./document.js').Tree} args.tree  changed in place
+ * @param {object} args.plan  from `planImport`
+ * @param {Map<string, boolean>} args.decisions  imported id to "merge into the local person"
+ * @param {Map<string, Uint8Array>} args.photos  the open tree's photos, added to in place
+ * @param {Map<string, Uint8Array>} args.importedPhotos  photos read out of the imported archive
+ * @param {string} args.label  what the undo entry should say
+ */
+export function applyImport({ tree, plan, decisions, photos = new Map(),
+  importedPhotos = new Map(), label = 'Import' }) {
+  const document = plan.document;
+  const result = {
+    peopleAdded: 0,
+    peopleMerged: 0,
+    relationshipsAdded: 0,
+    relationshipsAlreadyPresent: 0,
+    photosAdded: 0,
+    conflicts: [],
+    relationshipsRefused: [],
+  };
+
+  tree.edit(label, (state) => {
+    const byId = new Map(state.people.map((p) => [p.id, p]));
+
+    /*
+     * Every imported person resolved to a local id before anything is written.
+     *
+     * Somebody not being merged gets a *freshly generated* id rather than the one in the file: an
+     * imported id is only unique within the tree it came from, and here it could already belong to
+     * a different person entirely.
+     */
+    const idMap = new Map();
+    const merging = new Map();
+    const arriving = [];
+
+    for (const record of document.people) {
+      const match = plan.matchFor(record.id);
+      const localId = decisions.get(record.id) === true ? match?.localId ?? null : null;
+      if (localId != null && byId.has(localId)) {
+        idMap.set(record.id, localId);
+        merging.set(record.id, localId);
+      } else {
+        const fresh = crypto.randomUUID();
+        idMap.set(record.id, fresh);
+        arriving.push([record, fresh]);
+      }
+    }
+
+    // Photos first, and under names that cannot collide with ones already held.
+    const photoFor = new Map();
+    for (const record of document.people) {
+      const entry = record.photo;
+      if (!entry || !importedPhotos.has(entry)) continue;
+      const name = freePhotoName(photos, entry);
+      photos.set(name, importedPhotos.get(entry));
+      photoFor.set(record.id, name);
+      result.photosAdded += 1;
+    }
+
+    /*
+     * Provenance for everybody, merged and new alike.
+     *
+     * This is what makes the *next* import of a related file a lookup instead of a judgement, so
+     * it is recorded even when the match was certain and nothing else changed.
+     */
+    const originsFor = (record, localId) => {
+      const from = document.sourceTreeId ?? '';
+      const origins = [];
+      /*
+       * An origin that only restates the identity rule is not recorded: our own export, naming
+       * our own person by the id they still have here. It would be true and useless, and writing
+       * it would leave a re-import of our own file reporting unsaved work.
+       */
+      const restatesIdentity = from && from === tree.sourceTreeId && record.id === localId;
+      if (!restatesIdentity) origins.push({ treeId: from, personId: record.id });
+      for (const origin of record.origins ?? []) origins.push({ ...origin });
+      return origins;
+    };
+    const withOrigins = (existing, record, localId) => {
+      const seen = new Set((existing ?? []).map((o) => originKey(o.treeId, o.personId)));
+      const merged = [...(existing ?? [])];
+      for (const origin of originsFor(record, localId)) {
+        const key = originKey(origin.treeId, origin.personId);
+        if (origin.treeId && !seen.has(key)) { seen.add(key); merged.push(origin); }
+      }
+      // Absent rather than empty: an `origins: []` on somebody who has no recorded provenance is
+      // a key that says nothing, and adding one is enough to report the tree as changed.
+      return merged.length ? { origins: merged } : {};
+    };
+
+    for (const [record, fresh] of arriving) {
+      const { origins, id, photo, ...fields } = record;
+      state.people.push({
+        ...fields,
+        id: fresh,
+        ...(photoFor.has(record.id) ? { photo: photoFor.get(record.id) } : {}),
+        ...withOrigins([], record, fresh),
+      });
+      result.peopleAdded += 1;
+    }
+
+    for (const [importedId, localId] of merging) {
+      const record = document.people.find((p) => p.id === importedId);
+      const at = state.people.findIndex((p) => p.id === localId);
+      if (at < 0) continue;
+      const { filled, conflicts } = filledFrom(state.people[at], record, photoFor.get(importedId));
+      state.people[at] = { ...filled, ...withOrigins(state.people[at].origins, record, localId) };
+      result.conflicts.push(...conflicts);
+      result.peopleMerged += 1;
+    }
+
+    /*
+     * Every imported connection is put to the same rules that govern one added by hand.
+     *
+     * A deliberate divergence from the Kotlin, which inserts edges and lets the database drop
+     * exact duplicates. That is not enough here, for two reasons. A symmetric edge arriving the
+     * other way round -- they hold B is a spouse of A, we hold A is a spouse of B -- is the same
+     * connection, and a literal duplicate check counts it as new. And merging is what makes
+     * cycles reachable: two imported people collapsing onto one local person can close a line
+     * where somebody becomes their own ancestor, which no hand edit is allowed to create and
+     * which the layout has never had to survive.
+     *
+     * Refused connections are counted and reported, never dropped quietly.
+     */
+    const edgeKey = (from, to, type) => [from, to, type].join('\u0000');
+    const edges = new Set(state.relationships.map((r) => edgeKey(r.from, r.to, r.type)));
+    const parents = new Map();
+    for (const edge of state.relationships) {
+      if (edge.type !== RelationshipType.PARENT) continue;
+      if (!parents.has(edge.to)) parents.set(edge.to, []);
+      parents.get(edge.to).push(edge.from);
+    }
+
+    for (const record of document.relationships ?? []) {
+      const from = idMap.get(record.from);
+      const to = idMap.get(record.to);
+      if (from == null || to == null) continue;
+
+      const type = relationshipTypeFrom(record.type);
+      if (!type) {
+        result.relationshipsRefused.push({ reason: 'UNKNOWN_TYPE', type: record.type });
+        continue;
+      }
+
+      const verdict = checkRelationship({
+        from,
+        to,
+        type,
+        existingEdgeExists: (f, t, ty) => edges.has(edgeKey(f, t, ty)),
+        parentsOf: (who) => parents.get(who) ?? [],
+      });
+
+      if (!verdict.allowed) {
+        // Two imported people merged onto one local person is the ordinary way a self-edge or a
+        // duplicate arrives, so neither of those is a fault worth reporting as one.
+        if (verdict.reason === Rejection.DUPLICATE || verdict.reason === Rejection.SELF_REFERENCE) {
+          result.relationshipsAlreadyPresent += 1;
+        } else {
+          result.relationshipsRefused.push({ reason: verdict.reason, from, to, type });
+        }
+        continue;
+      }
+
+      edges.add(edgeKey(from, to, type));
+      if (type === RelationshipType.PARENT) {
+        if (!parents.has(to)) parents.set(to, []);
+        parents.get(to).push(from);
+      }
+      state.relationships.push({
+        id: crypto.randomUUID(),
+        from,
+        to,
+        type,
+        ...(record.subtype ? { subtype: record.subtype } : {}),
+      });
+      result.relationshipsAdded += 1;
+    }
+  });
+
+  return result;
+}

--- a/desktop/renderer/import.test.js
+++ b/desktop/renderer/import.test.js
@@ -1,0 +1,395 @@
+/*
+ * TreeImporterTest.kt, for a tree held in memory rather than a database.
+ *
+ * Every case the Kotlin's instrumented test makes is made here, in its own terms. Two are not:
+ * `aFileThatIsNotAnArchiveIsRefused` and `aFileFromANewerVersionIsRefusedRatherThanPartlyUnderstood`
+ * belong to `parseDocument` in `archive.js`, which refuses both before an import ever sees them,
+ * and re-asserting them here would test a function this file does not call.
+ *
+ * The backup cases are replaced rather than dropped. The phone writes a backup file because it
+ * commits to a database the moment it is told to; here an import is one `tree.edit`, so the same
+ * promise -- "backing out leaves the tree untouched" -- is kept by undo, and is tested as that.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { Tree } from './document.js';
+import { planImport, applyImport, ImportRefused } from './import.js';
+import { MatchTier } from './matching.js';
+
+const OTHER_TREE = 'tree-from-a-cousin';
+const MY_TREE = 'tree-of-mine';
+
+/** A document in the exchange shape, as `archive.js` would hand one over. */
+function document({ sourceTreeId = OTHER_TREE, people = [], relationships = [] }) {
+  return { format: 'f-tree', version: 1, exportedAt: '', sourceTreeId, people, relationships };
+}
+
+const person = (id, name, fields = {}) => ({ id, name, ...fields });
+const parentOf = (from, to) => ({ id: `${from}-${to}`, from, to, type: 'PARENT' });
+const spouseOf = (from, to) => ({ id: `${from}-${to}`, from, to, type: 'SPOUSE' });
+
+/** A tree with somebody in it, built the way the app builds one. */
+function treeWith(people, relationships = []) {
+  const tree = new Tree({ sourceTreeId: MY_TREE, people, relationships }, { ownTreeId: MY_TREE });
+  tree.markSaved();
+  return tree;
+}
+
+/** Plan and apply in one go, taking every default decision, as confirming without touching does. */
+function importInto(tree, doc, { ownTreeId = MY_TREE, decisions = null } = {}) {
+  const plan = planImport({ document: doc, tree, ownTreeId });
+  return {
+    plan,
+    result: applyImport({ tree, plan, decisions: decisions ?? plan.defaultDecisions }),
+  };
+}
+
+const namesIn = (tree) => tree.people.map((p) => p.name).sort();
+
+test('importing into an empty tree reproduces the original', () => {
+  const tree = treeWith([]);
+  const doc = document({
+    people: [person('a', 'Asha'), person('b', 'Bhim')],
+    relationships: [parentOf('a', 'b')],
+  });
+
+  const { result } = importInto(tree, doc);
+
+  assert.strictEqual(result.peopleAdded, 2);
+  assert.strictEqual(result.peopleMerged, 0);
+  assert.strictEqual(result.relationshipsAdded, 1);
+  assert.deepStrictEqual(namesIn(tree), ['Asha', 'Bhim']);
+
+  // The shape survived, not just the count: the edge still joins the same two people.
+  const [edge] = tree.relationships;
+  const byName = new Map(tree.people.map((p) => [p.id, p.name]));
+  assert.strictEqual(byName.get(edge.from), 'Asha');
+  assert.strictEqual(byName.get(edge.to), 'Bhim');
+});
+
+test('my own people are not touched by an import', () => {
+  const tree = treeWith([person('mine', 'Asha', { birthDate: '1970', notes: 'my note' })]);
+  const doc = document({
+    people: [person('theirs', 'Asha', { birthDate: '1970', notes: 'their note' })],
+  });
+
+  importInto(tree, doc);
+
+  const asha = tree.people.find((p) => p.name === 'Asha');
+  assert.strictEqual(asha.notes, 'my note', 'an imported value overwrote one already here');
+  assert.strictEqual(asha.birthDate, '1970');
+});
+
+test('importing the same file twice changes nothing the second time', () => {
+  const tree = treeWith([]);
+  const doc = document({
+    people: [person('a', 'Asha'), person('b', 'Bhim')],
+    relationships: [parentOf('a', 'b')],
+  });
+
+  importInto(tree, doc);
+  const afterFirst = tree.signature();
+
+  const { result } = importInto(tree, doc);
+
+  assert.strictEqual(result.peopleAdded, 0, 'the second import added somebody again');
+  assert.strictEqual(result.peopleMerged, 2);
+  assert.strictEqual(result.relationshipsAdded, 0);
+  assert.strictEqual(result.relationshipsAlreadyPresent, 1);
+  assert.strictEqual(tree.signature(), afterFirst, 'the second import changed the tree');
+});
+
+test('re-importing my own export is a no-op', () => {
+  // The identity rule: a file this installation wrote names people by ids this tree still uses,
+  // so everybody is matched outright without a single name being compared.
+  const tree = treeWith([person('p1', 'Asha'), person('p2', 'Bhim')], [parentOf('p1', 'p2')]);
+  const doc = document({
+    sourceTreeId: MY_TREE,
+    people: [person('p1', 'Asha'), person('p2', 'Bhim')],
+    relationships: [parentOf('p1', 'p2')],
+  });
+
+  const before = tree.signature();
+  const { plan, result } = importInto(tree, doc);
+
+  assert.ok(plan.matches.every((m) => m.tier === MatchTier.CERTAIN));
+  assert.strictEqual(result.peopleAdded, 0);
+  assert.strictEqual(tree.signature(), before);
+});
+
+test('a merge fills gaps and never overwrites', () => {
+  const tree = treeWith([
+    person('mine', 'Asha', { birthDate: '1970', notes: 'kept', deceased: false }),
+  ]);
+  const doc = document({
+    sourceTreeId: MY_TREE,
+    people: [person('mine', 'Asha', {
+      birthDate: '1971', deathDate: '2001', notes: 'ignored', gender: 'FEMALE', deceased: true,
+    })],
+  });
+
+  const { result } = importInto(tree, doc);
+  const asha = tree.person(tree.people[0].id);
+
+  assert.strictEqual(result.peopleMerged, 1);
+  assert.strictEqual(asha.birthDate, '1970', 'a filled field was overwritten');
+  assert.strictEqual(asha.notes, 'kept');
+  assert.strictEqual(asha.deathDate, '2001', 'an empty field was not filled');
+  assert.strictEqual(asha.gender, 'FEMALE', 'an unset gender was not filled');
+  assert.strictEqual(asha.deceased, true, 'deceased did not stay true once set');
+
+  // Disagreements are reported rather than resolved, so nothing is lost silently.
+  assert.deepStrictEqual(
+    result.conflicts.map((c) => [c.field, c.kept, c.ignored]).sort(),
+    [['born', '1970', '1971'], ['notes', 'kept', 'ignored']]);
+});
+
+test('a weak match is kept separate unless asked for', () => {
+  const tree = treeWith([person('mine', 'Asha')]);
+  const doc = document({ people: [person('theirs', 'Asha')] });
+
+  const plan = planImport({ document: doc, tree, ownTreeId: MY_TREE });
+  const [match] = plan.matches;
+  assert.strictEqual(match.tier, MatchTier.WEAK);
+  assert.strictEqual(plan.defaultDecisions.get('theirs'), false, 'a weak match merged by default');
+
+  applyImport({ tree, plan, decisions: plan.defaultDecisions });
+  assert.strictEqual(tree.people.length, 2, 'two people with one name were silently combined');
+
+  // ...and merged when it is asked for.
+  const second = treeWith([person('mine', 'Asha')]);
+  const secondPlan = planImport({ document: doc, tree: second, ownTreeId: MY_TREE });
+  applyImport({ tree: second, plan: secondPlan, decisions: new Map([['theirs', true]]) });
+  assert.strictEqual(second.people.length, 1);
+});
+
+test("the wife's family joins mine through the person we share", () => {
+  /*
+   * The case the whole matcher exists for. Her file holds her, her father and her mother; mine
+   * holds her and me. She matches on name, and once she is settled her parents arrive as new
+   * people attached to the person we both know -- not as a second disconnected family.
+   */
+  const tree = treeWith(
+    [person('me', 'Ankit'), person('her', 'Priya')],
+    [spouseOf('me', 'her')]);
+  const doc = document({
+    people: [person('w', 'Priya'), person('f', 'Rajesh'), person('m', 'Sunita')],
+    relationships: [parentOf('f', 'w'), parentOf('m', 'w'), spouseOf('f', 'm')],
+  });
+
+  const plan = planImport({ document: doc, tree, ownTreeId: MY_TREE });
+  // She is only a weak match on her own -- one name, nothing corroborating it -- so the merge is
+  // a decision somebody makes. That is the point of the review screen.
+  applyImport({ tree, plan, decisions: new Map([['w', true]]) });
+
+  assert.deepStrictEqual(namesIn(tree), ['Ankit', 'Priya', 'Rajesh', 'Sunita']);
+
+  const byName = new Map(tree.people.map((p) => [p.name, p.id]));
+  const parents = tree.parentsOf(byName.get('Priya')).sort();
+  assert.deepStrictEqual(
+    parents.map((id) => tree.person(id).name).sort(), ['Rajesh', 'Sunita'],
+    'her parents did not attach to the Priya we already had');
+});
+
+test('imported ids are remapped so they cannot collide', () => {
+  // Both files call somebody "p1", and they are different people. Reusing the id would overwrite
+  // mine or attach their relationships to him.
+  const tree = treeWith([person('p1', 'Asha')]);
+  const doc = document({ people: [person('p1', 'Bhim')] });
+
+  importInto(tree, doc);
+
+  assert.deepStrictEqual(namesIn(tree), ['Asha', 'Bhim']);
+  const bhim = tree.people.find((p) => p.name === 'Bhim');
+  assert.notStrictEqual(bhim.id, 'p1', 'an imported id was reused as-is');
+  assert.strictEqual(tree.person('p1').name, 'Asha');
+});
+
+test('a relationship already recorded is not duplicated', () => {
+  const tree = treeWith([person('p1', 'Asha'), person('p2', 'Bhim')], [parentOf('p1', 'p2')]);
+  const doc = document({
+    sourceTreeId: MY_TREE,
+    people: [person('p1', 'Asha'), person('p2', 'Bhim')],
+    relationships: [parentOf('p1', 'p2')],
+  });
+
+  const { result } = importInto(tree, doc);
+
+  assert.strictEqual(result.relationshipsAdded, 0);
+  assert.strictEqual(result.relationshipsAlreadyPresent, 1);
+  assert.strictEqual(tree.relationships.length, 1);
+});
+
+test('a symmetric connection recorded the other way round is not duplicated', () => {
+  /*
+   * Added here, and not in the Kotlin, because the desktop refuses it for a reason the phone does
+   * not have. "A is a spouse of B" and "B is a spouse of A" are one connection stored in one
+   * direction, so a literal duplicate check sees two. The phone's database sees two as well.
+   */
+  const tree = treeWith([person('p1', 'Asha'), person('p2', 'Bhim')], [spouseOf('p1', 'p2')]);
+  const doc = document({
+    sourceTreeId: MY_TREE,
+    people: [person('p1', 'Asha'), person('p2', 'Bhim')],
+    relationships: [spouseOf('p2', 'p1')],
+  });
+
+  const { result } = importInto(tree, doc);
+
+  assert.strictEqual(result.relationshipsAdded, 0, 'the same marriage was recorded twice');
+  assert.strictEqual(result.relationshipsAlreadyPresent, 1);
+  assert.strictEqual(tree.relationships.length, 1);
+});
+
+test('a connection that would make somebody their own ancestor is refused, not written', () => {
+  /*
+   * Added here. Merging is what makes this reachable: their file says Asha's parent is Bhim,
+   * mine says Bhim's parent is Asha, and merging both pairs closes the loop. No hand edit can
+   * create this, and the layout has never had to survive it.
+   */
+  const tree = treeWith([person('a', 'Asha'), person('b', 'Bhim')], [parentOf('a', 'b')]);
+  const doc = document({
+    sourceTreeId: MY_TREE,
+    people: [person('a', 'Asha'), person('b', 'Bhim')],
+    relationships: [parentOf('b', 'a')],
+  });
+
+  const { result } = importInto(tree, doc);
+
+  assert.strictEqual(result.relationshipsAdded, 0);
+  assert.deepStrictEqual(result.relationshipsRefused.map((r) => r.reason), ['ANCESTOR_CYCLE']);
+  assert.strictEqual(tree.relationships.length, 1, 'a cycle was written into the tree');
+});
+
+test('unknown people arrive as real nodes, not placeholders', () => {
+  const tree = treeWith([person('mine', 'Asha')]);
+  const doc = document({
+    people: [person('x', 'Chandra', { birthDate: '1955', gender: 'MALE', notes: 'a note' })],
+  });
+
+  importInto(tree, doc);
+
+  const chandra = tree.people.find((p) => p.name === 'Chandra');
+  assert.ok(chandra, 'the new person is not in the tree');
+  assert.strictEqual(chandra.birthDate, '1955');
+  assert.strictEqual(chandra.gender, 'MALE');
+  assert.strictEqual(chandra.notes, 'a note');
+});
+
+test('a file with nobody in it is refused', () => {
+  const tree = treeWith([person('mine', 'Asha')]);
+  assert.throws(
+    () => planImport({ document: document({ people: [] }), tree, ownTreeId: MY_TREE }),
+    ImportRefused);
+});
+
+test('planning changes nothing at all', () => {
+  const tree = treeWith([person('mine', 'Asha')]);
+  const before = tree.signature();
+
+  planImport({
+    document: document({ people: [person('a', 'Asha'), person('b', 'Bhim')] }),
+    tree,
+    ownTreeId: MY_TREE,
+  });
+
+  assert.strictEqual(tree.signature(), before, 'planning an import modified the tree');
+  assert.strictEqual(tree.isDirty, false);
+});
+
+test('backing out of an import leaves the tree untouched', () => {
+  // The phone writes a backup file for this. Here it is one edit, so undo is the whole promise.
+  const tree = treeWith([person('mine', 'Asha')], []);
+  const before = tree.signature();
+
+  importInto(tree, document({
+    people: [person('a', 'Bhim'), person('b', 'Chandra')],
+    relationships: [parentOf('a', 'b')],
+  }));
+  assert.notStrictEqual(tree.signature(), before);
+
+  const undone = tree.undo();
+
+  assert.strictEqual(undone.ok, true);
+  assert.strictEqual(tree.signature(), before, 'undoing an import did not restore the tree');
+  assert.deepStrictEqual(namesIn(tree), ['Asha']);
+});
+
+test('a whole import is one step on the undo stack, not one per person', () => {
+  const tree = treeWith([person('mine', 'Asha')]);
+  importInto(tree, document({
+    people: [person('a', 'Bhim'), person('b', 'Chandra'), person('c', 'Devi')],
+    relationships: [parentOf('a', 'b'), parentOf('a', 'c')],
+  }));
+
+  tree.undo();
+  assert.strictEqual(tree.canUndo, false, 'an import left more than one step to undo');
+});
+
+test('origins are recorded for everybody, so the next import is a lookup', () => {
+  const tree = treeWith([]);
+  const doc = document({ people: [person('a', 'Asha')] });
+
+  importInto(tree, doc);
+  const asha = tree.people[0];
+  assert.deepStrictEqual(asha.origins, [{ treeId: OTHER_TREE, personId: 'a' }]);
+
+  // A second file from the same tree now matches her by provenance rather than by her name.
+  const second = document({ people: [person('a', 'Asha Kumari')] });
+  const plan = planImport({ document: second, tree, ownTreeId: MY_TREE });
+  assert.strictEqual(plan.matches[0].tier, MatchTier.CERTAIN,
+    'a person known by origin was not recognised on the next import');
+});
+
+test("origins already on an imported record are carried across, not dropped", () => {
+  // Her file records that she originally came from a third tree. Losing that would make the next
+  // import from *that* tree a name guess instead of a fact.
+  const tree = treeWith([]);
+  const doc = document({
+    people: [person('a', 'Asha', { origins: [{ treeId: 'grandmothers-tree', personId: 'g1' }] })],
+  });
+
+  importInto(tree, doc);
+
+  assert.deepStrictEqual(tree.people[0].origins, [
+    { treeId: OTHER_TREE, personId: 'a' },
+    { treeId: 'grandmothers-tree', personId: 'g1' },
+  ]);
+});
+
+test('photos arrive under names that cannot overwrite one already held', () => {
+  const tree = treeWith([person('mine', 'Asha', { photo: 'photos/1.jpg' })]);
+  const photos = new Map([['photos/1.jpg', new Uint8Array([1, 1, 1])]]);
+  const doc = document({ people: [person('x', 'Bhim', { photo: 'photos/1.jpg' })] });
+
+  const plan = planImport({ document: doc, tree, ownTreeId: MY_TREE });
+  const result = applyImport({
+    tree,
+    plan,
+    decisions: plan.defaultDecisions,
+    photos,
+    importedPhotos: new Map([['photos/1.jpg', new Uint8Array([2, 2, 2])]]),
+  });
+
+  assert.strictEqual(result.photosAdded, 1);
+  assert.deepStrictEqual([...photos.get('photos/1.jpg')], [1, 1, 1], "Asha's photo was overwritten");
+  const bhim = tree.people.find((p) => p.name === 'Bhim');
+  assert.notStrictEqual(bhim.photo, 'photos/1.jpg');
+  assert.deepStrictEqual([...photos.get(bhim.photo)], [2, 2, 2]);
+});
+
+test('the plan says what confirming would do before it is confirmed', () => {
+  const tree = treeWith([person('mine', 'Asha')]);
+  const doc = document({ people: [person('a', 'Asha'), person('b', 'Bhim')] });
+
+  const plan = planImport({ document: doc, tree, ownTreeId: MY_TREE });
+
+  assert.deepStrictEqual(plan.outcomeUnder(plan.defaultDecisions), { added: 2, merged: 0 });
+  assert.deepStrictEqual(plan.outcomeUnder(new Map([['a', true]])), { added: 1, merged: 1 });
+
+  // And the count it promised is the count it delivers.
+  const result = applyImport({ tree, plan, decisions: new Map([['a', true]]) });
+  assert.strictEqual(result.peopleAdded, 1);
+  assert.strictEqual(result.peopleMerged, 1);
+});

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -175,6 +175,28 @@
     </div>
   </footer>
 
+  <!--
+    Deciding which people in two files are the same person.
+
+    A dialog and not a panel: this is the one moment in the app where confirming does something
+    that cannot be put right by hand, so it takes the screen and asks. Native <dialog>, for the
+    focus trap and Escape that a div would have to reimplement and get wrong.
+  -->
+  <dialog class="review" id="review" aria-labelledby="review-title">
+    <div class="review-head" id="review-head" tabindex="-1">
+      <h2 class="review-title" id="review-title"></h2>
+      <p class="review-lead" id="review-lead"></p>
+    </div>
+    <div class="review-body" id="review-body"></div>
+    <div class="review-foot">
+      <p class="review-outcome" id="review-outcome" aria-live="polite"></p>
+      <div class="review-actions">
+        <button type="button" class="btn quiet" id="review-cancel">Cancel</button>
+        <button type="button" class="btn primary" id="review-confirm">Import</button>
+      </div>
+    </div>
+  </dialog>
+
   <!-- Said once, where the eye already is, and gone again. Never a dialog for a saved file. -->
   <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
 </div>

--- a/tools/make_sample_tree.py
+++ b/tools/make_sample_tree.py
@@ -269,6 +269,36 @@ def large(count=2000):
     return t, {}
 
 
+def cousins():
+    """
+    A relative's file that overlaps the tree the desktop smoke test builds by hand.
+
+    It has to overlap on *names* and not on provenance: this is the ordinary case, where two people
+    recorded the same family on two machines that have never met. Shyam Lal matches on his name
+    alone, which is only a weak claim; Ravi matches on his name *and* on having Shyam as a parent
+    in both files, which is what makes a strong one. One of each is what the review dialog exists
+    to tell apart, so the fixture produces one of each on purpose.
+
+    The birth years *agree* deliberately, and the notes disagree. Two different birth years are not
+    a weak signal, they are a veto -- the matcher rules the pairing out entirely, which is the whole
+    point of PartialDate.isCompatibleWith. So the field that differs here has to be one that cannot
+    rule anything out, because a merge keeps the local value and the screen has to be able to show
+    which of theirs is being set aside.
+    """
+    t = Tree(pid("a-cousins-tree"))
+    shyam = t.person("cousin-shyam", "Shyam Lal", "MALE", birth="1938",
+                     notes="Moved to Kanpur in 1961. Worked on the railways.")
+    ravi = t.person("cousin-ravi", "Ravi", "MALE", birth="1962")
+    meena = t.person("cousin-meena", "Meena Devi", "FEMALE", birth="1965")
+    asha = t.person("cousin-asha", "Asha Lal", "FEMALE", birth="1990")
+
+    t.rel(shyam, ravi, "PARENT")
+    t.rel(ravi, meena, "SPOUSE")
+    t.rel(ravi, asha, "PARENT")
+    t.rel(meena, asha, "PARENT")
+    return t, {}
+
+
 if __name__ == "__main__":
     out = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
     out.mkdir(parents=True, exist_ok=True)
@@ -276,6 +306,9 @@ if __name__ == "__main__":
     tree, photos = sample()
     write_archive(out / "sample-family.ftree", tree, photos)
     write_archive(out / "sample-streamed.ftree", tree, photos, streamed=True)
+
+    kin, _ = cousins()
+    write_archive(out / "a-cousins-tree.ftree", kin, {})
 
     big, _ = large()
     write_archive(out / "large-tree.ftree", big, {})


### PR DESCRIPTION
The other half of standing alone. Until now a tree could be built here and sent to the phone, but a cousin's file could not be merged into it.

A port of `transfer/TreeImporter.kt`, keeping its governing rule exactly: **an import adds, it never replaces.** Nothing already here is deleted and no value already written is overwritten — a disagreement is reported, not resolved. The worst this can do is add duplicates, which somebody can merge by hand. The opposite mistake cannot be undone by hand, because the fact that they were ever two people is gone.

`planImport` reads and judges and changes nothing. `applyImport` writes once, using decisions somebody has seen.

## Deliberate divergences from the phone

**Undo instead of a backup file.** The phone writes a backup because it commits to a database the moment it is told to. Here the tree is in memory, so an import is one `tree.edit`: Ctrl+Z puts it back exactly, and closing without saving leaves the file untouched.

**Imported connections go through `checkRelationship`** rather than being inserted and de-duplicated. A symmetric edge arriving the other way round is the same connection, and a literal duplicate check counts it as new. And merging is what makes cycles reachable — two imported people collapsing onto one local person can close a line where somebody is their own ancestor, which no hand edit may create. Refused connections are counted and reported, never dropped quietly.

## Two bugs the tests found

Both the same kind — writing a key that says nothing. The merge set `deceased: false` on people who never had the field, and added `origins: []` to people with no provenance. Either was enough to make re-importing an unchanged file report unsaved work and ask you to save a file identical to the one on disk. An origin that merely restates the identity rule is no longer recorded either: true and useless.

## The review screen

This is where the care went, because a strong match merges unless it is refused.

It is a **comparison, not a checkbox beside a name**: the two records side by side, the fields that disagree marked, and the evidence named — *"the name is the same, the dates fit, and you both have Ravi"* — because that is an argument somebody can disagree with, where "2 relatives in common" is only an assertion. The button says what pressing it does; the line beside it answers the question actually being asked at that moment, which is what happens if this turns out to be wrong.

## Verified on screen, not only in tests

The smoke test now merges a second file and screenshots the dialog in both themes. That found three things no unit test could:

- the dialog opened **scrolled past the first person's name**, because a `<dialog>` focuses its first focusable child and the browser scrolls it into view;
- **every card was sliced mid-row** — flex children shrink before their container scrolls, so the evidence and the choice were both below the cut;
- the footer buttons were set in the chrome's **monospace**, which is right for "Fit" and wrong for a sentence.

`tools/make_sample_tree.py` gains the fixture these exercise. Its birth years agree on purpose: two different birth years are not a weak signal but a **veto**, so a fixture that disagreed on them proved nothing — which is how the first version of it failed.

CI now runs the import step both from source and against the packaged binary.

115 tests pass. `git status --short app/` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)