### PR TITLE
feat(desktop): compact view — generations you can read at any size

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,6 +47,13 @@ jobs:
                    | sed -E 's/:(src|href)="/ /; s/"$//')
           test "$missing" -eq 0
 
+      # The engine's own suites, which are the rules ported out of the Kotlin rather than anything
+      # about the page: who belongs on a chart centred on one person, and how a generation is read
+      # across. They run here as well as in the desktop workflow because the engine ships to both
+      # shells, and the site is the one that deploys without a desktop build in the way.
+      - name: The engine's rules, ported out of the Kotlin
+        run: node --test "site/playground/*.test.mjs"
+
       - name: Check the viewer parses and lays out a real archive
         run: |
           set -euo pipefail

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -446,6 +446,8 @@ function buildMenu(win) {
       submenu: [
         { label: 'Chart', accelerator: 'CmdOrCtrl+1', click: () => win.webContents.send('menu:command', 'view:chart') },
         { label: 'Index', accelerator: 'CmdOrCtrl+2', click: () => win.webContents.send('menu:command', 'view:index') },
+        // Third, and third in the numbering, so nobody's Cmd+2 changes meaning under them.
+        { label: 'Compact', accelerator: 'CmdOrCtrl+3', click: () => win.webContents.send('menu:command', 'view:compact') },
         { type: 'separator' },
         { label: 'Zoom in', accelerator: 'CmdOrCtrl+Plus', click: () => win.webContents.send('menu:command', 'zoom:in') },
         { label: 'Zoom out', accelerator: 'CmdOrCtrl+-', click: () => win.webContents.send('menu:command', 'zoom:out') },
@@ -921,6 +923,149 @@ async function runEditSmoke(win, check) {
  * hand, so what is asserted here is not "it worked" but "it asked first": the dialog opens, it
  * names the evidence, and the tree is untouched until the button is pressed.
  */
+/*
+ * The compact view, read rather than drawn.
+ *
+ * What this asserts is not "it rendered" but the three claims the view makes that a picture cannot
+ * be trusted to keep: that the generations are named from their distance, that a person married
+ * into a generation is shown without being counted as one of it, and that clicking a name walks the
+ * reading to that person rather than doing something else. The last one matters because everywhere
+ * else in this app a click on a person opens the editor, and here it deliberately does not.
+ */
+async function runCompactSmoke(win, check) {
+  const page = (fn, ...args) => win.webContents.executeJavaScript(
+    `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
+  const settle = (ms = 350) => new Promise((r) => setTimeout(r, ms));
+
+  console.log('\n  -- reading the generations --');
+
+  win.webContents.send('menu:command', 'view:compact');
+  await settle(500);
+
+  const seen = await page(() => {
+    const view = document.getElementById('compact');
+    const bands = [...view.querySelectorAll('.band')];
+    return {
+      shown: view.hidden === false,
+      chartHidden: getComputedStyle(document.getElementById('canvas')).display === 'none',
+      headings: bands.map((b) => b.querySelector('.band-heading span')?.textContent ?? ''),
+      offsets: bands.map((b) => b.dataset.offset),
+      focusName: view.querySelector('.band-focus-name')?.textContent ?? '',
+      names: [...view.querySelectorAll('.band-name')].length,
+      marriedIn: [...view.querySelectorAll(".band-name[data-married='true']")].length,
+      rules: [...view.querySelectorAll('.band-join.married')].length,
+      // Per group: how many names, and how many marriage rules between them.
+      groups: [...view.querySelectorAll('.band-group')].map((g) => ({
+        names: g.querySelectorAll('.band-name').length,
+        rules: g.querySelectorAll('.band-join.married').length,
+      })),
+      // The count in a heading is what the band is about, so it can be lower than the number of
+      // names on the row -- that difference is the step-grandmother.
+      counts: bands.map((b) => b.querySelector('.band-count')?.textContent ?? ''),
+      note: document.querySelector('#compact .index-note')?.textContent ?? '',
+    };
+  });
+
+  check('the compact view opens on its own', seen.shown, String(seen.shown));
+  check('the chart stands down while the bands are up', seen.chartHidden,
+    String(seen.chartHidden));
+  check('it is centred on somebody', seen.focusName.length > 0, seen.focusName);
+  check('there are generations to read', seen.headings.length > 0,
+    `${seen.headings.length} bands: ${seen.headings.join(' / ')}`);
+  check('a generation is named, not numbered',
+    seen.headings.every((h) => h.length > 0 && !/^-?\d+$/.test(h)), seen.headings.join(' / '));
+  check('the reading says how far it reaches', /generation|nobody/.test(seen.note), seen.note);
+  check('every name on the page is reachable', seen.names > 0, `${seen.names} names`);
+
+  /*
+   * A marriage is a doubled rule, and only a marriage.
+   *
+   * Stated as an invariant rather than as "there is at least one rule", because a tree of cousins
+   * has no marriages in it at all and would fail that for being correct. A group is a set of people
+   * joined *by marriage*, so:
+   *
+   *   two or more names in a group means at least one marriage joined them; and
+   *   there can never be more rules than gaps -- somebody who married twice puts three people in
+   *   one group, and only two of the three pairs are marriages. Marking the third would state a
+   *   wedding that never happened, and that is exactly what `CompactGroup.links` exists to prevent.
+   *
+   * Both hold whatever is in the file, and neither is visible in a screenshot.
+   */
+  const joined = seen.groups.filter((g) => g.names >= 2);
+  check('a couple on a row is joined by a doubled rule',
+    joined.every((g) => g.rules >= 1),
+    `${joined.length} groups of two or more, rules ${joined.map((g) => g.rules).join(',') || 'n/a'}`);
+  check('no rule is drawn where there was no wedding',
+    seen.groups.every((g) => g.rules <= Math.max(0, g.names - 1)),
+    seen.groups.map((g) => `${g.names}:${g.rules}`).join(' '));
+
+  // Both themes, because this screen is read in whichever one somebody happens to use and a token
+  // that only exists in one of them looks fine right up until it does not. Taken before the walk
+  // below, because the first reading is the one with every band on it.
+  if (process.env.FTREE_SMOKE_SHOT_COMPACT) {
+    const shot = process.env.FTREE_SMOKE_SHOT_COMPACT;
+    await fs.writeFile(shot, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${shot}`);
+
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(300);
+    const other = shot.replace(/(\.png)?$/, '-other-theme.png');
+    await fs.writeFile(other, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${other}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(200);
+  }
+
+  /*
+   * Reading further, where the record goes further.
+   *
+   * The offer is only made when the walk actually stopped short of the end, so the first assertion
+   * is that the button and the sentence agree -- an offer to read on where there is nothing more is
+   * the kind of thing nobody notices until they press it.
+   */
+  const reach = await page(() => ({
+    offered: Boolean(document.querySelector('#compact .band-more')),
+    bands: document.querySelectorAll('#compact .band').length,
+  }));
+  check('the offer to read further matches whether there is further to read',
+    reach.offered === /continues past/.test(seen.note),
+    `offered ${reach.offered}, said "${seen.note}"`);
+
+  if (reach.offered) {
+    await page(() => document.querySelector('#compact .band-more').click());
+    await settle(500);
+    const further = await page(() => document.querySelectorAll('#compact .band').length);
+    check('reading further actually reaches further', further > reach.bands,
+      `${reach.bands} bands -> ${further}`);
+  }
+
+  // Walking the reading. Clicking a name must re-centre rather than open the editor: two meanings
+  // for one click on a person's name would make both of them uncertain.
+  const walked = await page(() => {
+    const before = document.querySelector('.band-focus-name').textContent;
+    const target = [...document.querySelectorAll('#compact .band .band-name')]
+      .find((el) => el.querySelector('.band-who').textContent !== before);
+    const wanted = target?.querySelector('.band-who').textContent ?? '';
+    target?.click();
+    return { before, wanted };
+  });
+  await settle(400);
+
+  const after = await page(() => ({
+    focusName: document.querySelector('.band-focus-name')?.textContent ?? '',
+    panelOpen: document.getElementById('panel')?.hidden === false,
+  }));
+
+  check('clicking a name walks the reading to that person',
+    after.focusName === walked.wanted && after.focusName !== walked.before,
+    `${walked.before} -> ${after.focusName}`);
+  check('walking does not open the editor over what was asked for', !after.panelOpen,
+    String(after.panelOpen));
+
+  win.webContents.send('menu:command', 'view:chart');
+  await settle(300);
+}
+
 async function runImportSmoke(win, check) {
   const page = (fn, ...args) => win.webContents.executeJavaScript(
     `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
@@ -1087,7 +1232,17 @@ async function runSmoke(win, file) {
    * screen no name is readable, so this is the only way to find somebody by name -- and the only
    * place a person with no relatives is as visible as everybody else.
    */
-  check('everybody in the file is listed by name', seen.peopleRows === 23,
+  /*
+   * Counted against the file rather than against 23.
+   *
+   * The literal was the sample family's population, which made the whole harness refuse to be
+   * pointed at any other fixture -- it failed on the 2030-person tree by saying "2030 rows, 2030
+   * people". The claim worth making is that the list holds *everybody*, whoever was opened, and
+   * that is what the tree's own count is for.
+   */
+  const population = Number(/(\d+)\s+(?:person|people)/.exec(seen.counts ?? '')?.[1] ?? NaN);
+  check('everybody in the file is listed by name',
+    Number.isFinite(population) && seen.peopleRows === population,
     `${seen.peopleRows} rows — ${seen.peopleNote}`);
   // Refusing the network must not quietly cost the app its typography.
   check('the bundled typefaces loaded without the network', seen.literata && seen.mono,
@@ -1143,6 +1298,8 @@ async function runSmoke(win, file) {
   }
 
   if (process.env.FTREE_SMOKE_SAVE_TO) await runEditSmoke(win, check);
+
+  if (process.env.FTREE_SMOKE_COMPACT) await runCompactSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_IMPORT) await runImportSmoke(win, check);
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
     "smoke": "electron . --no-sandbox",
     "pack:linux": "electron-builder --linux",
     "pack:win": "electron-builder --win nsis",
-    "test": "node --test update.test.js atomic.test.js identity.test.js suite.test.js \"renderer/*.test.js\"",
+    "test": "node --test update.test.js atomic.test.js identity.test.js suite.test.js \"renderer/*.test.js\" \"../site/playground/*.test.mjs\"",
     "test:package": "node --test package.test.js"
   },
   "devDependencies": {
@@ -43,7 +43,8 @@
         "from": "../site/playground",
         "to": "page/site/playground",
         "filter": [
-          "**/*"
+          "**/*",
+          "!*.test.mjs"
         ]
       },
       {

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -24,11 +24,14 @@ import { openArchive, parseDocument, ArchiveError } from '../../site/playground/
 import { buildGraph, displayName, lifespan, relationsOf } from '../../site/playground/model.js';
 import { layoutArchive } from '../../site/playground/layout.js';
 import { Chart } from '../../site/playground/chart.js';
+import { compactFamily } from '../../site/playground/compact.js';
+import { mostConnected } from '../../site/playground/focus.js';
 
 import { Tree, RelationshipType, Rejection } from './document.js';
 import { bytesForTree, SaveRefused } from './save.js';
 import { planImport, applyImport, ImportRefused } from './import.js';
 import { MatchTier } from './matching.js';
+import { renderBands } from './bands.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
 
@@ -47,8 +50,18 @@ const state = {
   selected: null,
   /** Which kind of relative the "add" form is currently offering. */
   adding: null,
-  /** 'chart' or 'index'. */
+  /** 'chart', 'compact' or 'index'. */
   view: 'chart',
+  /**
+   * The person the compact view is centred on, and how far it reaches from them.
+   *
+   * Kept apart from `selected` because they answer different questions: `selected` is "who am I
+   * editing", which the chart and the panel share, and this is "whose family am I reading". Walking
+   * outwards through a family should not silently change what the panel is about.
+   */
+  focus: null,
+  generationsUp: 3,
+  generationsDown: 3,
   /** 'all' or 'living' -- the same filter the phone's people list offers. */
   who: 'all',
   saving: false,
@@ -155,8 +168,61 @@ function setView(view) {
     button.setAttribute('aria-pressed', String(button.dataset.view === view));
   }
   $('index').hidden = view !== 'index';
+  $('compact').hidden = view !== 'compact';
   if (view === 'chart') chart.resize();
+  else if (view === 'compact') renderCompact();
   else renderPeople();
+}
+
+/* ------------------------------------------------------------------ generations, as bands */
+
+/**
+ * The compact view, centred on somebody.
+ *
+ * Needs a focus person, which the phone never has to work out: you arrive at its focused chart
+ * *from* a person. This app can open a file with nothing selected, so the order is the selected
+ * person, then whoever the view was last centred on, then the most-connected person -- never the
+ * first row of the file, which is export order and means nothing to a reader.
+ */
+function renderCompact() {
+  if (!state.graph) return;
+
+  let focusId = state.focus;
+  if (!focusId || !state.graph.people.has(focusId)) {
+    focusId = state.selected && state.graph.people.has(state.selected)
+      ? state.selected
+      : mostConnected(state.graph);
+    state.focus = focusId;
+  }
+
+  const family = compactFamily(state.graph, focusId, {
+    up: state.generationsUp,
+    down: state.generationsDown,
+  });
+
+  renderBands($('compact-inner'), family, {
+    generations: reachWords(),
+    onFocus: (id) => {
+      state.focus = id;
+      // A walk outwards resets the reach: the reader asked to see this person's family, not to
+      // carry somebody else's "show more" over onto them.
+      state.generationsUp = 3;
+      state.generationsDown = 3;
+      renderCompact();
+      $('compact').scrollTop = 0;
+    },
+    onEdit: (id) => select(id),
+    onMore: () => {
+      state.generationsUp += 2;
+      state.generationsDown += 2;
+      renderCompact();
+    },
+  });
+}
+
+/** How far the reading currently reaches, for the line that offers to extend it. */
+function reachWords() {
+  return `${state.generationsUp} generations`;
 }
 
 /**
@@ -1073,6 +1139,7 @@ function wireShell() {
     if (command === 'zoom:out') { chart.zoomBy(0.8); updateZoom(); return; }
     if (command === 'zoom:fit') { chart.fit(); updateZoom(); return; }
     if (command === 'view:chart') { setView('chart'); return; }
+    if (command === 'view:compact') { setView('compact'); return; }
     if (command === 'view:index') { setView('index'); return; }
     if (command === 'search') { $('search').focus(); return; }
     if (command === 'theme') { $('theme-btn').click(); return; }
@@ -1097,6 +1164,9 @@ function wireKeys() {
     if (event.key === '/') { event.preventDefault(); $('search').focus(); }
     if (event.key === 'i' || event.key === 'I') {
       setView(state.view === 'index' ? 'chart' : 'index');
+    }
+    if (event.key === 'c' || event.key === 'C') {
+      setView(state.view === 'compact' ? 'chart' : 'compact');
     }
     if (event.key === 'f' || event.key === 'F') { chart.fit(); updateZoom(); }
   });

--- a/desktop/renderer/bands.js
+++ b/desktop/renderer/bands.js
@@ -1,0 +1,252 @@
+/*
+ * The compact view's own rendering: generation bands, as text.
+ *
+ * Kept apart from `app.js` and from the model on purpose. `compactFamily` in
+ * `site/playground/compact.js` decides *who is on which row and in what order* -- a family rule,
+ * shared with the website and held to the Kotlin's test table. This file decides only how that
+ * reads on a page, which is this shell's business alone and nobody else's.
+ *
+ * The two visual devices here both come from the chart rather than from a stylesheet:
+ *
+ *   A marriage is a doubled rule. The chart draws a couple joined by one, and a couple that drifts
+ *   apart on screen stops looking like a couple. Between names, the same mark: a double line
+ *   between two people who married, and nothing between two people who merely share a group. That
+ *   is why `CompactGroup.links` exists rather than the group simply being a list -- somebody who
+ *   married twice puts three people in one group, and marking all three gaps would state a wedding
+ *   that never happened.
+ *
+ *   A generation's heading counts the people it is *about*. A step-grandmother is family and is
+ *   shown, and she is not a fifth grandparent.
+ */
+
+import { displayName, birthYear, lifespan } from '../../site/playground/model.js';
+
+/**
+ * What a generation is called, worked out from its distance rather than looked up.
+ *
+ * The bands are keyed by number, so "four generations up" needs no new case: the greats accumulate.
+ * The alternative -- a table of names -- runs out, and a chart that says "generation -5" has given
+ * up on being read aloud.
+ */
+export function bandHeading(offset) {
+  if (offset === 0) return 'Brothers and sisters';
+  const up = offset < 0;
+  const rings = Math.abs(offset);
+  const base = up ? 'Parents' : 'Children';
+  if (rings === 1) return base;
+  // Lower-case after the first, because that is how the word is written: "great-grandparents", not
+  // "Great-Grandparents". The heading is set in capitals by the stylesheet, but the string is also
+  // the accessible name for the section, and that is read as written.
+  const grand = up ? 'grandparents' : 'grandchildren';
+  const greats = 'great-'.repeat(rings - 2) + grand;
+  return greats[0].toUpperCase() + greats.slice(1);
+}
+
+/** The years under a name: a lifespan where there is one, and nothing rather than a guess. */
+function years(person) {
+  const span = lifespan(person);
+  return span === 'Late' ? 'Late' : span;
+}
+
+function nameOf(person, ofBand) {
+  const el = document.createElement('button');
+  el.type = 'button';
+  el.className = 'band-name';
+  el.dataset.id = person.id;
+  // Married into this generation rather than born to it. The heading has already declined to count
+  // them; this is the same fact, said quietly enough to read past.
+  el.dataset.married = String(!ofBand);
+
+  const who = document.createElement('span');
+  who.className = 'band-who';
+  const name = displayName(person);
+  if (person.name) who.textContent = name;
+  else {
+    // The viewer shows an unnamed person in italics everywhere else. Keep it.
+    const em = document.createElement('em');
+    em.textContent = name;
+    who.append(em);
+  }
+  el.append(who);
+
+  const when = years(person);
+  if (when) {
+    const dates = document.createElement('span');
+    dates.className = 'band-when';
+    dates.textContent = when;
+    el.append(dates);
+  }
+  el.title = `Centre this view on ${name}`;
+  return el;
+}
+
+/** One block on a row: the people, with a doubled rule wherever there is a marriage. */
+function groupRow(group) {
+  const row = document.createElement('div');
+  row.className = 'band-group';
+  group.people.forEach((person, i) => {
+    if (i > 0) {
+      const join = document.createElement('span');
+      // Only a marriage gets the mark. A gap inside a group that is not a marriage stays a gap.
+      join.className = group.married(i - 1) ? 'band-join married' : 'band-join';
+      join.setAttribute('aria-hidden', 'true');
+      row.append(join);
+      if (group.married(i - 1)) {
+        const said = document.createElement('span');
+        said.className = 'sr-only';
+        said.textContent = ' married to ';
+        row.append(said);
+      }
+    }
+    row.append(nameOf(person, group.ofBand.has(person.id)));
+  });
+  return row;
+}
+
+/**
+ * The centre of the view: its own block rather than a card in a row.
+ *
+ * Everywhere else in this app, clicking a person opens the panel that edits them. Here a click
+ * re-centres, because walking outwards through a family is what this view is for and asking for two
+ * different clicks on the same name would make both of them uncertain. So editing is offered once,
+ * from the block for the person already centred, and the walk stays a single unambiguous action.
+ */
+function focusBlock(focus, { onEdit }) {
+  const block = document.createElement('div');
+  block.className = 'band-focus';
+
+  const head = document.createElement('div');
+  head.className = 'band-focus-head';
+
+  const name = document.createElement('h3');
+  name.className = 'band-focus-name';
+  name.textContent = displayName(focus.person);
+  head.append(name);
+
+  const when = years(focus.person);
+  if (when) {
+    const dates = document.createElement('p');
+    dates.className = 'band-focus-when';
+    dates.textContent = when;
+    head.append(dates);
+  }
+
+  const edit = document.createElement('button');
+  edit.type = 'button';
+  edit.className = 'btn quiet band-edit';
+  edit.textContent = 'Edit this person';
+  edit.addEventListener('click', () => onEdit(focus.person.id));
+  head.append(edit);
+
+  block.append(head);
+
+  if (focus.partners.length) {
+    const married = document.createElement('p');
+    married.className = 'band-focus-married';
+    focus.partners.forEach((partner, i) => {
+      if (i > 0) married.append(document.createTextNode(' and '));
+      married.append(document.createTextNode(i === 0 ? 'Married to ' : ''));
+      married.append(nameOf(partner, false));
+    });
+    block.append(married);
+  }
+
+  return block;
+}
+
+function bandSection(band) {
+  const section = document.createElement('section');
+  section.className = 'band';
+  section.dataset.offset = String(band.offset);
+
+  const heading = document.createElement('h3');
+  heading.className = 'band-heading';
+  const words = document.createElement('span');
+  words.textContent = bandHeading(band.offset);
+  heading.append(words);
+  // The count is what the heading is about, so it sits in the heading: the number of people of this
+  // generation, not the number of names on the row.
+  if (band.count > 0) {
+    const tally = document.createElement('span');
+    tally.className = 'band-count';
+    tally.textContent = String(band.count);
+    heading.append(tally);
+  }
+  section.append(heading);
+
+  for (const group of band.groups) section.append(groupRow(group));
+  return section;
+}
+
+/**
+ * Draws a `CompactFamily` into `container`.
+ *
+ * `onFocus` is given a person's id when somebody clicks a name; `onEdit` when the centred person is
+ * to be edited; `onMore` when the reader asks for another generation. All three are the caller's,
+ * so this file holds no state and can be rendered twice with the same result.
+ */
+export function renderBands(container, family, { onFocus, onEdit, onMore, generations }) {
+  container.replaceChildren();
+
+  if (family.isEmpty) {
+    const empty = document.createElement('p');
+    empty.className = 'band-empty';
+    empty.textContent = 'Add somebody to the tree and their family will be read out here.';
+    container.append(empty);
+    return;
+  }
+
+  const head = document.createElement('div');
+  head.className = 'band-head';
+  const title = document.createElement('h2');
+  title.className = 'index-heading';
+  title.textContent = `${displayName(family.focus.person)}’s family`;
+  head.append(title);
+
+  const note = document.createElement('p');
+  note.className = 'index-note';
+  note.textContent = summary(family, generations);
+  head.append(note);
+  container.append(head);
+
+  for (const band of family.ancestors) container.append(bandSection(band));
+  container.append(focusBlock(family.focus, { onEdit }));
+  if (family.siblings) container.append(bandSection(family.siblings));
+  for (const band of family.descendants) container.append(bandSection(band));
+
+  if (family.truncated) {
+    const more = document.createElement('button');
+    more.type = 'button';
+    more.className = 'btn quiet band-more';
+    more.textContent = 'Show more generations';
+    more.addEventListener('click', onMore);
+    container.append(more);
+  }
+
+  container.addEventListener('click', (event) => {
+    const name = event.target.closest('.band-name');
+    if (name) onFocus(name.dataset.id);
+  });
+}
+
+/**
+ * The line under the heading: how far this reading reaches, and whether the record goes further.
+ *
+ * Said in generations rather than in a count of people, because that is the question a reader has
+ * when they are deciding whether to ask for more.
+ */
+export function summary(family, generations) {
+  const up = family.ancestors.length;
+  const down = family.descendants.length;
+  const parts = [];
+  if (up) parts.push(`${count(up, 'generation')} up`);
+  if (down) parts.push(`${count(down, 'generation')} down`);
+  if (!parts.length) parts.push('nobody else recorded');
+  const reach = parts.join(', ');
+  if (!family.truncated) return `${reach}. That is everybody the record holds.`;
+  return `${reach}. The record continues past ${generations} — ask for more to read it.`;
+}
+
+function count(n, singular) {
+  return `${n} ${n === 1 ? singular : `${singular}s`}`;
+}

--- a/desktop/renderer/bands.test.js
+++ b/desktop/renderer/bands.test.js
@@ -1,0 +1,83 @@
+/*
+ * The two pieces of the compact view that are decisions rather than markup.
+ *
+ * `bands.js` mostly builds DOM, and there is no jsdom in this project -- the drawing is checked by
+ * screenshotting the packaged app in both themes, which is what caught the sliced cards and the
+ * monospace buttons in the import work. What is worth testing here is the arithmetic that turns a
+ * generation's *distance* into a word, because it is the reason the bands are keyed by number: a
+ * table of names runs out, and a chart that says "generation -5" has given up on being read aloud.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { bandHeading, summary } from './bands.js';
+import { CompactFamily, CompactBand } from '../../site/playground/compact.js';
+
+test('a generation is named from its distance, and the greats accumulate', () => {
+  assert.strictEqual(bandHeading(0), 'Brothers and sisters');
+
+  assert.strictEqual(bandHeading(-1), 'Parents');
+  assert.strictEqual(bandHeading(-2), 'Grandparents');
+  assert.strictEqual(bandHeading(-3), 'Great-grandparents');
+  assert.strictEqual(bandHeading(-4), 'Great-great-grandparents');
+
+  assert.strictEqual(bandHeading(1), 'Children');
+  assert.strictEqual(bandHeading(2), 'Grandchildren');
+  assert.strictEqual(bandHeading(3), 'Great-grandchildren');
+  assert.strictEqual(bandHeading(4), 'Great-great-grandchildren');
+});
+
+test('a distance no table would have covered still gets a name', () => {
+  // The point of deriving rather than looking up. Nobody will read eight generations up on one
+  // page, and it should not say "generation -8" if they do.
+  // Six greats, not five: -2 is the grandparents with no great at all, so the greats start at -3.
+  assert.strictEqual(bandHeading(-8), 'Great-great-great-great-great-great-grandparents');
+  assert.strictEqual(bandHeading(8), 'Great-great-great-great-great-great-grandchildren');
+});
+
+const familyOf = (offsets, truncated = false) => new CompactFamily({
+  focus: { person: { id: 'me', name: 'Me' }, partners: [], ids: ['me'] },
+  bands: offsets.map((offset) => new CompactBand(offset, [])),
+  truncated,
+});
+
+test('the summary counts generations, not people', () => {
+  // A reader deciding whether to ask for more wants to know how far this reaches, and a count of
+  // people does not tell them.
+  assert.strictEqual(
+    summary(familyOf([-2, -1, 0, 1]), '3 generations'),
+    '2 generations up, 1 generation down. That is everybody the record holds.',
+  );
+});
+
+test('one generation is singular', () => {
+  assert.strictEqual(
+    summary(familyOf([-1]), '3 generations'),
+    '1 generation up. That is everybody the record holds.',
+  );
+});
+
+test('a person with nobody recorded is told so, not shown an empty page', () => {
+  assert.strictEqual(
+    summary(familyOf([]), '3 generations'),
+    'nobody else recorded. That is everybody the record holds.',
+  );
+});
+
+test('a truncated reading says where it stopped and offers to go on', () => {
+  assert.strictEqual(
+    summary(familyOf([-1, 1], true), '3 generations'),
+    '1 generation up, 1 generation down. '
+      + 'The record continues past 3 generations — ask for more to read it.',
+  );
+});
+
+test("the focus's own row is not counted as a generation up or down", () => {
+  // Offset 0 is the row the focus stands in. Counting it as a generation would make a person with
+  // one brother and nothing else read as "1 generation down", which is a different family.
+  assert.strictEqual(
+    summary(familyOf([0]), '3 generations'),
+    'nobody else recorded. That is everybody the record holds.',
+  );
+});

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -658,3 +658,239 @@
   scrollbar-width: thin;
   scrollbar-color: var(--rule-strong) transparent;
 }
+
+/* ------------------------------------------------------------------ generations, as bands */
+
+/*
+ * The compact view.
+ *
+ * It borrows the index view's furniture deliberately -- the serif heading, the mono note, the
+ * tracked heading over a hairline -- because it is the same app reading the same tree, and a third
+ * visual language would say there was a third kind of thing here. What it does not borrow is the
+ * row: the index is a list of people, and this is a list of *generations*.
+ *
+ * The one device invented here is the marriage rule, and it is not decoration. The chart joins a
+ * couple with a doubled line; between names, the same doubled line, and only where there really was
+ * a marriage. Somebody who married twice sits between their two spouses with a rule on each side,
+ * which is exactly what the chart draws and exactly what a single flat list cannot say.
+ */
+
+/*
+ * The chart stands down while the bands are up.
+ *
+ * playground.css already does this for the index view, but it is shared with the website, which has
+ * no compact view to hide anything for. So the rule for this one lives here, with the view.
+ */
+.editor.viewer[data-view='compact'] [data-when='chart'] { display: none; }
+
+.editor .compact { position: absolute; inset: 0; overflow-y: auto; }
+
+.editor .compact-inner {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: clamp(18px, 2.4vw, 30px) clamp(18px, 3vw, 36px) 96px;
+}
+
+.editor .band-head { margin-bottom: 2px; }
+.editor .compact .index-heading { font-size: clamp(21px, 2.4vw, 27px); margin-bottom: 5px; }
+.editor .compact .index-note { margin-bottom: 0; }
+
+/*
+ * The heading over each generation: the name of the generation, and how many people it is about.
+ *
+ * The count is pushed to the far end rather than tucked after the words, so a reader scanning down
+ * the page reads a column of numbers -- four grandparents, two parents, three children -- which is
+ * a shape you can take in without reading any of the names.
+ */
+.editor .band-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--brass);
+  padding: 22px 0 7px;
+  margin: 0 0 4px;
+  border-bottom: 1px solid var(--rule);
+}
+
+.editor .band-count {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: .06em;
+  color: var(--ink-faint);
+}
+
+/*
+ * Baseline, not centre.
+ *
+ * Centring puts the marriage rule on the middle of the whole name button -- name and years
+ * together -- which lands it in the gap between the two lines, where it reads as a dash between
+ * two names or, worse, as a line struck through them. Aligned to the baseline it sits across the
+ * middle of the names themselves, which is where the chart draws it.
+ */
+.editor .band-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0 4px;
+  padding: 0;
+}
+
+.editor .band-name {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  font-family: var(--serif);
+  text-align: left;
+  padding: 5px 9px;
+  border-radius: 3px;
+  min-width: 0;
+}
+
+.editor .band-name:hover,
+.editor .band-name:focus-visible {
+  background: var(--bone-dim);
+  outline: none;
+}
+
+.editor .band-name:focus-visible { box-shadow: inset 0 0 0 2px var(--forest); }
+
+.editor .band-who { font-size: 16.5px; font-weight: 600; line-height: 1.25; }
+.editor .band-who em { color: var(--brass); font-style: italic; }
+
+.editor .band-when {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+ * Married into this generation rather than born to it.
+ *
+ * Lighter, and not italic: italics already mean "no name recorded" everywhere in this app, and one
+ * mark cannot mean two things. The heading has declined to count them, which is the load-bearing
+ * statement; this is only so the row can be read without consulting it.
+ */
+.editor .band-name[data-married='true'] .band-who {
+  font-weight: 400;
+  color: var(--ink-soft);
+}
+
+/* The gap between two people in a group who did not marry each other: a gap, and nothing else. */
+.editor .band-join { width: 14px; }
+
+/* The mark the chart draws. Two rules, because one would read as a dash between two names. */
+.editor .band-join.married {
+  width: 22px;
+  height: 8px;
+  border-top: 1px solid var(--rule-strong);
+  border-bottom: 1px solid var(--rule-strong);
+  flex: none;
+  /*
+   * An empty flex item synthesises its baseline from the bottom of its border box, so it lands
+   * just under the names rather than across them. Margin does not move it -- measured, it does
+   * not -- so the last 3px are nudged, which is safe here because the mark is drawn rather than
+   * laid out: nothing else is positioned from it.
+   */
+  position: relative;
+  top: -3px;
+}
+
+/*
+ * The person the reading is centred on.
+ *
+ * The one loud element on the page, and the only one, because it answers the question a reader
+ * arriving here has: whose family is this? Everything above it is their ancestry and everything
+ * below is their descent, so it is also the hinge the page turns on -- worth finding without
+ * reading.
+ */
+.editor .band-focus {
+  background: var(--sage-container);
+  border-radius: 4px;
+  padding: 13px 18px 12px;
+  margin: 26px 0 2px;
+  /* Sized to the person, not to the column. Run full width and it becomes a banner with half of
+     itself empty; sized to its contents it is what it actually is -- the card this reading is
+     about -- and the generations above and below still read as being either side of it. */
+  width: fit-content;
+  max-width: 100%;
+}
+
+.editor .band-focus-head {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+/* The years sit against the name rather than across the block: at this width, pushing them to the
+   far edge separates a person from their own dates by 500px of nothing. */
+.editor .band-focus-when { margin-right: auto; }
+
+.editor .band-focus-name {
+  font-family: var(--serif);
+  font-size: clamp(19px, 2vw, 23px);
+  font-weight: 600;
+  letter-spacing: -.015em;
+  line-height: 1.15;
+  margin: 0;
+  color: var(--ink);
+}
+
+.editor .band-focus-when {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-soft);
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+}
+
+.editor .band-focus-married {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0 2px;
+  font-family: var(--serif);
+  font-size: 14.5px;
+  color: var(--ink-soft);
+  margin: 2px 0 0;
+  margin-left: -5px;   /* the name button carries its own padding; pull the row back into line */
+}
+
+.editor .band-focus-married .band-name { padding: 4px 5px; }
+.editor .band-focus-married .band-who { font-size: 14.5px; font-weight: 600; color: var(--ink); }
+.editor .band-focus-married .band-when { display: none; }
+.editor .band-focus-married .band-name:hover,
+.editor .band-focus-married .band-name:focus-visible { background: rgba(0, 0, 0, .06); }
+
+.editor .band-edit {
+  font-size: 12px;
+  padding: 6px 13px;
+  align-self: center;
+  flex: none;
+}
+
+.editor .band-more { margin-top: 30px; }
+
+.editor .band-empty {
+  font-family: var(--serif);
+  font-size: 16px;
+  color: var(--ink-soft);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* One name per line on a narrow window: a marriage rule that wraps says nothing. */
+@media (max-width: 560px) {
+  .editor .band-group { flex-direction: column; align-items: flex-start; gap: 0; }
+  .editor .band-join.married { width: 22px; margin: 0 0 0 9px; height: 5px; }
+}

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -73,6 +73,7 @@
       <div class="segmented" role="group" aria-label="View">
         <button type="button" data-view="chart" aria-pressed="true">Chart</button>
         <button type="button" data-view="index" aria-pressed="false">People</button>
+        <button type="button" data-view="compact" aria-pressed="false">Compact</button>
       </div>
 
       <button type="button" class="tool primary-tool" id="add-person">Add a person</button>
@@ -152,6 +153,18 @@
         <p class="index-note" id="index-note"></p>
         <ol class="index-list" id="index-list"></ol>
       </div>
+    </section>
+
+    <!-- ------------------------------------------------------------ generation bands -->
+    <!--
+      The third reading of a tree, and the only one that is composed rather than painted. The chart
+      is a picture: to read a name you zoom, to reach a relative you pan, and a canvas holds nothing
+      at all for a screen reader. The people list is alphabetical and has no family in it. This is
+      the missing middle -- the same people, as generations you can read at any size, with a
+      keyboard and nothing else.
+    -->
+    <section class="compact" id="compact" data-when="compact" hidden aria-label="Generations">
+      <div class="compact-inner" id="compact-inner"></div>
     </section>
 
     <!-- ------------------------------------------------------------ one person, editable -->

--- a/desktop/suite.test.js
+++ b/desktop/suite.test.js
@@ -20,14 +20,24 @@ const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'ut
 
 // The scripts that run tests, and the directories a test file may live in. Both are stated
 // rather than discovered, so adding either is a deliberate edit to this file.
+//
+// `../site/playground` is here because the shared engine's tests run from this package: `site/`
+// has no package.json of its own, so there is nowhere else for them to be run from, and a rule
+// ported out of the Kotlin into the engine is exactly as able to go unrun as one ported into the
+// renderer. The extension differs -- `.test.mjs` there, because those files must be modules
+// whatever the directory above them says.
 const RUNNERS = ['test', 'test:package'];
-const TEST_DIRS = ['.', 'renderer'];
+const TEST_DIRS = [
+  { dir: '.', suffix: '.test.js' },
+  { dir: 'renderer', suffix: '.test.js' },
+  { dir: '../site/playground', suffix: '.test.mjs' },
+];
 
 function testFiles() {
   const found = [];
-  for (const dir of TEST_DIRS) {
+  for (const { dir, suffix } of TEST_DIRS) {
     for (const name of fs.readdirSync(path.join(__dirname, dir))) {
-      if (name.endsWith('.test.js')) found.push(dir === '.' ? name : `${dir}/${name}`);
+      if (name.endsWith(suffix)) found.push(dir === '.' ? name : `${dir}/${name}`);
     }
   }
   return found.sort();
@@ -46,7 +56,8 @@ function argumentsOf(script) {
 // unclaimed rather than be waved through.
 function claims(script, file) {
   const dir = path.dirname(file);
-  const patterns = new Set([file, dir === '.' ? '*.test.js' : `${dir}/*.test.js`]);
+  const suffix = file.endsWith('.test.mjs') ? '.test.mjs' : '.test.js';
+  const patterns = new Set([file, dir === '.' ? `*${suffix}` : `${dir}/*${suffix}`]);
   return argumentsOf(script).some((arg) => patterns.has(arg));
 }
 
@@ -65,7 +76,7 @@ test('the scripts do not name test files that no longer exist', () => {
   const named = [];
   for (const name of RUNNERS) {
     for (const file of argumentsOf(pkg.scripts[name] || '')) {
-      if (file.endsWith('.test.js') && !file.includes('*')) named.push(file);
+      if (/\.test\.m?js$/.test(file) && !file.includes('*')) named.push(file);
     }
   }
   assert.deepStrictEqual(named.filter((f) => !present.has(f)), []);

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,14 +1,37 @@
 # The desktop app
 
-f-tree on Windows and Ubuntu. It reads a `.ftree` exported from the Android app and draws it the
-way the app does — a generation is a column, ancestors at the left — with the people index, the
-search and the relation finder.
+f-tree on Windows and Ubuntu. It reads a `.ftree`, and it writes one: a tree can be built here from
+nothing by somebody who has never owned the phone app. Generations run as **rows**, ancestors at the
+top, as the website viewer draws them — columns are the layout for a screen taller than it is wide,
+and a laptop never is.
 
 `desktop/` is an Electron shell around `site/playground/`. **One viewer, two shells**: the chart,
-the index, the search, the relation finder and the themes are the same files the website serves,
-so a fix to the chart is a fix in both places rather than a fix and a note to remember the other
-one. What the shell adds is what a browser tab cannot have — a real file picker, a native menu,
-and a memory of which tree you were reading.
+the index, the search, the kinship engine and the themes are the same files the website serves, so
+a fix to the chart is a fix in both places rather than a fix and a note to remember the other one.
+What the shell adds is what a browser tab cannot have — a real file picker, a native menu, and a
+memory of which tree you were reading.
+
+## Three ways to read a tree
+
+| | | |
+|---|---|---|
+| **Chart** | `Ctrl+1` | The whole tree, drawn. Pan, zoom, search, click a person to edit them. |
+| **People** | `Ctrl+2` | Everybody by name, grouped as the chart groups them, filterable to the living. The only place somebody with no recorded relatives is as visible as anybody else. |
+| **Compact** | `Ctrl+3` | One person's family as generation bands, read as text at any size. |
+
+Compact exists for the space between the other two. The chart is a picture: to read a name you
+zoom, to reach a relative you pan, and a canvas holds nothing at all for a screen reader. The people
+list is alphabetical and has no family in it. Compact is the missing middle — centred on somebody,
+three generations up and down, with everybody's partners; deliberately **not** cousins or nieces,
+which multiply a chart's width far faster than they add to what it tells you. Clicking a name walks
+the reading to that person. Where the record goes further than the reading, it says so and offers
+to go on.
+
+The rules about who appears live in `site/playground/focus.js` and `site/playground/compact.js`,
+ported from `graph/TreeLayoutEngine.kt` and `graph/CompactFamily.kt` with their test tables. On
+Android, compact is derived from the focused chart, so the two cannot disagree; the desktop's chart
+is the whole tree and there is no focused chart here, so compact makes that selection itself. That
+is a deliberate difference, and the reason the selection rules sit in one shared module.
 
 ## Why Electron and not the app's own code
 

--- a/site/playground/compact.js
+++ b/site/playground/compact.js
@@ -1,0 +1,324 @@
+/*
+ * One person's family, arranged for reading rather than for drawing.
+ *
+ * This is the third reading of a tree, and the only one that is composed rather than painted. The
+ * charts are pictures: to read a name you zoom, to reach a relative you pan, and a canvas holds
+ * nothing at all for a screen reader -- which is why the chart describes itself and then points at
+ * the people list. But that list is alphabetical and has no family in it. Between "a picture you
+ * must zoom" and "a list with no shape" there was nothing, and this is the missing middle: the same
+ * people the focused selection chooses, as text that can be read at any size.
+ *
+ * Ported from `app/.../graph/CompactFamily.kt`, with its test table. `CompactFamily.from` consumes
+ * only ids and levels, so none of the placement arithmetic came with it -- `collectFocused` in
+ * `focus.js` supplies the levels, and this file supplies the arrangement.
+ */
+
+import { birthYear } from './model.js';
+import { collectFocused } from './focus.js';
+
+/** Sorts last, so an undated placeholder never displaces the eldest. */
+const UNDATED = Number.MAX_SAFE_INTEGER;
+
+/** Sorts after every real name, for the same reason. */
+const UNNAMED = '￿';
+
+/**
+ * One block on a row: a person, a couple, or somebody with the two people they married.
+ *
+ * The chart lays a marriage out as a single unit joined by a doubled rule, because a couple that
+ * drifts apart on screen stops looking like a couple. There are no coordinates here to drift, so
+ * the same idea is expressed in the data: everybody joined by a marriage on this row comes out as
+ * one group, in the order they are read across it.
+ *
+ * `links` says which neighbours are actually married -- `links[i]` joins `people[i]` to
+ * `people[i + 1]`. It is not always every gap. Somebody who married twice puts three people in one
+ * group and only two of the three pairs are marriages; drawing the mark between all of them would
+ * state a wedding that never happened.
+ *
+ * `ofBand` is who belongs to the row by *descent*. A step-grandmother is family and is shown, but
+ * she is not a fifth grandparent, and the heading counts grandparents.
+ */
+export class CompactGroup {
+  constructor(people, links, ofBand) {
+    this.people = people;
+    this.links = links;
+    this.ofBand = ofBand;
+  }
+
+  get ids() { return this.people.map((p) => p.id); }
+
+  /** True when `people[index]` and `people[index + 1]` are married to each other. */
+  married(index) { return this.links[index] === true; }
+}
+
+/**
+ * One generation, at a distance from the person the view is centred on.
+ *
+ * `offset` is generations from the focus: -1 is their parents, +1 their children, 0 the row they
+ * stand in themselves. Bands are keyed by the number rather than by a name, so "three generations
+ * up" needs no new case -- the heading is worked out from the offset when it is drawn.
+ */
+export class CompactBand {
+  constructor(offset, groups) {
+    this.offset = offset;
+    this.groups = groups;
+  }
+
+  /** What the heading counts: people who are of this generation, not married into it. */
+  get count() { return this.groups.reduce((sum, g) => sum + g.ofBand.size, 0); }
+
+  get isEmpty() { return this.groups.length === 0; }
+}
+
+/**
+ * A person and whoever they married, for the one place a couple is read downwards.
+ *
+ * The centre of the view is a block of its own rather than a card in a row, so its marriages are
+ * listed under it and each is unambiguous. The bands need `CompactGroup` instead, because there a
+ * couple runs across the page.
+ */
+export class CompactMember {
+  constructor(person, partners = []) {
+    this.person = person;
+    this.partners = partners;
+  }
+
+  get ids() { return [this.person.id, ...this.partners.map((p) => p.id)]; }
+}
+
+export class CompactFamily {
+  constructor({ focus = null, bands = [], truncated = false } = {}) {
+    this.focus = focus;
+    this.bands = bands;
+    this.truncated = truncated;
+  }
+
+  get isEmpty() { return this.focus === null; }
+
+  band(offset) { return this.bands.find((b) => b.offset === offset) ?? null; }
+
+  /** Generations above the focus, oldest first. */
+  get ancestors() { return this.bands.filter((b) => b.offset < 0); }
+
+  /** Generations below the focus, nearest first. */
+  get descendants() { return this.bands.filter((b) => b.offset > 0); }
+
+  /** The focus's own row, without the focus or their partners: brothers and sisters. */
+  get siblings() { return this.band(0); }
+
+  /** Everybody shown, focus included. Used to check this view against the selection it came from. */
+  get everyone() {
+    const out = this.focus ? [...this.focus.ids] : [];
+    for (const band of this.bands) for (const group of band.groups) out.push(...group.ids);
+    return out;
+  }
+}
+
+/**
+ * Rearranges a focused selection into generation bands.
+ *
+ * `collectFocused` supplies who is on the chart and which row they stand in; the graph supplies the
+ * marriages. Pure, so the view can be rebuilt on any edit without touching anything else.
+ *
+ * Pass `selection` to reuse a selection already made -- the desktop does, so that "show more
+ * generations" does not walk the graph twice.
+ */
+export function compactFamily(graph, focusId, { up = 3, down = 3, selection = null } = {}) {
+  const included = selection ?? collectFocused(graph, focusId, { up, down });
+  if (included.focusId === null) return new CompactFamily();
+
+  const focusPerson = graph.people.get(included.focusId);
+  if (!focusPerson) return new CompactFamily();
+
+  const levelOf = included.levels;
+  const peopleByLevel = new Map();
+  for (const [id, level] of levelOf) {
+    if (!peopleByLevel.has(level)) peopleByLevel.set(level, []);
+    peopleByLevel.get(level).push(id);
+  }
+
+  const spousesOf = (id) => graph.spouses(id).map((s) => s.id);
+
+  /*
+   * Who belongs to a row by descent, as opposed to by marriage.
+   *
+   * Walked one generation at a time from the focus's own row outwards, following the same lines the
+   * selection followed: parents of the row above, children of the row below. A spouse is reached by
+   * neither, which is exactly what makes them a partner -- and is how a step-grandparent stays
+   * visible without being counted as a grandparent.
+   */
+  const ownRow = new Set([included.focusId]);
+  for (const s of graph.siblings(included.focusId)) {
+    if (levelOf.get(s.id) === 0) ownRow.add(s.id);
+  }
+  const descentAt = new Map([[0, ownRow]]);
+
+  const walk = (step, direction) => {
+    let frontier = ownRow;
+    let row = direction;
+    while (peopleByLevel.has(row)) {
+      const next = new Set();
+      for (const id of frontier) {
+        for (const reached of step(id)) if (levelOf.get(reached) === row) next.add(reached);
+      }
+      descentAt.set(row, next);
+      frontier = next;
+      row += direction;
+    }
+  };
+  walk((id) => graph.parents(id).map((p) => p.id), -1);
+  walk((id) => graph.children(id).map((c) => c.id), 1);
+
+  const focus = new CompactMember(
+    focusPerson,
+    spousesOf(included.focusId)
+      .filter((id) => levelOf.get(id) === 0)
+      .map((id) => graph.people.get(id))
+      .filter(Boolean)
+      .sort(readingOrder),
+  );
+
+  // The centre is drawn as the view's own block, so its row lists only who stands beside it.
+  // Everybody else on that row still appears.
+  const spokenFor = new Set(focus.ids);
+
+  const bands = [];
+  for (const level of [...peopleByLevel.keys()].sort((a, b) => a - b)) {
+    const here = new Set(
+      peopleByLevel.get(level).filter((id) => level !== 0 || !spokenFor.has(id)),
+    );
+    const byDescent = new Set([...(descentAt.get(level) ?? [])].filter((id) => here.has(id)));
+
+    const groups = marriageGroups(here, spousesOf)
+      .map((group) => {
+        const order = readAcross(group, byDescent, graph, spousesOf);
+        const people = order.map((id) => graph.people.get(id)).filter(Boolean);
+        const links = order.slice(0, -1)
+          .map((id, i) => spousesOf(id).includes(order[i + 1]));
+        return new CompactGroup(
+          people,
+          links,
+          new Set(order.filter((id) => byDescent.has(id))),
+        );
+      })
+      .sort(groupOrder(graph));
+
+    if (groups.length > 0) bands.push(new CompactBand(level, groups));
+  }
+
+  return new CompactFamily({ focus, bands, truncated: included.truncated });
+}
+
+/**
+ * Everyone on a row who is joined, directly or through somebody else, by a marriage.
+ *
+ * The seed is taken in sorted order rather than in the order the row happened to be built. The
+ * Kotlin takes whatever its LinkedHashSet offers first; the groups it finds are connected
+ * components either way, so the *membership* cannot differ -- only which group is emitted first,
+ * and `groupOrder` decides that afterwards. Sorting here just means two runs on the same file walk
+ * the row identically.
+ */
+function marriageGroups(row, spousesOf) {
+  const remaining = new Set([...row].sort());
+  const groups = [];
+  while (remaining.size > 0) {
+    const seed = remaining.values().next().value;
+    const group = new Set([seed]);
+    const queue = [seed];
+    while (queue.length > 0) {
+      for (const spouse of spousesOf(queue.shift())) {
+        if (remaining.has(spouse) && !group.has(spouse)) { group.add(spouse); queue.push(spouse); }
+      }
+    }
+    for (const id of group) remaining.delete(id);
+    groups.push(group);
+  }
+  return groups;
+}
+
+/**
+ * The order a marriage group is read across the row.
+ *
+ * Walked along the marriages themselves, starting from somebody at the end of the chain, so that a
+ * person who married twice ends up *between* their two spouses rather than beside one of them with
+ * the other stranded. That is what lets the doubled rule be drawn only where there really is a
+ * marriage.
+ *
+ * Where the chain could start at either end it starts with somebody the band is about, so a row of
+ * brothers and sisters leads with the sister rather than with the man she married. Remaining ties
+ * break on birth and then on id: a row that reshuffles itself when the window is resized is
+ * disorienting for no reason.
+ */
+function readAcross(group, byDescent, graph, spousesOf) {
+  if (group.size <= 1) return [...group];
+
+  const within = new Map(
+    [...group].map((id) => [id, spousesOf(id).filter((s) => group.has(s)).sort()]),
+  );
+  const birthOf = (id) => birthYear(graph.people.get(id) ?? {}) ?? UNDATED;
+
+  const start = [...group].sort(by(
+    (id) => within.get(id).length,
+    (id) => (byDescent.has(id) ? 0 : 1),
+    (id) => birthOf(id),
+    (id) => id,
+  ))[0];
+
+  const order = [];
+  const seen = new Set();
+  const queue = [start];
+  while (queue.length > 0) {
+    const next = queue.shift();
+    if (seen.has(next)) continue;
+    seen.add(next);
+    order.push(next);
+    const neighbours = within.get(next)
+      .filter((id) => !seen.has(id))
+      .sort(by((id) => within.get(id).length, (id) => birthOf(id)));
+    // Depth-first along the chain: pushed to the front, in reverse, so the first neighbour after
+    // the sort is the first one walked. `ArrayDeque.addFirst` in a forEach has the same effect.
+    for (const id of [...neighbours].reverse()) queue.unshift(id);
+  }
+  // Anyone the walk could not reach -- impossible for a connected group, but the row is more
+  // useful missing a mark than missing a person.
+  order.push(...[...group].filter((id) => !seen.has(id)).sort());
+  return order;
+}
+
+/**
+ * Groups run oldest first, judged on the people the band is actually about.
+ *
+ * Birth order is how a family lists a generation aloud, and in Hindi it is a kinship fact in its
+ * own right -- an elder and a younger brother are different words. Someone with no recorded birth
+ * year sorts last, so an undated placeholder never displaces the eldest.
+ */
+function groupOrder(graph) {
+  const yearOf = (id) => birthYear(graph.people.get(id) ?? {}) ?? UNDATED;
+  return by(
+    (group) => {
+      const counted = group.ofBand.size > 0 ? [...group.ofBand] : group.ids;
+      return Math.min(...counted.map(yearOf));
+    },
+    (group) => group.people[0]?.name?.toLowerCase() ?? UNNAMED,
+    (group) => group.ids[0],
+  );
+}
+
+const readingOrder = by(
+  (person) => birthYear(person) ?? UNDATED,
+  (person) => person.name?.toLowerCase() ?? UNNAMED,
+  (person) => person.id,
+);
+
+/** `compareBy` with several keys, as Kotlin has it: the first key that differs decides. */
+function by(...keys) {
+  return (a, b) => {
+    for (const key of keys) {
+      const ka = key(a);
+      const kb = key(b);
+      if (ka < kb) return -1;
+      if (ka > kb) return 1;
+    }
+    return 0;
+  };
+}

--- a/site/playground/compact.js
+++ b/site/playground/compact.js
@@ -275,9 +275,15 @@ function readAcross(group, byDescent, graph, spousesOf) {
     const neighbours = within.get(next)
       .filter((id) => !seen.has(id))
       .sort(by((id) => within.get(id).length, (id) => birthOf(id)));
-    // Depth-first along the chain: pushed to the front, in reverse, so the first neighbour after
-    // the sort is the first one walked. `ArrayDeque.addFirst` in a forEach has the same effect.
-    for (const id of [...neighbours].reverse()) queue.unshift(id);
+    /*
+     * `neighbours.forEach { queue.addFirst(it) }`, exactly as the Kotlin has it.
+     *
+     * Pushing a, then b, then c to the *front* leaves the queue as c, b, a -- so the walk carries
+     * on with the LAST of the sorted neighbours, not the first. Reversing first to "fix" that
+     * reads more natural and produces the opposite order, which is what this did until a group
+     * containing somebody married three times was tested. Every smaller group passes either way.
+     */
+    for (const id of neighbours) queue.unshift(id);
   }
   // Anyone the walk could not reach -- impossible for a connected group, but the row is more
   // useful missing a mark than missing a person.

--- a/site/playground/compact.test.mjs
+++ b/site/playground/compact.test.mjs
@@ -1,0 +1,363 @@
+/*
+ * CompactFamilyTest.kt, case for case, plus the selection half of TreeLayoutEngineTest.kt.
+ *
+ * These are not new tests. Almost every one is a translation of a case in
+ * `app/src/test/java/com/vibethroughcode/ftree/graph/CompactFamilyTest.kt` or
+ * `TreeLayoutEngineTest.kt`, kept in the same order and with the same names, because the point of
+ * the exercise is that two implementations of one set of family rules must not drift apart.
+ * Reading the two files side by side should be dull.
+ *
+ * Where a case is added rather than translated it says so.
+ *
+ * The Kotlin builds a `TreeLayout` and reads levels back off it. Here `collectFocused` returns the
+ * levels directly, so the cases that assert `layout.node("g2") == null` become assertions about
+ * `levels.has('g2')` -- the same claim about the same rule, without a coordinate in sight.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { buildGraph } from './model.js';
+import { collectFocused, mostConnected } from './focus.js';
+import { compactFamily } from './compact.js';
+
+/** Builds a graph from a compact description of a family, as the Kotlin's Builder does. */
+class Builder {
+  constructor() {
+    this.people = [];
+    this.relationships = [];
+  }
+
+  person(id, born = null) {
+    this.people.push({ id, name: id, birthDate: born });
+    return this;
+  }
+
+  unnamed(id) {
+    this.people.push({ id, name: null });
+    return this;
+  }
+
+  parentOf(parent, child) {
+    this.relationships.push({ from: parent, to: child, type: 'PARENT' });
+    return this;
+  }
+
+  married(a, b) {
+    this.relationships.push({ from: a, to: b, type: 'SPOUSE' });
+    return this;
+  }
+
+  siblingOf(a, b) {
+    this.relationships.push({ from: a, to: b, type: 'SIBLING' });
+    return this;
+  }
+
+  build() {
+    return buildGraph({ people: this.people, relationships: this.relationships });
+  }
+}
+
+const compact = (graph, focusId, { up = 3, down = 3 } = {}) =>
+  compactFamily(graph, focusId, { up, down });
+
+/** Three generations, a second marriage upstairs, and a sibling with a spouse of their own. */
+const family = () => new Builder()
+  .person('grandfather', '1935').person('grandmother', '1938')
+  .person('stepGrandmother', '1944')
+  .person('father', '1962').person('mother', '1965')
+  .person('me', '1990').person('sister', '1987').person('wife', '1992')
+  .person('brotherInLaw', '1985')
+  .person('son', '2018').person('daughter', '2020')
+  .married('grandfather', 'grandmother')
+  .married('grandfather', 'stepGrandmother')
+  .married('father', 'mother')
+  .married('me', 'wife')
+  .married('sister', 'brotherInLaw')
+  .parentOf('grandfather', 'father').parentOf('grandmother', 'father')
+  .parentOf('father', 'me').parentOf('mother', 'me')
+  .parentOf('father', 'sister').parentOf('mother', 'sister')
+  .parentOf('me', 'son').parentOf('wife', 'son')
+  .parentOf('me', 'daughter').parentOf('wife', 'daughter')
+  .build();
+
+/** Everybody on a row, in the order they are read across it. */
+const ids = (view, offset) =>
+  (view.band(offset)?.groups ?? []).flatMap((group) => group.ids);
+
+/** Only the people the row's heading counts. */
+const counted = (view, offset) =>
+  (view.band(offset)?.groups ?? [])
+    .flatMap((group) => group.ids.filter((id) => group.ofBand.has(id)));
+
+// ------------------------------------------------------------------ CompactFamilyTest.kt
+
+test('an unknown focus produces nothing rather than throwing', () => {
+  assert.ok(compact(family(), 'nobody').isEmpty);
+});
+
+test('generations become bands measured from the focus', () => {
+  const view = compact(family(), 'me');
+
+  assert.strictEqual(view.focus.person.id, 'me');
+  assert.deepStrictEqual(counted(view, -2), ['grandmother', 'grandfather']);
+  assert.deepStrictEqual(counted(view, -1), ['father', 'mother']);
+  assert.deepStrictEqual(counted(view, 0), ['sister']);
+  assert.deepStrictEqual(counted(view, 1), ['son', 'daughter']);
+});
+
+test('the focus is shown with whoever they married rather than beside them', () => {
+  const view = compact(family(), 'me');
+
+  assert.deepStrictEqual(view.focus.partners.map((p) => p.id), ['wife']);
+  // The wife is on row zero too, but she belongs to the centre, not to the row of siblings.
+  assert.ok(!ids(view, 0).includes('wife'));
+});
+
+test('somebody married into a generation is shown there but not counted as one of it', () => {
+  const view = compact(family(), 'me');
+
+  // Both parents are parents; the heading counts two.
+  assert.strictEqual(view.band(-1).count, 2);
+
+  // A second marriage upstairs shows the step-grandmother without making her a grandparent.
+  assert.strictEqual(view.band(-2).count, 2);
+  assert.deepStrictEqual(ids(view, -2), ['grandmother', 'grandfather', 'stepGrandmother']);
+});
+
+test('a second marriage puts the twice-married person between their two spouses', () => {
+  const groups = compact(family(), 'me').band(-2).groups;
+  assert.strictEqual(groups.length, 1);
+  const group = groups[0];
+
+  assert.deepStrictEqual(group.ids, ['grandmother', 'grandfather', 'stepGrandmother']);
+  // Every mark drawn is a marriage that happened: the two wives were never wed.
+  assert.ok(group.married(0));
+  assert.ok(group.married(1));
+  assert.strictEqual(group.links.length, 2);
+});
+
+test('two people who never married stand apart rather than joined', () => {
+  const graph = new Builder()
+    .person('me', '1990')
+    .person('son', '2015').person('daughter', '2018')
+    .parentOf('me', 'son').parentOf('me', 'daughter')
+    .build();
+
+  const children = compact(graph, 'me').band(1);
+  assert.strictEqual(children.groups.length, 2);
+  assert.ok(children.groups.every((g) => g.links.length === 0));
+});
+
+test('a row of brothers and sisters leads with the sibling, not the person she married', () => {
+  const siblings = compact(family(), 'me').band(0);
+
+  assert.strictEqual(siblings.count, 1);
+  assert.strictEqual(siblings.groups.length, 1);
+  assert.deepStrictEqual(siblings.groups[0].ids, ['sister', 'brotherInLaw']);
+  assert.ok(siblings.groups[0].married(0));
+});
+
+test('a band is read oldest first, with undated people last', () => {
+  const graph = new Builder()
+    .person('me', '1990')
+    .person('father', '1960')
+    .person('youngest', '2015').person('eldest', '2005').unnamed('undated')
+    .parentOf('father', 'me')
+    .parentOf('me', 'youngest').parentOf('me', 'eldest').parentOf('me', 'undated')
+    .build();
+
+  assert.deepStrictEqual(ids(compact(graph, 'me'), 1), ['eldest', 'youngest', 'undated']);
+});
+
+test('an empty generation is left out rather than shown as an empty band', () => {
+  const view = compact(new Builder().person('me', '1990').build(), 'me');
+
+  assert.strictEqual(view.focus.person.id, 'me');
+  assert.deepStrictEqual(view.bands, []);
+  assert.strictEqual(view.band(-1), null);
+  assert.strictEqual(view.band(1), null);
+});
+
+test("siblings joined only by an explicit edge still share the focus's row", () => {
+  const graph = new Builder()
+    .person('me', '1990').person('cousinless', '1992')
+    .siblingOf('me', 'cousinless')
+    .build();
+
+  assert.deepStrictEqual(ids(compact(graph, 'me'), 0), ['cousinless']);
+});
+
+test('it shows exactly the people the selection chose', () => {
+  const graph = family();
+  for (const focusId of ['me', 'father', 'grandfather', 'sister', 'son']) {
+    const selection = collectFocused(graph, focusId);
+    const view = compactFamily(graph, focusId, { selection });
+
+    assert.deepStrictEqual(
+      new Set(view.everyone),
+      new Set(selection.levels.keys()),
+      `centred on ${focusId}`,
+    );
+    // Nobody is shown twice: a partner belongs to one person, and the centre is not also standing
+    // in its own row.
+    assert.strictEqual(
+      view.everyone.length,
+      new Set(view.everyone).size,
+      `centred on ${focusId}`,
+    );
+  }
+});
+
+test('it says when the record continues past what was loaded', () => {
+  const graph = family();
+
+  assert.ok(compact(graph, 'me', { up: 1 }).truncated);
+  assert.ok(!compact(graph, 'me', { up: 3 }).truncated);
+});
+
+// ------------------------------------------------- TreeLayoutEngineTest.kt, the selection half
+
+const nuclearFamily = () => new Builder()
+  .person('father', '1962').person('mother', '1965')
+  .person('me', '1990').person('sister', '1993')
+  .person('wife', '1992').person('child', '2020')
+  .married('father', 'mother')
+  .married('me', 'wife')
+  .parentOf('father', 'me').parentOf('mother', 'me')
+  .parentOf('father', 'sister').parentOf('mother', 'sister')
+  .parentOf('me', 'child').parentOf('wife', 'child')
+  .build();
+
+test('an unknown focus selects nothing rather than throwing', () => {
+  const selection = collectFocused(nuclearFamily(), 'nobody');
+  assert.strictEqual(selection.focusId, null);
+  assert.strictEqual(selection.levels.size, 0);
+});
+
+test('a lone person is a chart of one', () => {
+  const selection = collectFocused(new Builder().person('me').build(), 'me');
+
+  assert.strictEqual(selection.levels.size, 1);
+  assert.strictEqual(selection.levels.get('me'), 0);
+});
+
+test('generations sit at their own offsets before and after the focus', () => {
+  const levels = collectFocused(nuclearFamily(), 'me').levels;
+
+  assert.strictEqual(levels.get('father'), -1);
+  assert.strictEqual(levels.get('mother'), -1);
+  assert.strictEqual(levels.get('me'), 0);
+  assert.strictEqual(levels.get('sister'), 0);
+  assert.strictEqual(levels.get('wife'), 0);
+  assert.strictEqual(levels.get('child'), 1);
+});
+
+test('siblings joined only by an explicit edge still share the generation', () => {
+  const graph = new Builder()
+    .person('me', '1990').person('brother', '1992')
+    .siblingOf('me', 'brother')
+    .build();
+
+  assert.strictEqual(collectFocused(graph, 'me').levels.get('brother'), 0);
+});
+
+test('the generation limit bounds how far the chart reaches', () => {
+  const builder = new Builder();
+  // A ten-generation line of descent.
+  for (let i = 0; i <= 10; i++) builder.person(`g${i}`, String(1900 + i * 25));
+  for (let i = 0; i < 10; i++) builder.parentOf(`g${i}`, `g${i + 1}`);
+
+  const levels = collectFocused(builder.build(), 'g5', { up: 2, down: 2 }).levels;
+
+  assert.ok(levels.has('g3'));
+  assert.ok(levels.has('g7'));
+  assert.ok(!levels.has('g2'));
+  assert.ok(!levels.has('g8'));
+  assert.ok(
+    collectFocused(builder.build(), 'g5', { up: 2, down: 2 }).truncated,
+    'more generations exist, so the chart says so',
+  );
+});
+
+test('a fully shown family is not marked truncated', () => {
+  assert.ok(!collectFocused(nuclearFamily(), 'me').truncated);
+});
+
+test('cousins are left out because re-focusing reaches them', () => {
+  const graph = new Builder()
+    .person('grandfather').person('father').person('uncle')
+    .person('me').person('cousin')
+    .parentOf('grandfather', 'father').parentOf('grandfather', 'uncle')
+    .parentOf('father', 'me').parentOf('uncle', 'cousin')
+    .build();
+
+  const levels = collectFocused(graph, 'me').levels;
+
+  assert.ok(levels.has('grandfather'));
+  assert.ok(levels.has('father'));
+  // The uncle's line would multiply the width without adding to what the chart says.
+  assert.ok(!levels.has('cousin'));
+  // Added, not translated, and worth pinning because it surprised me: the *uncle himself* is out
+  // too. The upward walk adds parents and their partners -- never siblings, except on the focus's
+  // own row. So "not the descendants of ancestors' siblings" is really "not ancestors' siblings at
+  // all", and an uncle is reached by re-focusing on the grandfather rather than from here.
+  assert.ok(!levels.has('uncle'));
+});
+
+test('the same family always selects the same way', () => {
+  const graph = family();
+  const once = compactFamily(graph, 'me');
+  const twice = compactFamily(graph, 'me');
+
+  assert.deepStrictEqual(once.everyone, twice.everyone);
+  for (const offset of [-2, -1, 0, 1]) {
+    assert.deepStrictEqual(ids(once, offset), ids(twice, offset));
+  }
+});
+
+// ------------------------------------------------------------------ added, not translated
+
+test("nieces and nephews are left out, which is the same rule from the other direction", () => {
+  // The Kotlin tests cousins; it does not test the downward half of the same exclusion, and the
+  // downward walk starts from the focus alone precisely to produce it.
+  const graph = new Builder()
+    .person('me').person('sister').person('niece')
+    .person('mother')
+    .parentOf('mother', 'me').parentOf('mother', 'sister')
+    .parentOf('sister', 'niece')
+    .build();
+
+  const levels = collectFocused(graph, 'me').levels;
+
+  assert.ok(levels.has('sister'));
+  assert.ok(!levels.has('niece'));
+});
+
+test('a cousin marriage gets one stable level rather than two', () => {
+  // The reason every assignment is `putIfAbsent`. Reachable as both a spouse on row 0 and a child
+  // on row 1, this person must land on one row and stay there.
+  const graph = new Builder()
+    .person('me', '1990').person('cousinWife', '1991')
+    .person('father', '1960').person('uncle', '1958')
+    .married('me', 'cousinWife')
+    .parentOf('father', 'me').parentOf('uncle', 'cousinWife')
+    .build();
+
+  const levels = collectFocused(graph, 'me').levels;
+  assert.strictEqual(levels.get('cousinWife'), 0);
+});
+
+test('the most-connected person is the fallback focus, and it is stable', () => {
+  // Not in the Kotlin: the phone always arrives at this view holding a person. The desktop can
+  // open a file with nobody selected, and "the first row of the file" is export order.
+  const graph = family();
+  assert.strictEqual(mostConnected(graph), mostConnected(graph));
+  // `me` has two parents, two children, a wife and a sister: nobody in this family has more.
+  assert.strictEqual(mostConnected(graph), 'me');
+});
+
+test('an empty tree has no focus to fall back to', () => {
+  assert.strictEqual(mostConnected(buildGraph({ people: [], relationships: [] })), null);
+  assert.ok(compactFamily(buildGraph({ people: [], relationships: [] }), null).isEmpty);
+});

--- a/site/playground/compact.test.mjs
+++ b/site/playground/compact.test.mjs
@@ -361,3 +361,36 @@ test('an empty tree has no focus to fall back to', () => {
   assert.strictEqual(mostConnected(buildGraph({ people: [], relationships: [] })), null);
   assert.ok(compactFamily(buildGraph({ people: [], relationships: [] }), null).isEmpty);
 });
+
+test('somebody married three times is walked in the Kotlin’s order, not the obvious one', () => {
+  /*
+   * Added, not translated -- and it exists because the first version of `readAcross` got this
+   * wrong in a way no other case could see.
+   *
+   * The Kotlin pushes each sorted neighbour with `ArrayDeque.addFirst`, in a `forEach`. Pushing a,
+   * then b, then c to the *front* leaves the queue as c, b, a -- so the walk continues with the
+   * LAST of the sorted neighbours, not the first. Translating that as "unshift them in reverse"
+   * reads more natural and is the opposite order.
+   *
+   * It can only show where one person has two or more unwalked spouses inside the group, which
+   * means somebody married at least three times. Every other case in this file has a group whose
+   * members each have one unwalked neighbour, and passes under either order.
+   */
+  const graph = new Builder()
+    .person('me', '1990')
+    .person('thrice', '1960')
+    .person('first', '1958').person('second', '1962').person('third', '1966')
+    .married('thrice', 'first').married('thrice', 'second').married('thrice', 'third')
+    .parentOf('thrice', 'me')
+    .build();
+
+  const group = compact(graph, 'me').band(-1).groups[0];
+
+  // `thrice` is the only person with more than one marriage, so the chain starts at an end and
+  // reaches them second. What follows is the part the order decides.
+  assert.deepStrictEqual(group.ids, ['first', 'thrice', 'third', 'second']);
+
+  // Every mark is a real marriage: the three spouses were never wed to each other, so only the
+  // gaps that touch `thrice` are marked.
+  assert.deepStrictEqual(group.links, [true, true, false]);
+});

--- a/site/playground/focus.js
+++ b/site/playground/focus.js
@@ -1,0 +1,110 @@
+/*
+ * Who belongs on a chart centred on one person, and which generation they stand in.
+ *
+ * A transcription of the selection half of `app/.../graph/TreeLayoutEngine.kt` -- the function
+ * `collect`, and nothing else from that file. The other 250 lines of it work out coordinates, and
+ * coordinates are the one thing this does not need: `compactFamily` consumes ids and levels.
+ *
+ * It lives in `site/playground/` rather than in the desktop app because it is a *rule about
+ * families*, not a drawing decision, and every rule ported out of the Kotlin is a rule that can
+ * quietly drift. One copy, one test table.
+ *
+ * A divergence worth stating plainly, because it is deliberate rather than an oversight:
+ *
+ *   On Android, the compact view is built from the focused chart's own output, so the two cannot
+ *   disagree about who is family. The desktop's chart is the *whole* tree, and the focused chart is
+ *   not being ported (see #89) -- so on the desktop, compact makes this selection itself. That is
+ *   why the rules are here, in one shared module, instead of inside whichever view happened to
+ *   need them first.
+ */
+
+/**
+ * Chooses who appears on a chart centred on `focusId`, and at what generation offset.
+ *
+ * Ancestors and descendants of the focus, the focus's own siblings, and the partners of all of
+ * them. Deliberately *not* included: the descendants of siblings and of ancestors' siblings.
+ * Cousins and nieces multiply a chart's width far faster than they add to what it tells you, and
+ * they are one click away by re-focusing.
+ *
+ * Returns `{ levels, focusId, truncated }`, where `levels` maps a person's id to their offset from
+ * the focus: -1 is a parent, +1 a child, 0 the row the focus stands in. `focusId` is null when
+ * there is no such person, and `levels` is then empty -- an unknown focus produces nothing rather
+ * than throwing, because "the tree you loaded no longer has the person you had selected" is a
+ * thing that happens and is not an error.
+ */
+export function collectFocused(graph, focusId, { up = 3, down = 3 } = {}) {
+  if (!graph.people.has(focusId)) return { levels: new Map(), focusId: null, truncated: false };
+
+  const levels = new Map([[focusId, 0]]);
+  let truncated = false;
+
+  // `putIfAbsent` throughout, as the Kotlin has it: the first assignment of a level wins. It is
+  // what keeps a cousin marriage stable -- somebody reachable as both a cousin and an in-law gets
+  // one level and keeps it, rather than flickering between two depending on the walk.
+  const place = (id, level) => { if (!levels.has(id)) levels.set(id, level); };
+  const addPartners = (id, level) => {
+    for (const spouse of graph.spouses(id)) place(spouse.id, level);
+  };
+
+  // The focus's siblings share the row.
+  const siblingIds = graph.siblings(focusId).map((s) => s.id);
+  for (const id of siblingIds) place(id, 0);
+  for (const id of [...levels.keys()]) addPartners(id, 0);
+
+  // Upwards, from the focus and their siblings together: a chart centred on somebody shows their
+  // parents, and their siblings' parents are the same people.
+  let frontier = new Set([...siblingIds, focusId]);
+  for (let generation = 1; generation <= up; generation++) {
+    const parents = new Set();
+    for (const id of frontier) for (const p of graph.parents(id)) parents.add(p.id);
+    if (parents.size === 0) break;
+    for (const id of parents) place(id, -generation);
+    for (const id of parents) addPartners(id, -generation);
+    frontier = parents;
+    // Only asked at the limit, and only of the ring actually reached. A line that simply ends is
+    // not truncated -- the `break` above has already left the loop in that case.
+    if (generation === up && [...parents].some((id) => graph.parents(id).length > 0)) {
+      truncated = true;
+    }
+  }
+
+  // Downwards from the focus alone. Not from the siblings: their children are nieces and nephews,
+  // and including them is the same width explosion as cousins, arriving from the other direction.
+  frontier = new Set([focusId]);
+  for (let generation = 1; generation <= down; generation++) {
+    const children = new Set();
+    for (const id of frontier) for (const c of graph.children(id)) children.add(c.id);
+    if (children.size === 0) break;
+    for (const id of children) place(id, generation);
+    for (const id of children) addPartners(id, generation);
+    frontier = children;
+    if (generation === down && [...children].some((id) => graph.children(id).length > 0)) {
+      truncated = true;
+    }
+  }
+
+  return { levels, focusId, truncated };
+}
+
+/**
+ * The person to centre on when nobody has been chosen: whoever has the most relatives recorded.
+ *
+ * Not in the Kotlin, because the phone always has a person in hand -- you arrive at the focused
+ * chart *from* somebody. The desktop can open a file and show a chart with nothing selected, so it
+ * needs an answer to "centred on whom?" that is better than "the first row of the file", which is
+ * export order and means nothing to a reader.
+ *
+ * The most-connected person is a good guess for the same reason they are most connected: a tree is
+ * usually built outwards from somebody, and the chart is most legible centred near the middle of
+ * it. Ties break on id so that opening the same file twice gives the same chart.
+ */
+export function mostConnected(graph) {
+  let best = null;
+  let bestScore = -1;
+  for (const id of [...graph.order].sort()) {
+    const score = graph.parents(id).length + graph.children(id).length
+      + graph.spouses(id).length + graph.siblings(id).length;
+    if (score > bestScore) { best = id; bestScore = score; }
+  }
+  return best;
+}


### PR DESCRIPTION
Closes #120. Phase 1 of the #89 closing sequence.

The third reading of a tree, and the only one that is composed rather than painted. The chart is a picture — to read a name you zoom, to reach a relative you pan, and a canvas holds nothing at all for a screen reader. The people list is alphabetical and has no family in it. Between *"a picture you must zoom"* and *"a list with no shape"* there was nothing.

On the 2030-person fixture the chart fits at **2% zoom**. Compact shows that person's family in **37 names**.

## What was ported

From `graph/CompactFamily.kt` and the **selection** half of `graph/TreeLayoutEngine.kt`, both with the Kotlin's own test tables. `CompactFamily.from` consumes only ids and levels, so none of the ~250 lines of placement arithmetic came across — only the ~50 that decide who is on the chart and on which row.

- **`site/playground/focus.js`** — `collectFocused`, a transcription of `collect`: the focus, their siblings, everyone's partners; rings of parents upward from *siblings + focus*, rings of children downward from *the focus alone*; `putIfAbsent` throughout so a cousin marriage gets one stable level; `truncated` only when the last ring walked still has family beyond it.
- **`site/playground/compact.js`** — `CompactGroup` / `CompactBand` / `CompactMember`, with `ofBand` (membership by descent, so a step-grandmother is shown but not counted as a fifth grandparent), `readAcross` and `groupOrder`.

**24 cases**, 19 translated and 5 added. One of the added ones corrected me: I asserted an uncle appears on the chart, and he does not — the upward walk adds parents and their partners, never siblings, so *"not the descendants of ancestors' siblings"* is really *"not ancestors' siblings at all"*. Pinned, because it surprised me and will surprise the next reader.

## The divergence, stated in the code

On Android compact derives **from the focused chart**, so the two cannot disagree about who is family. The desktop's chart is whole-tree, and the focused chart is [deliberately not being ported](https://github.com/thisisankit27/f-tree/issues/89#issuecomment-5610043982) — so compact here makes its own selection. That is why the rules live in one shared module instead of inside whichever view needed them first.

## In the app

**View → Compact** on `Ctrl+3` — third in the menu and third in the numbering, so nobody's `Ctrl+2` changes meaning under them. Also `C`.

Clicking a name **walks the reading** to that person rather than opening the editor. Everywhere else in this app a click on a person edits them, and two meanings for one click would make both uncertain — so editing is offered once, from the block for the person already centred, and the walk stays a single unambiguous action.

The one visual device invented here is the **marriage rule**, and it comes from the chart rather than from a stylesheet: a doubled line between two names, drawn only where there was a marriage. Somebody who married twice puts three people in one group and only two of the three pairs are weddings.

The smoke test asserts that as an **invariant over whatever file is opened** — a group of two or more has at least one rule, and never more rules than gaps — rather than *"there is at least one rule"*, which a tree of cousins fails for being correct. On the sample family it reads `3:2`: three people, two rules.

## Also here, because this work needed them

- `"../site/playground/*.test.mjs"` wired into `desktop`'s `npm test`, with a `node --test` step added to `pages.yml` and the engine's tests excluded from `extraResources` (confirmed absent from the built package). `suite.test.js` now guards that directory too, so an engine test cannot go unrun either.
- The smoke test counted the people list against a hardcoded `23` — the sample family's population — so the harness **refused to be pointed at any other fixture**, failing on the large tree by reporting *"2030 rows — 2030 people"*. Counted against the tree's own total now.

Docs: `docs/desktop.md` gains the three views, and loses two stale claims — that generations are drawn as columns (reversed long ago; both shells draw rows) and that the desktop has a relation finder (the engine exists, the panel is #121).

## Verification

- `cd desktop && npm test` — **126 → 157**, 0 fail.
- `node --test "site/playground/*.test.mjs"` — 24 pass.
- `check_layout.mjs` and `check_writer.mjs` — all pass; module graph resolves.
- **The packaged app**, not `electron .`: built, then run unconfined through `systemd-run --user` (this shell is snap-confined and gives false passes on launch behaviour). Four fixtures — 4, 23, 23-streamed and 2030 people — all green, including the "show more generations" path on the large tree (7 bands → 9).
- Both themes screenshotted.
- `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
