### PR TITLE
fix(kinship): walk blood before marriage, as the Kotlin does

### DIFF
--- a/site/playground/kinship-golden.txt
+++ b/site/playground/kinship-golden.txt
@@ -517,14 +517,14 @@ My Brother [brother] -> Her Sister [her-sister]  kind=related  term=wife  marrie
 My Brother [brother] -> Me [me]  kind=related  term=brother  marriedTo=-  ofSpouse=-  via=our-father  chain=sibling/brother/me
 My Brother [brother] -> Our Father [our-father]  kind=related  term=father  marriedTo=-  ofSpouse=-  via=our-father  chain=parent/father/our-father
 My Brother [brother] -> Their Father [their-father]  kind=related  term=father-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/wife/her-sister > parent/father/their-father
-My Brother [brother] -> My Wife [wife]  kind=related  term=sister-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/wife/her-sister > sibling/sister/wife
+My Brother [brother] -> My Wife [wife]  kind=related  term=sister-in-law  marriedTo=-  ofSpouse=-  via=-  chain=sibling/brother/me > spouse/wife/wife
 Her Sister [her-sister] -> My Brother [brother]  kind=related  term=husband  marriedTo=-  ofSpouse=-  via=-  chain=spouse/husband/brother
-Her Sister [her-sister] -> Me [me]  kind=related  term=brother-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/husband/brother > sibling/brother/me
+Her Sister [her-sister] -> Me [me]  kind=related  term=brother-in-law  marriedTo=-  ofSpouse=-  via=-  chain=sibling/sister/wife > spouse/husband/me
 Her Sister [her-sister] -> Our Father [our-father]  kind=related  term=father-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/husband/brother > parent/father/our-father
 Her Sister [her-sister] -> Their Father [their-father]  kind=related  term=father  marriedTo=-  ofSpouse=-  via=their-father  chain=parent/father/their-father
 Her Sister [her-sister] -> My Wife [wife]  kind=related  term=sister  marriedTo=-  ofSpouse=-  via=their-father  chain=sibling/sister/wife
 Me [me] -> My Brother [brother]  kind=related  term=brother  marriedTo=-  ofSpouse=-  via=our-father  chain=sibling/brother/brother
-Me [me] -> Her Sister [her-sister]  kind=related  term=sister-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/wife/wife > sibling/sister/her-sister
+Me [me] -> Her Sister [her-sister]  kind=related  term=sister-in-law  marriedTo=-  ofSpouse=-  via=-  chain=sibling/brother/brother > spouse/wife/her-sister
 Me [me] -> Our Father [our-father]  kind=related  term=father  marriedTo=-  ofSpouse=-  via=our-father  chain=parent/father/our-father
 Me [me] -> Their Father [their-father]  kind=related  term=father-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/wife/wife > parent/father/their-father
 Me [me] -> My Wife [wife]  kind=related  term=wife  marriedTo=-  ofSpouse=-  via=-  chain=spouse/wife/wife
@@ -538,7 +538,7 @@ Their Father [their-father] -> Her Sister [her-sister]  kind=related  term=daugh
 Their Father [their-father] -> Me [me]  kind=related  term=son-in-law  marriedTo=-  ofSpouse=-  via=-  chain=child/daughter/wife > spouse/husband/me
 Their Father [their-father] -> Our Father [our-father]  kind=related  term=-  marriedTo=-  ofSpouse=-  via=-  chain=child/daughter/wife > spouse/husband/me > parent/father/our-father
 Their Father [their-father] -> My Wife [wife]  kind=related  term=daughter  marriedTo=-  ofSpouse=-  via=their-father  chain=child/daughter/wife
-My Wife [wife] -> My Brother [brother]  kind=related  term=brother-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/husband/me > sibling/brother/brother
+My Wife [wife] -> My Brother [brother]  kind=related  term=brother-in-law  marriedTo=-  ofSpouse=-  via=-  chain=sibling/sister/her-sister > spouse/husband/brother
 My Wife [wife] -> Her Sister [her-sister]  kind=related  term=sister  marriedTo=-  ofSpouse=-  via=their-father  chain=sibling/sister/her-sister
 My Wife [wife] -> Me [me]  kind=related  term=husband  marriedTo=-  ofSpouse=-  via=-  chain=spouse/husband/me
 My Wife [wife] -> Our Father [our-father]  kind=related  term=father-in-law  marriedTo=-  ofSpouse=-  via=-  chain=spouse/husband/me > parent/father/our-father

--- a/site/playground/model.js
+++ b/site/playground/model.js
@@ -531,7 +531,22 @@ function inLawTerm(relative, other, direction) {
   return null;
 }
 
-/** Breadth-first over every edge kind, so in-laws and step-relations are reachable too. */
+/**
+ * The shortest chain of relationships joining two people, over every kind of edge.
+ *
+ * Breadth-first over every edge kind, so in-laws and step-relations are reachable too. Marriage is
+ * walked as well as blood, because "my wife's mother" is exactly the sort of question this feature
+ * is asked, and no blood-only search can answer it.
+ *
+ * The order the neighbours are enqueued in is the Kotlin's, and it is load-bearing rather than
+ * arbitrary -- see `Kinship.kt:441-444` and the note above it. Blood steps go in before marriage
+ * ones so that where two routes are the same length the one through the family wins: arriving at a
+ * cousin through their spouse would be a true answer and a useless one.
+ *
+ * It can only matter where two routes tie, since this is breadth-first and a shorter route wins
+ * whatever the order. Ties are not rare -- two brothers marrying two sisters produces one -- and
+ * `kinship-golden.txt` holds that shape on purpose.
+ */
 function shortestPath(graph, fromId, toId) {
   const previous = new Map([[fromId, null]]);
   const queue = [fromId];
@@ -543,8 +558,9 @@ function shortestPath(graph, fromId, toId) {
     const steps = [];
     for (const p of graph.parents(current)) steps.push({ id: p.id, via: 'parent', subtype: p.subtype });
     for (const c of graph.children(current)) steps.push({ id: c.id, via: 'child', subtype: c.subtype });
-    for (const s of graph.spouses(current)) steps.push({ id: s.id, via: 'spouse', subtype: s.subtype });
+    // Siblings before spouses: blood before marriage, matching Kinship.kt:441-444.
     for (const s of graph.siblings(current)) steps.push({ id: s.id, via: 'sibling', half: s.half });
+    for (const s of graph.spouses(current)) steps.push({ id: s.id, via: 'spouse', subtype: s.subtype });
 
     for (const step of steps) {
       if (previous.has(step.id)) continue;

--- a/site/playground/shortest-path.test.mjs
+++ b/site/playground/shortest-path.test.mjs
@@ -1,0 +1,97 @@
+/*
+ * The rule the neighbour order exists for, stated as a rule.
+ *
+ * `kinship-golden.txt` guards this too, but it guards it by holding 753 lines of output, and "four
+ * of those lines moved" is a proof nobody can read at a glance. This file says the thing itself:
+ * where two routes are the same length, the one through the family wins.
+ *
+ * Ported from the reasoning at `app/.../graph/Kinship.kt:417-424`:
+ *
+ *   Marriage is walked as well as blood, because "my wife's mother" is exactly the sort of question
+ *   this feature is asked, and no blood-only search can answer it. Blood steps are enqueued before
+ *   marriage ones so that where two routes are the same length the one through the family wins --
+ *   arriving at a cousin through their spouse would be a true answer and a useless one.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { buildGraph, relate } from './model.js';
+
+/**
+ * Two brothers married two sisters.
+ *
+ * My wife's sister is also my brother's wife. She is two steps away either way -- spouse then
+ * sibling, or sibling then spouse -- so which of the two the search reaches her by is decided
+ * entirely by the order the neighbours were enqueued in, and by nothing else.
+ */
+const twoAndTwo = () => buildGraph({
+  people: [
+    { id: 'me', name: 'Me', gender: 'MALE' },
+    { id: 'brother', name: 'My Brother', gender: 'MALE' },
+    { id: 'wife', name: 'My Wife', gender: 'FEMALE' },
+    { id: 'her-sister', name: 'Her Sister', gender: 'FEMALE' },
+    { id: 'our-father', name: 'Our Father', gender: 'MALE' },
+    { id: 'their-father', name: 'Their Father', gender: 'MALE' },
+  ],
+  relationships: [
+    { from: 'our-father', to: 'me', type: 'PARENT' },
+    { from: 'our-father', to: 'brother', type: 'PARENT' },
+    { from: 'their-father', to: 'wife', type: 'PARENT' },
+    { from: 'their-father', to: 'her-sister', type: 'PARENT' },
+    { from: 'me', to: 'wife', type: 'SPOUSE' },
+    { from: 'brother', to: 'her-sister', type: 'SPOUSE' },
+  ],
+});
+
+const chain = (graph, from, to) => relate(graph, from, to).path.map((step) => step.via);
+
+test('where two routes tie, the one through the family wins', () => {
+  const graph = twoAndTwo();
+
+  // She is my brother's wife, not my wife's sister. Both are true; the blood route is the useful
+  // one, because it reaches her through somebody I am related to rather than around the outside.
+  assert.deepStrictEqual(chain(graph, 'me', 'her-sister'), ['sibling', 'spouse']);
+
+  // And the same claim from each of the other three corners of the square, because a rule that
+  // held in one direction only would be a coincidence.
+  assert.deepStrictEqual(chain(graph, 'her-sister', 'me'), ['sibling', 'spouse']);
+  assert.deepStrictEqual(chain(graph, 'brother', 'wife'), ['sibling', 'spouse']);
+  assert.deepStrictEqual(chain(graph, 'wife', 'brother'), ['sibling', 'spouse']);
+});
+
+test('the tie is real: both routes are the same length', () => {
+  // Without this the test above could be passing because the blood route is simply shorter, which
+  // would prove nothing about the order at all.
+  const graph = twoAndTwo();
+  assert.strictEqual(relate(graph, 'me', 'her-sister').path.length, 2);
+  assert.strictEqual(relate(graph, 'me', 'wife').path.length, 1);
+  assert.strictEqual(relate(graph, 'me', 'brother').path.length, 1);
+});
+
+test('a shorter route still wins, whatever it is made of', () => {
+  // The order decides ties and nothing else. My wife is one marriage step away and there is no
+  // blood route to her at all, so preferring blood must not mean preferring a longer answer.
+  const graph = twoAndTwo();
+  assert.deepStrictEqual(chain(graph, 'me', 'wife'), ['spouse']);
+  assert.deepStrictEqual(chain(graph, 'me', 'their-father'), ['spouse', 'parent']);
+});
+
+test('marriage is still walked, or in-laws would be unreachable', () => {
+  // The reason the search is not blood-only in the first place: "my wife's mother" is exactly the
+  // sort of question this feature is asked.
+  const graph = buildGraph({
+    people: [
+      { id: 'me', name: 'Me', gender: 'MALE' },
+      { id: 'wife', name: 'My Wife', gender: 'FEMALE' },
+      { id: 'her-mother', name: 'Her Mother', gender: 'FEMALE' },
+    ],
+    relationships: [
+      { from: 'her-mother', to: 'wife', type: 'PARENT' },
+      { from: 'me', to: 'wife', type: 'SPOUSE' },
+    ],
+  });
+
+  assert.deepStrictEqual(chain(graph, 'me', 'her-mother'), ['spouse', 'parent']);
+  assert.strictEqual(relate(graph, 'me', 'her-mother').term, 'mother-in-law');
+});


### PR DESCRIPTION
Closes #119. Phase 2b, and the one PR in this sequence whose **diff is the deliverable**.

`site/playground/model.js` enqueued `parents, children, spouses, siblings`. `app/.../graph/Kinship.kt:441-444` enqueues `parents, children, siblings, spouses`, and says why at `:417-424`:

> Marriage is walked as well as blood, because "my wife's mother" is exactly the sort of question this feature is asked, and no blood-only search can answer it. **Blood steps are enqueued before marriage ones so that where two routes are the same length the one through the family wins** — arriving at a cousin through their spouse would be a true answer and a useless one.

So for the same pair of people the website viewer — and now the desktop — could name a different route than the phone. That is the drift #89's ground rules exist to prevent, and `relate` is about to be exposed on a new surface (#121), so it should not ship there first.

**Two lines swap.** Everything else here is the consequence.

## Every changed line of the golden, and why

| pair | was | is |
|---|---|---|
| `Me -> Her Sister` | my wife's sister | my brother's wife |
| `Her Sister -> Me` | the same claim from her side | |
| `My Brother -> My Wife` | his wife's sister | his brother's wife |
| `My Wife -> My Brother` | the same claim from her side | |

All four are the one family — **two brothers married two sisters** — and all four **keep their term**:

```
Me -> Her Sister   term=sister-in-law
  was: chain=spouse/wife/wife > sibling/sister/her-sister      (my wife's sister)
  now: chain=sibling/brother/brother > spouse/wife/her-sister  (my brother's wife)
```

Both routes were always true. She *is* both. What moves is the chain of people — which is what the chart draws and what the relation panel will list. The Kotlin's preference is to reach her through somebody I am related to rather than around the outside.

**4 lines of 753 move.** Nothing in `sample-family.ftree` moves at all: it contains no ties, which is why the golden carries a constructed one (#128). And the website's own summary is byte-identical —

```
274 of 506 get a sentence (230 a word, 23 "married to", 21 "of the spouse"); 68 show the chain alone; 164 not connected
```

— because the sentence was never what this changes.

## A rule stated as a rule

The golden guards this by holding 753 lines of output, and *"four of those moved"* is not a proof anybody can read. New `site/playground/shortest-path.test.mjs` says the thing itself:

- the tie resolves through blood, asserted from **all four corners of the square** — a rule that held in one direction only would be a coincidence;
- **the tie is a real tie** — both routes are length 2. Without this the test above could be passing because the blood route is simply shorter, which would prove nothing about the order;
- **a shorter route still wins** whatever it is made of — my wife is one marriage step away and there is no blood route to her at all, so preferring blood must not mean preferring a longer answer;
- **marriage is still walked**, or "my wife's mother" would be unreachable — the reason the search is not blood-only in the first place.

It fails on the old order:

```
not ok 1 - where two routes tie, the one through the family wins
```

## Verification

- `node --test "site/playground/*.test.mjs"` — 32 pass (28 → 32).
- `cd desktop && npm test` — 165 pass.
- `check_layout.mjs`, `check_writer.mjs` — all pass, sentence counts unchanged.
- `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)