### PR TITLE
fix(desktop): stop drawing the import dialog when nobody opened it

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1106,6 +1106,23 @@ async function runSmoke(win, file) {
     ICON_FOR_WINDOW);
 
   /*
+   * A question nobody asked is not on the screen.
+   *
+   * #125: the review dialog's box was styled without `[open]`, which beat the user agent's
+   * `dialog:not([open]) { display: none }` and left 160px of empty dialog -- with a live Import
+   * button in it -- painted over the tree on every screen. Asserted here rather than in the import
+   * smoke because the failure is about the state where no import is happening, which is every
+   * other moment the app is running.
+   */
+  const shut = await win.webContents.executeJavaScript(`(() => {
+    const dialog = document.getElementById('review');
+    return { open: dialog.open, display: getComputedStyle(dialog).display,
+             height: dialog.getBoundingClientRect().height };
+  })()`);
+  check('a dialog nobody opened takes up no room', !shut.open && shut.display === 'none'
+    && shut.height === 0, JSON.stringify(shut));
+
+  /*
    * The updater must not be blocked by the page's own guard.
    *
    * This is the regression that shipped: the refusal was installed on the default session, which

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -410,7 +410,15 @@
    disagree are marked. A list of ticked names would be asking the same question while hiding
    the evidence needed to answer it. */
 
-.editor .review {
+/*
+ * `[open]` is load-bearing, not tidiness.
+ *
+ * A <dialog> with no `open` attribute is hidden by the user agent's `dialog:not([open])
+ * { display: none }`, and a class selector beats that. So an unconditional `display: flex` here
+ * un-hides the closed dialog: it was laid out and painted over the top of the stage on every
+ * screen, 160px of empty panel with a live Import button in it, from 0.4.1 until #125.
+ */
+.editor .review[open] {
   width: min(760px, calc(100vw - 48px));
   max-height: min(84vh, 760px);
   padding: 0;


### PR DESCRIPTION
Closes #125. Shipped in `desktop-v0.4.1`; found while screenshotting the compact view for #120.

`desktop/renderer/editor.css` styled the review dialog's box with an unconditional `display: flex`. A `<dialog>` without the `open` attribute is hidden by the user agent's `dialog:not([open]) { display: none }`, and a class selector beats that — so the **closed** dialog was laid out and painted like any other block.

Measured in the packaged app with no import in progress:

```
{"open":false,"display":"flex","height":159.55813598632812}
```

160px of empty dialog across the top of the stage, with a live **Import** button in it, on every screen, at all times.

## The fix

Scope the box to `[open]`, so the closed dialog gets the user agent's `display: none` back. After:

```
{"open":false,"display":"none","height":0}
```

## Why it was missed, and what stops it coming back

The import work screenshotted this dialog **open** — the state it was written for — and never captured the state it is in the rest of the time. The existing note in that stylesheet is about `capturePage` not compositing the backdrop, which is also an open-state concern.

So the smoke test now asserts the shut case, placed with the other always-on checks rather than inside the import smoke: *"no import is happening"* is every other moment the app is running. Reverting the CSS makes it fail:

```
 FAIL  a dialog nobody opened takes up no room  {"open":false,"display":"flex","height":159.55...}
```

## Verification

On the packaged app (`dist/linux-unpacked/f-tree-desktop`), run unconfined through `systemd-run --user` — not `electron .`:

- `ok   a dialog nobody opened takes up no room  {"open":false,"display":"none","height":0}`
- the import flow still works end to end: opens, asks first, *"Add 4 people"*, 23 → 27 people, and undo puts it back.
- `cd desktop && npm test` — 126 pass.
- `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)