### PR TITLE
fix(desktop): run identity.test.js, and stop a test file going unrun again

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
     "smoke": "electron . --no-sandbox",
     "pack:linux": "electron-builder --linux",
     "pack:win": "electron-builder --win nsis",
-    "test": "node --test update.test.js atomic.test.js \"renderer/*.test.js\"",
+    "test": "node --test update.test.js atomic.test.js identity.test.js suite.test.js \"renderer/*.test.js\"",
     "test:package": "node --test package.test.js"
   },
   "devDependencies": {

--- a/desktop/suite.test.js
+++ b/desktop/suite.test.js
@@ -1,0 +1,78 @@
+// Every test file this directory holds is actually run by a script here.
+//
+// The bug this exists for: `identity.test.js` was written, passed, and then ran nowhere for
+// several releases, because the `test` script names its files one by one and nobody added it.
+// Eight tests guarding the installation identity -- the thing that stops two desktop-made trees
+// claiming the same origin and merging strangers -- were dead the whole time, and a dead suite
+// looks exactly like a passing one from the outside.
+//
+// The list stays explicit rather than becoming a glob: `package.test.js` reads a built artifact
+// and belongs to `test:package`, which runs after `pack:linux`. So the check is not "use a
+// glob", it is "every file is claimed by some script", and a new test file that nobody wired up
+// fails here.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+
+// The scripts that run tests, and the directories a test file may live in. Both are stated
+// rather than discovered, so adding either is a deliberate edit to this file.
+const RUNNERS = ['test', 'test:package'];
+const TEST_DIRS = ['.', 'renderer'];
+
+function testFiles() {
+  const found = [];
+  for (const dir of TEST_DIRS) {
+    for (const name of fs.readdirSync(path.join(__dirname, dir))) {
+      if (name.endsWith('.test.js')) found.push(dir === '.' ? name : `${dir}/${name}`);
+    }
+  }
+  return found.sort();
+}
+
+// The file arguments a script passes to `node --test`, unquoted. Split into whole tokens rather
+// than matched as substrings: `renderer/*.test.js` *contains* `*.test.js`, so a substring test
+// would report every top-level file as covered by the renderer glob -- which is the exact hole
+// this file exists to close, found by removing identity.test.js and watching the check pass.
+function argumentsOf(script) {
+  return script.split(/\s+/).map((token) => token.replace(/^"|"$/g, '')).filter(Boolean);
+}
+
+// A script "claims" a file if it names it outright or by the glob over its own directory.
+// Deliberately literal: this is not a shell, and a pattern it cannot understand should read as
+// unclaimed rather than be waved through.
+function claims(script, file) {
+  const dir = path.dirname(file);
+  const patterns = new Set([file, dir === '.' ? '*.test.js' : `${dir}/*.test.js`]);
+  return argumentsOf(script).some((arg) => patterns.has(arg));
+}
+
+test('every test file is run by some npm script', () => {
+  const scripts = RUNNERS.map((name) => pkg.scripts[name] || '');
+  const orphans = testFiles().filter((file) => !scripts.some((s) => claims(s, file)));
+  assert.deepStrictEqual(
+    orphans,
+    [],
+    `these test files are never run -- add them to "${RUNNERS[0]}" in package.json: ${orphans.join(', ')}`,
+  );
+});
+
+test('the scripts do not name test files that no longer exist', () => {
+  const present = new Set(testFiles());
+  const named = [];
+  for (const name of RUNNERS) {
+    for (const file of argumentsOf(pkg.scripts[name] || '')) {
+      if (file.endsWith('.test.js') && !file.includes('*')) named.push(file);
+    }
+  }
+  assert.deepStrictEqual(named.filter((f) => !present.has(f)), []);
+});
+
+test('identity.test.js in particular is run', () => {
+  // Named on purpose. The general check above would pass again if this file were deleted along
+  // with the tests, and the installation identity is not a thing to lose quietly.
+  assert.ok(claims(pkg.scripts.test, 'identity.test.js'));
+});


### PR DESCRIPTION
Closes #117.

`desktop/package.json`'s `test` script listed its files one at a time and `identity.test.js` was not among them. Its 8 tests passed whenever anybody ran the file directly and ran **nowhere** otherwise — not locally, not in CI's *"The rules ported out of the Kotlin"* step.

Those 8 tests are the only thing standing over the installation identity: the rule that stops a tree built on one desktop and a tree built on another from claiming the same `origins` entry. A collision there makes import merge two strangers into one person, and that is the one failure in this app that cannot be undone afterwards. The rule was unguarded while looking guarded.

## What changed

- `identity.test.js` added to the `test` script. **115 tests → 126.**
- New `desktop/suite.test.js`: every `*.test.js` under `desktop/` and `desktop/renderer/` must be claimed by some npm script, so the next test file cannot go unrun the same way.

The list stays explicit rather than becoming a glob on purpose — `package.test.js` opens the built `.deb` and belongs to `test:package`, which only makes sense after `pack:linux`. The requirement is *"every file is claimed by some script"*, not *"use a glob"*.

## The guard was wrong first, which is the interesting part

The first version matched patterns as substrings. `renderer/*.test.js` **contains** `*.test.js`, so every top-level file read as covered by the renderer glob — the check passed with `identity.test.js` removed again, which is precisely the bug it exists to catch. Found by trying exactly that. It now compares whole `node --test` arguments:

```
$ python3 -c "...remove identity.test.js from the script..."
$ node --test suite.test.js
    these test files are never run -- add them to "test" in package.json: identity.test.js
# pass 1
# fail 2
```

## Verification

- `cd desktop && npm test` → 126 pass, 0 fail.
- Negative case above: removing the file from the script fails the guard.
- `git status --short app/` empty — nothing under `app/` is touched.

Part of the #89 closing sequence (Phase 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)