### PR TITLE
feat(desktop): ask how two people are related

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -449,6 +449,8 @@ function buildMenu(win) {
         // Third, and third in the numbering, so nobody's Cmd+2 changes meaning under them.
         { label: 'Compact', accelerator: 'CmdOrCtrl+3', click: () => win.webContents.send('menu:command', 'view:compact') },
         { type: 'separator' },
+        { label: 'How are two people related?', accelerator: 'CmdOrCtrl+R', click: () => win.webContents.send('menu:command', 'view:relate') },
+        { type: 'separator' },
         { label: 'Zoom in', accelerator: 'CmdOrCtrl+Plus', click: () => win.webContents.send('menu:command', 'zoom:in') },
         { label: 'Zoom out', accelerator: 'CmdOrCtrl+-', click: () => win.webContents.send('menu:command', 'zoom:out') },
         { label: 'Fit to window', accelerator: 'CmdOrCtrl+0', click: () => win.webContents.send('menu:command', 'zoom:fit') },
@@ -1066,6 +1068,168 @@ async function runCompactSmoke(win, check) {
   await settle(300);
 }
 
+/*
+ * How two people are related, asked in the app.
+ *
+ * The engine has a golden of its own (`kinship-golden.txt`), so nothing here re-checks *what* the
+ * answer is. What it checks is the panel's own decisions: that the question is seeded from whoever
+ * was selected, that the chart is cut down to the line joining the two, that the whole tree comes
+ * back when the question is closed, and -- the one worth having -- that two people the file does
+ * not connect are told exactly that rather than shown an empty box.
+ */
+async function runRelateSmoke(win, check) {
+  const page = (fn, ...args) => win.webContents.executeJavaScript(
+    `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
+  const settle = (ms = 400) => new Promise((r) => setTimeout(r, ms));
+
+  console.log('\n  -- how two people are related --');
+
+  // Somebody selected first, so the seeding is checked rather than assumed. The people list is the
+  // reliable way to click a person: the chart needs coordinates.
+  win.webContents.send('menu:command', 'view:index');
+  await settle();
+  const seeded = await page(() => {
+    const row = document.querySelector('#index-list .index-row');
+    row?.click();
+    return {
+      selected: document.getElementById('panel')?.hidden === false,
+      name: row?.querySelector('.who')?.textContent.trim() ?? '',
+    };
+  });
+  await settle();
+
+  win.webContents.send('menu:command', 'view:relate');
+  await settle(600);
+
+  const opened = await page(() => ({
+    shown: document.getElementById('relate').hidden === false,
+    a: document.getElementById('relate-a').value,
+    editorOpen: document.getElementById('panel').hidden === false,
+  }));
+
+  // The bar is deliberately not a way in -- see the note in app.js. Pinned, so that adding one
+  // later is a decision somebody makes on purpose rather than a header that quietly grows a row.
+  const header = await page(() => ({
+    height: Math.round(document.querySelector('header').getBoundingClientRect().height),
+    button: Boolean(document.getElementById('relate-btn')),
+  }));
+  check('the bar stays one row', header.height <= 60 && !header.button, JSON.stringify(header));
+
+  check('the relation finder opens', opened.shown, String(opened.shown));
+  check('it is seeded from the person that was selected',
+    seeded.selected && opened.a === seeded.name, `selected "${seeded.name}", seeded "${opened.a}"`);
+  check('one question at a time: the editor stands down', !opened.editorOpen,
+    String(opened.editorOpen));
+
+  const chartSize = () => page(() => document.getElementById('canvas').dataset.people ?? '');
+
+  /** Types a name into a picker and takes the first person it offers. */
+  const pick = async (slot, name) => {
+    const offered = await page((s, n) => {
+      const input = document.getElementById(`relate-${s}`);
+      input.value = n;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      return document.querySelectorAll(`#relate-${s}-results li button`).length;
+    }, slot, name);
+    await settle(250);
+    await page((s) => document.querySelector(`#relate-${s}-results li button`)?.click(), slot);
+    await settle(500);
+    return offered;
+  };
+
+  // A relative of the seeded person: whoever their panel listed. Guaranteed to be connected.
+  const relative = await page(() => {
+    const rows = [...document.querySelectorAll('#index-list .index-row')];
+    const first = document.getElementById('relate-a').value;
+    const group = rows.find((r) => r.querySelector('.who')?.textContent.trim() === first)
+      ?.closest('li')?.parentElement;
+    const other = rows
+      .map((r) => r.querySelector('.who')?.textContent.trim())
+      .find((n) => n && n !== first);
+    return other ?? '';
+  });
+
+  const offered = await pick('b', relative);
+  check('the picker offers people by name', offered > 0, `${offered} offered for "${relative}"`);
+
+  const answer = await page(() => {
+    const box = document.getElementById('relate-answer');
+    return {
+      sentence: box.querySelector('.r-term')?.textContent.trim() ?? '',
+      unrelated: Boolean(box.querySelector('.r-term.r-none')),
+      steps: box.querySelectorAll('.r-chain li').length,
+      links: box.querySelectorAll('.r-chain .link-btn').length,
+      scripted: box.innerHTML.includes('<script'),
+    };
+  });
+
+  check('the question is answered', answer.steps > 0 || answer.unrelated,
+    `${answer.steps} steps, sentence "${answer.sentence}"`);
+  check('the chain starts with the first person and every step after is clickable',
+    answer.steps === answer.links + 1, `${answer.steps} rows, ${answer.links} clickable`);
+  check('no markup is built out of a name', !answer.scripted, String(answer.scripted));
+
+  /*
+   * Two people the file does not connect.
+   *
+   * The sample family deliberately contains people connected to nobody -- it is the reason the
+   * people list exists at all -- so this case is reachable, and it is the one where an empty box
+   * would be worst. The claim is that the app says the *record* is silent, not that they are
+   * unrelated, which no file can know.
+   */
+  const alone = await page(() => {
+    const headings = [...document.querySelectorAll('#index-list .index-group')];
+    const isolated = headings.find((h) => /Not connected/.test(h.textContent));
+    return isolated?.nextElementSibling?.querySelector('.who')?.textContent.trim() ?? '';
+  });
+
+  if (alone) {
+    await pick('b', alone);
+    const said = await page(() => {
+      const note = document.getElementById('relate-answer').querySelector('.r-term');
+      return {
+        text: note?.textContent.trim() ?? '',
+        flagged: note?.classList.contains('r-none') ?? false,
+        steps: document.querySelectorAll('#relate-answer .r-chain li').length,
+      };
+    });
+    check('two people the file does not connect are told exactly that',
+      said.flagged && /does not say how/.test(said.text), said.text);
+    check('and are not shown a chain that does not exist', said.steps === 0, `${said.steps} steps`);
+  } else {
+    check('the sample family has somebody connected to nobody', false,
+      'none found — this case went unchecked');
+  }
+
+  if (process.env.FTREE_SMOKE_SHOT_RELATE) {
+    const shot = process.env.FTREE_SMOKE_SHOT_RELATE;
+    // Back to a real answer for the picture: the unrelated case is checked above, not photographed.
+    await pick('b', relative);
+    await fs.writeFile(shot, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${shot}`);
+
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(300);
+    const other = shot.replace(/(\.png)?$/, '-other-theme.png');
+    await fs.writeFile(other, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${other}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(200);
+  }
+
+  // Closing puts the whole tree back, rather than stranding somebody on a three-person chart.
+  await page(() => document.getElementById('relate-close').click());
+  await settle(600);
+  const closed = await page(() => ({
+    shown: document.getElementById('relate').hidden === false,
+    a: document.getElementById('relate-a').value,
+  }));
+  check('closing the question puts the panel away', !closed.shown, String(closed.shown));
+
+  win.webContents.send('menu:command', 'view:chart');
+  await settle(300);
+}
+
 async function runImportSmoke(win, check) {
   const page = (fn, ...args) => win.webContents.executeJavaScript(
     `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
@@ -1300,6 +1464,8 @@ async function runSmoke(win, file) {
   if (process.env.FTREE_SMOKE_SAVE_TO) await runEditSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_COMPACT) await runCompactSmoke(win, check);
+
+  if (process.env.FTREE_SMOKE_RELATE) await runRelateSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_IMPORT) await runImportSmoke(win, check);
 

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -25,6 +25,8 @@ import { buildGraph, displayName, lifespan, relationsOf } from '../../site/playg
 import { layoutArchive } from '../../site/playground/layout.js';
 import { Chart } from '../../site/playground/chart.js';
 import { compactFamily } from '../../site/playground/compact.js';
+import { relate, peopleToDraw, restrictedGraph } from '../../site/playground/model.js';
+import { searchPeople } from '../../site/playground/search.js';
 import { mostConnected } from '../../site/playground/focus.js';
 
 import { Tree, RelationshipType, Rejection } from './document.js';
@@ -32,6 +34,7 @@ import { bytesForTree, SaveRefused } from './save.js';
 import { planImport, applyImport, ImportRefused } from './import.js';
 import { MatchTier } from './matching.js';
 import { renderBands } from './bands.js';
+import { sentenceFor, unrelatedWording, paintSentence, nameNode } from './relation.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
 
@@ -62,6 +65,10 @@ const state = {
   focus: null,
   generationsUp: 3,
   generationsDown: 3,
+  /** The two people the relation finder is comparing, and whether the chart is cut down to them. */
+  relateA: null,
+  relateB: null,
+  trace: null,
   /** 'all' or 'living' -- the same filter the phone's people list offers. */
   who: 'all',
   saving: false,
@@ -131,6 +138,16 @@ function rebuild({ refit = false } = {}) {
   renderEmptyInvitation();
   reflectDirty();
   updateZoom();
+
+  /*
+   * An edit can change the answer, so an open question is asked again.
+   *
+   * `chart.load` above has already put the whole tree back, so the trace this is holding is gone
+   * from the screen whatever happens -- dropping it first is what stops `clearTrace` reloading a
+   * chart that is already correct, and what stops the trace surviving as a lie about what is drawn.
+   */
+  state.trace = null;
+  if (!$('relate').hidden) renderRelation();
 }
 
 /**
@@ -172,6 +189,233 @@ function setView(view) {
   if (view === 'chart') chart.resize();
   else if (view === 'compact') renderCompact();
   else renderPeople();
+}
+
+/* ------------------------------------------------------------------ how two people are related */
+
+/*
+ * Reached from the menu and the keyboard, and deliberately not from the bar.
+ *
+ * The website has a "Relate" button because a browser tab has nowhere else to put it. This bar
+ * already carries what the website's does *and* the editing tools, and it is full: measured on a
+ * 1095px window, adding one 26px icon took the header from 56px to 93px, because the row wraps.
+ * The desktop has the affordance a tab does not -- View > How are two people related?, on Ctrl+R --
+ * so the question is asked there, and the bar keeps the width it was designed for.
+ */
+
+/**
+ * Cuts the chart down to the line joining two people, and back again.
+ *
+ * `peopleToDraw` decides who has to be on the page for the answer to be drawable at all -- a
+ * sibling step carries no edge of its own, so two siblings would otherwise arrive as two loose
+ * cards with nothing between them, which is precisely the question the reader asked.
+ */
+function drawTrace(ids) {
+  state.trace = ids;
+  const cut = restrictedGraph(state.graph, ids);
+  chart.load(cut, layoutArchive(cut, { orientation: 'rows' }), archiveShim());
+  chart.fit();
+  updateZoom();
+}
+
+function clearTrace() {
+  if (!state.trace) return;
+  state.trace = null;
+  chart.load(state.graph, state.layout, archiveShim());
+  chart.fit();
+  updateZoom();
+}
+
+/**
+ * Ends the question, because it was about a tree that is no longer open.
+ *
+ * Two ids from the previous file would either name nobody or -- worse, since ids are stable across
+ * a save -- name two people in the new one, and answer confidently about a family nobody asked
+ * about.
+ */
+function forgetRelate() {
+  state.relateA = null;
+  state.relateB = null;
+  state.trace = null;
+  const panel = $('relate');
+  if (panel) {
+    panel.hidden = true;
+    $('relate-a').value = '';
+    $('relate-b').value = '';
+    $('relate-answer').replaceChildren();
+  }
+}
+
+function openRelate(seed = state.selected) {
+  // One question at a time. Both panels are positioned in the same corner, and two open at once
+  // would be two things claiming to be what the window is about.
+  if (state.selected) select(null);
+
+  $('relate').hidden = false;
+
+  // Seeded from whoever was selected, because "how is this person related to..." is the question
+  // somebody has in mind when they reach for this while looking at a person.
+  if (seed && state.graph?.people.has(seed) && !state.relateA) {
+    state.relateA = seed;
+    $('relate-a').value = displayName(state.graph.people.get(seed));
+  }
+  renderRelation();
+  $(state.relateA ? 'relate-b' : 'relate-a').focus();
+}
+
+function closeRelate() {
+  $('relate').hidden = true;
+  // The whole tree comes back. Leaving the chart cut down after the question is closed would strand
+  // somebody on a three-person chart with no obvious way out.
+  clearTrace();
+}
+
+/** One row of the chain: the step's label, and the person it reaches. */
+function chainRow(step) {
+  const li = document.createElement('li');
+
+  const label = document.createElement('span');
+  label.className = 'step';
+  label.textContent = step.label;
+
+  const who = document.createElement('span');
+  who.className = 'who';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'link-btn';
+  button.append(nameNode(state.graph.people.get(step.id)));
+  button.addEventListener('click', () => {
+    chart.centreOn(step.id);
+    chart.selected = step.id;
+    chart.invalidate();
+  });
+  who.append(button);
+
+  li.append(label, who);
+  return li;
+}
+
+function renderRelation() {
+  const box = $('relate-answer');
+  box.replaceChildren();
+
+  // Somebody chosen here can be deleted while the question is open. Forget them rather than
+  // answering about a person the file no longer has.
+  for (const [slot, key] of [['a', 'relateA'], ['b', 'relateB']]) {
+    if (state[key] && !state.graph?.people.has(state[key])) {
+      state[key] = null;
+      $(`relate-${slot}`).value = '';
+    }
+  }
+
+  const { relateA: a, relateB: b } = state;
+
+  /*
+   * The instructions stand down once they have been followed.
+   *
+   * Three lines explaining what the panel is for are worth having on an empty panel and worth
+   * nothing on an answered one, where they push the chain of people below the fold -- and the
+   * chain is the part that explains an answer no single word covers, which is what those three
+   * lines promised.
+   */
+  $('relate').dataset.answered = String(Boolean(a && b));
+
+  if (!a || !b || !state.graph) { clearTrace(); return; }
+
+  const from = state.graph.people.get(a);
+  const to = state.graph.people.get(b);
+  const result = relate(state.graph, a, b);
+
+  const note = document.createElement('p');
+  note.className = 'r-term';
+
+  if (result.kind === 'same') {
+    note.classList.add('r-none');
+    note.textContent = 'Those are the same person.';
+    box.append(note);
+    clearTrace();
+    return;
+  }
+
+  if (result.kind === 'none' || !result.path) {
+    note.classList.add('r-none');
+    paintSentence(note, unrelatedWording(from, to));
+    box.append(note);
+    clearTrace();
+    return;
+  }
+
+  const parts = sentenceFor(result, from, to);
+  if (parts) {
+    paintSentence(note, parts);
+    box.append(note);
+  }
+
+  const chain = document.createElement('ol');
+  chain.className = 'r-chain';
+
+  const start = document.createElement('li');
+  const startLabel = document.createElement('span');
+  startLabel.className = 'step';
+  startLabel.textContent = 'start';
+  const startWho = document.createElement('span');
+  startWho.className = 'who';
+  startWho.append(nameNode(from));
+  start.append(startLabel, startWho);
+  chain.append(start);
+
+  for (const step of result.path) chain.append(chainRow(step));
+  box.append(chain);
+
+  // The chart shows this line and nothing else.
+  drawTrace(peopleToDraw(state.graph, a, result.path));
+}
+
+/** The two pickers, each its own little search over the same shared function. */
+function wireRelate() {
+  for (const slot of ['a', 'b']) {
+    const input = $(`relate-${slot}`);
+    const list = $(`relate-${slot}-results`);
+
+    input.addEventListener('input', () => {
+      list.replaceChildren();
+      if (!input.value.trim() || !state.graph) { list.hidden = true; return; }
+
+      const found = searchPeople(state.graph, input.value, 8);
+      if (!found.length) {
+        const none = document.createElement('li');
+        none.className = 'row-none';
+        none.textContent = 'Nobody by that name in this file.';
+        list.append(none);
+        list.hidden = false;
+        return;
+      }
+
+      for (const person of found) {
+        const li = document.createElement('li');
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.append(nameNode(person));
+        const dates = document.createElement('span');
+        dates.className = 'row-dates';
+        dates.textContent = lifespan(person) || '';
+        button.append(dates);
+        button.addEventListener('click', () => {
+          state[slot === 'a' ? 'relateA' : 'relateB'] = person.id;
+          input.value = displayName(person);
+          list.hidden = true;
+          renderRelation();
+        });
+        li.append(button);
+        list.append(li);
+      }
+      list.hidden = false;
+    });
+
+    input.addEventListener('focus', () => input.select());
+  }
+
+  $('relate-close').addEventListener('click', closeRelate);
 }
 
 /* ------------------------------------------------------------------ generations, as bands */
@@ -744,6 +988,7 @@ function startNewTree() {
   state.path = null;
   state.name = 'Untitled tree';
   state.selected = null;
+  forgetRelate();
   $('file-name').textContent = state.name;
   setState('loaded');
   chart.resize();
@@ -776,6 +1021,7 @@ async function openBytes(bytes, name, filePath) {
     state.path = filePath ?? null;
     state.name = name;
     state.selected = null;
+    forgetRelate();
     $('file-name').textContent = name;
     setState('loaded');
     chart.resize();
@@ -1140,12 +1386,14 @@ function wireShell() {
     if (command === 'zoom:fit') { chart.fit(); updateZoom(); return; }
     if (command === 'view:chart') { setView('chart'); return; }
     if (command === 'view:compact') { setView('compact'); return; }
+    if (command === 'view:relate') { setView('chart'); openRelate(); return; }
     if (command === 'view:index') { setView('index'); return; }
     if (command === 'search') { $('search').focus(); return; }
     if (command === 'theme') { $('theme-btn').click(); return; }
     if (command === 'close') {
       state.tree = null;
       state.selected = null;
+      forgetRelate();
       setState('empty');
       shell.setDirty(false);
     }
@@ -1157,6 +1405,9 @@ function wireKeys() {
     const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(event.target.tagName);
     if (event.key === 'Escape') {
       if (state.adding) { state.adding = null; renderPanel(); return; }
+      // The question closes before the person does: it is the thing most recently opened, and it
+      // is the one holding the chart cut down to three people.
+      if (!$('relate').hidden) { closeRelate(); return; }
       if (state.selected) select(null);
       return;
     }
@@ -1167,6 +1418,9 @@ function wireKeys() {
     }
     if (event.key === 'c' || event.key === 'C') {
       setView(state.view === 'compact' ? 'chart' : 'compact');
+    }
+    if (event.key === 'r' || event.key === 'R') {
+      if ($('relate').hidden) { setView('chart'); openRelate(); } else closeRelate();
     }
     if (event.key === 'f' || event.key === 'F') { chart.fit(); updateZoom(); }
   });
@@ -1180,6 +1434,7 @@ async function boot() {
   chart.setTheme(document.documentElement.getAttribute('data-theme') ?? 'light');
 
   wireChrome();
+  wireRelate();
   wireShell();
   wireKeys();
 

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -894,3 +894,17 @@
   .editor .band-group { flex-direction: column; align-items: flex-start; gap: 0; }
   .editor .band-join.married { width: 22px; margin: 0 0 0 9px; height: 5px; }
 }
+
+/* ------------------------------------------------------------------ how two people are related */
+
+/*
+ * The panel itself is styled by playground.css -- `.relate`, `.r-term`, `.r-chain` and the rest are
+ * the website's, and the markup here is the website's markup so that the two shells cannot drift
+ * into looking like different features. What follows is the one thing only this shell needs.
+ *
+ * The help text is for a reader who has not asked anything yet. Once two people are chosen it is
+ * three lines of advice about a thing already done, and it pushes the chain of people below the
+ * fold -- the chain being exactly what those three lines promised would explain a connection no
+ * single word covers.
+ */
+.editor .relate[data-answered='true'] .relate-help { display: none; }

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -167,6 +167,35 @@
       <div class="compact-inner" id="compact-inner"></div>
     </section>
 
+    <!-- ------------------------------------------------------------ how two people are related -->
+    <!--
+      The same markup and the same class names as the website's panel, on purpose: `.relate`,
+      `.r-term` and `.r-chain` are already styled in playground.css, which this app loads, so the
+      two shells cannot drift into looking like different features. The engine underneath is the
+      same `relate` as well; what differs is only that this one is seeded from whoever is selected.
+    -->
+    <aside class="relate" id="relate" hidden aria-labelledby="relate-heading">
+      <button type="button" class="panel-close" id="relate-close" aria-label="Close">&times;</button>
+      <h2 id="relate-heading">How are two people related?</h2>
+      <p class="relate-help">
+        Pick two people. The answer works through marriages and adoptions as well as blood, so it
+        can explain a connection no single word covers.
+      </p>
+      <div class="relate-picks">
+        <div class="relate-pick" data-slot="a">
+          <label for="relate-a">First person</label>
+          <input type="search" id="relate-a" autocomplete="off" placeholder="Search">
+          <ul class="search-results" id="relate-a-results" hidden></ul>
+        </div>
+        <div class="relate-pick" data-slot="b">
+          <label for="relate-b">Second person</label>
+          <input type="search" id="relate-b" autocomplete="off" placeholder="Search">
+          <ul class="search-results" id="relate-b-results" hidden></ul>
+        </div>
+      </div>
+      <div class="relate-answer" id="relate-answer"></div>
+    </aside>
+
     <!-- ------------------------------------------------------------ one person, editable -->
     <aside class="panel edit-panel" id="panel" hidden aria-label="Edit this person">
       <button type="button" class="panel-close" id="panel-close" aria-label="Close">&times;</button>

--- a/desktop/renderer/relation.js
+++ b/desktop/renderer/relation.js
@@ -1,0 +1,104 @@
+/*
+ * How two people are related, said in a sentence and drawn as a chain.
+ *
+ * The engine is `relate` in `site/playground/model.js` and none of it is here. What is here is the
+ * wording, and the wording is the part with a decision in it: which of three sentences fits, and
+ * when to say nothing at all.
+ *
+ * `sentenceFor` is separated from the drawing so it can be tested without a DOM -- there is no
+ * jsdom in this project, and "which sentence does this answer get" is exactly the sort of thing
+ * that should be checked by a table rather than by looking at a screenshot.
+ */
+
+import { displayName, spouseLabel } from '../../site/playground/model.js';
+
+/**
+ * The sentence for an answer, as parts rather than as a string.
+ *
+ * Parts, because the renderer needs to know which fragments are names and which is the term: names
+ * are set in the running face and the term is emphasised, and handing back finished HTML would
+ * mean building markup out of somebody's name in a file. Returns null where no sentence fits, and
+ * that null is a decision rather than a gap -- see below.
+ *
+ * Three shapes, because a relationship through a marriage is not a noun the way a blood one is:
+ *
+ *   term       "Priya is Ankit's first cousin."
+ *   marriedTo  "Madhu is married to Ankit's first cousin once removed."  -- because "Ankit's first
+ *              cousin once removed's wife" is a possessive chain nobody says out loud, so it is
+ *              turned around: the same fact, said the way a person would say it.
+ *   ofSpouse   "Rekha is the mother of Ankit's wife."
+ */
+export function sentenceFor(result, from, to) {
+  if (!result || result.kind !== 'related') return null;
+
+  if (result.term) {
+    return [
+      { name: to }, ' is ', { name: from }, '’s ', { term: result.term }, '.',
+    ];
+  }
+  if (result.marriedTo) {
+    return [
+      { name: to }, ' is married to ', { name: from }, '’s ',
+      { term: result.marriedTo.term }, '.',
+    ];
+  }
+  if (result.ofSpouse) {
+    return [
+      { name: to }, ' is the ', { term: result.ofSpouse.term }, ' of ', { name: from }, '’s ',
+      spouseLabel(result.ofSpouse.spouse, null).toLowerCase(), '.',
+    ];
+  }
+
+  /*
+   * No sentence, deliberately, and the chain below says it instead.
+   *
+   * A sentence amounting to "these two are related somehow" tells a reader nothing the chain does
+   * not tell them exactly. The website tried "connected only through marriage" and it was worse
+   * than nothing: every relative anybody had married into the family came back under one flat
+   * phrase, so the phrase stopped meaning anything. "My aunt's husband's brother" is what he is,
+   * and the chain says it better than any invented word.
+   */
+  return null;
+}
+
+/** What to say when the file does not connect them at all. */
+export function unrelatedWording(from, to) {
+  return [
+    'Nothing in this file connects ', { name: from }, ' to ', { name: to },
+    '. They may still be related — the record simply does not say how.',
+  ];
+}
+
+/**
+ * Renders a sentence's parts into `into`, as elements rather than as markup.
+ *
+ * Names come out of somebody's file, so they are never concatenated into HTML. `textContent`
+ * throughout: a person called `<b>` is a person, not a tag.
+ */
+export function paintSentence(into, parts) {
+  into.replaceChildren();
+  for (const part of parts) {
+    if (typeof part === 'string') {
+      into.append(document.createTextNode(part));
+    } else if (part.term) {
+      const em = document.createElement('b');
+      em.textContent = part.term;
+      into.append(em);
+    } else {
+      into.append(nameNode(part.name));
+    }
+  }
+}
+
+/** A person's name, in italics where the file does not record one, as everywhere else in the app. */
+export function nameNode(person) {
+  const name = displayName(person ?? {});
+  if (person?.name) {
+    const span = document.createElement('b');
+    span.textContent = name;
+    return span;
+  }
+  const em = document.createElement('em');
+  em.textContent = name;
+  return em;
+}

--- a/desktop/renderer/relation.test.js
+++ b/desktop/renderer/relation.test.js
@@ -1,0 +1,84 @@
+/*
+ * Which sentence an answer gets, and when it gets none.
+ *
+ * The three shapes are a wording decision rather than an engine one, so they are checked here as a
+ * table. The fourth case -- no sentence at all -- is the one most worth pinning, because the
+ * tempting thing to do is fill it, and filling it is what made the website's earlier attempt
+ * useless.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { sentenceFor, unrelatedWording } from './relation.js';
+
+const ankit = { id: 'ankit', name: 'Ankit Kumar', gender: 'MALE' };
+const priya = { id: 'priya', name: 'Priya Sharma', gender: 'FEMALE' };
+const wife = { id: 'wife', name: 'Anita Kumar', gender: 'FEMALE' };
+
+/** The sentence as a plain string, for reading in an assertion. */
+const said = (parts) => (parts ?? []).map((p) => {
+  if (typeof p === 'string') return p;
+  if (p.term) return `*${p.term}*`;
+  return p.name.name ?? 'Unknown';
+}).join('');
+
+test('a blood relationship is a noun', () => {
+  assert.strictEqual(
+    said(sentenceFor({ kind: 'related', term: 'first cousin' }, ankit, priya)),
+    'Priya Sharma is Ankit Kumar’s *first cousin*.',
+  );
+});
+
+test('a marriage at the far end is turned around rather than possessed twice', () => {
+  // "Ankit's first cousin once removed's wife" is a chain nobody says out loud.
+  assert.strictEqual(
+    said(sentenceFor(
+      { kind: 'related', marriedTo: { term: 'first cousin once removed', person: priya } },
+      ankit, wife,
+    )),
+    'Anita Kumar is married to Ankit Kumar’s *first cousin once removed*.',
+  );
+});
+
+test('a relative of the person somebody married is named through them', () => {
+  assert.strictEqual(
+    said(sentenceFor(
+      { kind: 'related', ofSpouse: { term: 'mother', spouse: wife } },
+      ankit, priya,
+    )),
+    'Priya Sharma is the *mother* of Ankit Kumar’s wife.',
+  );
+});
+
+test('where no word fits, there is no sentence', () => {
+  /*
+   * The case worth pinning. "Connected only through marriage" was tried and was worse than
+   * nothing: every relative anybody had married into the family came back under the same flat
+   * phrase, so it stopped telling a reader anything. The chain says it exactly instead.
+   */
+  assert.strictEqual(sentenceFor({ kind: 'related', term: null }, ankit, priya), null);
+  assert.strictEqual(
+    sentenceFor({ kind: 'related', term: null, marriedTo: null, ofSpouse: null }, ankit, priya),
+    null,
+  );
+});
+
+test('a term wins over the other two, so an answer never gets two sentences', () => {
+  const both = { kind: 'related', term: 'sister', marriedTo: { term: 'brother', person: priya } };
+  assert.strictEqual(said(sentenceFor(both, ankit, priya)), 'Priya Sharma is Ankit Kumar’s *sister*.');
+});
+
+test('an answer that is not a relationship gets no sentence', () => {
+  assert.strictEqual(sentenceFor({ kind: 'none' }, ankit, priya), null);
+  assert.strictEqual(sentenceFor({ kind: 'same' }, ankit, ankit), null);
+  assert.strictEqual(sentenceFor(null, ankit, priya), null);
+});
+
+test('two people the file does not connect are told exactly that', () => {
+  // And told that the record is what is silent, not that they are unrelated -- which the file
+  // cannot know and this app must not claim.
+  const words = said(unrelatedWording(ankit, priya));
+  assert.match(words, /^Nothing in this file connects Ankit Kumar to Priya Sharma\./);
+  assert.match(words, /may still be related — the record simply does not say how/);
+});

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -27,6 +27,31 @@ which multiply a chart's width far faster than they add to what it tells you. Cl
 the reading to that person. Where the record goes further than the reading, it says so and offers
 to go on.
 
+## How two people are related
+
+`View > How are two people related?`, on `Ctrl+R`, or the `R` key. Pick two people; the answer is a
+sentence, a chain of people you can click through, and the chart cut down to just that line, with the
+whole tree back when the question is closed. It is seeded from whoever is selected, because "how is
+*this* person related to…" is the question somebody has in mind when they reach for it.
+
+The engine is `relate` in `site/playground/model.js` — the same one the website uses, held to
+`kinship-golden.txt`. It walks marriages and adoptions as well as blood, so it answers questions no
+blood-only search can: "my wife's mother" is exactly what this feature gets asked.
+
+Three sentences, and sometimes none:
+
+| | |
+|---|---|
+| a blood relationship | *"Priya is Ankit's **first cousin**."* |
+| a marriage at the far end | *"Madhu is married to Ankit's **first cousin once removed**."* — because "Ankit's first cousin once removed's wife" is a possessive chain nobody says out loud |
+| a relative of somebody's spouse | *"Rekha is the **mother** of Ankit's wife."* |
+| none of those | no sentence at all — the chain says it exactly, and a sentence amounting to "these two are related somehow" tells a reader nothing the chain does not |
+
+There is no button for it on the toolbar, deliberately. The website has one because a browser tab has
+nowhere else to put it; this bar already carries what the website's does *and* the editing tools, and
+it is full — measured on a 1095px window, adding one 26px icon took the header from 56px to 93px
+because the row wraps. The menu is the affordance a tab does not have, so that is where it lives.
+
 The rules about who appears live in `site/playground/focus.js` and `site/playground/compact.js`,
 ported from `graph/TreeLayoutEngine.kt` and `graph/CompactFamily.kt` with their test tables. On
 Android, compact is derived from the focused chart, so the two cannot disagree; the desktop's chart

--- a/site/playground/main.js
+++ b/site/playground/main.js
@@ -14,6 +14,7 @@ import {
 } from './model.js';
 import { layoutArchive } from './layout.js';
 import { Chart } from './chart.js';
+import { searchPeople as findPeople } from './search.js';
 
 const $ = (id) => document.getElementById(id);
 
@@ -326,24 +327,8 @@ function renderPanel(id) {
 
 /* ------------------------------------------------------------------ search */
 
-function searchPeople(query, limit = 14) {
-  if (!state.graph) return [];
-  const q = query.trim().toLowerCase();
-  if (!q) return [];
-  const hits = [];
-  for (const person of state.graph.people.values()) {
-    const name = person.name?.toLowerCase() ?? '';
-    let rank = -1;
-    if (name.startsWith(q)) rank = 0;
-    else if (name.includes(q)) rank = 1;
-    else if (!person.name && ('unknown'.startsWith(q) || 'unnamed'.startsWith(q))) rank = 2;
-    else if ((person.birthDate ?? '').startsWith(q) || (person.deathDate ?? '').startsWith(q)) rank = 3;
-    if (rank >= 0) hits.push({ person, rank });
-  }
-  hits.sort((a, b) => a.rank - b.rank
-    || (a.person.name ?? '').localeCompare(b.person.name ?? ''));
-  return hits.slice(0, limit).map((h) => h.person);
-}
+/** The shared one, over this page's graph. Moved to search.js so the desktop uses the same. */
+const searchPeople = (query, limit = 14) => findPeople(state.graph, query, limit);
 
 function renderResults(listEl, people, onPick) {
   if (!people.length) {

--- a/site/playground/search.js
+++ b/site/playground/search.js
@@ -1,0 +1,47 @@
+/*
+ * Finding a person by name, in one place rather than three.
+ *
+ * The website had this; the desktop had a weaker one of its own, which matched names only, needed
+ * two characters before it would answer, and returned people in file order -- so searching a large
+ * tree for "an" put whoever happened to be exported first at the top. The relation finder needs two
+ * more of these, and three implementations of "find me a person" is how two of them quietly stop
+ * agreeing about who is in the file.
+ *
+ * Pure, over the graph, so it belongs with the graph.
+ */
+
+/**
+ * People matching `query`, best matches first.
+ *
+ * The ranking is the useful part. A name that *starts* with what was typed is almost always the one
+ * wanted, so those come first and a mid-name match second -- typing "ram" should offer Ram Lal
+ * before Sitaram. Then two kinds of match a plain name search would miss:
+ *
+ *   somebody with no name recorded, findable by typing "unknown" or "unnamed", because they are
+ *   drawn that way and there is otherwise no way to search for them at all;
+ *
+ *   a year, so "1962" finds whoever was born or died then. It is how somebody looks for a person
+ *   whose name they cannot spell, and it costs one comparison.
+ *
+ * Ties break on name so that the same query always gives the same list.
+ */
+export function searchPeople(graph, query, limit = 14) {
+  if (!graph) return [];
+  const q = query.trim().toLowerCase();
+  if (!q) return [];
+
+  const hits = [];
+  for (const person of graph.people.values()) {
+    const name = person.name?.toLowerCase() ?? '';
+    let rank = -1;
+    if (name.startsWith(q)) rank = 0;
+    else if (name.includes(q)) rank = 1;
+    else if (!person.name && ('unknown'.startsWith(q) || 'unnamed'.startsWith(q))) rank = 2;
+    else if ((person.birthDate ?? '').startsWith(q) || (person.deathDate ?? '').startsWith(q)) rank = 3;
+    if (rank >= 0) hits.push({ person, rank });
+  }
+
+  hits.sort((a, b) => a.rank - b.rank
+    || (a.person.name ?? '').localeCompare(b.person.name ?? ''));
+  return hits.slice(0, limit).map((h) => h.person);
+}

--- a/site/playground/search.test.mjs
+++ b/site/playground/search.test.mjs
@@ -1,0 +1,67 @@
+/*
+ * What "find me a person" means, now that three places ask for it.
+ *
+ * These are new rather than ported -- the Kotlin's people list filters a Room query and shares no
+ * code with this. They exist because the desktop and the website had drifted into two different
+ * answers, and the point of moving the function here is that they cannot drift again.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { buildGraph } from './model.js';
+import { searchPeople } from './search.js';
+
+const graph = buildGraph({
+  people: [
+    { id: 'ram', name: 'Ram Lal', birthDate: '1935', deathDate: '1999' },
+    { id: 'sitaram', name: 'Sitaram Prasad', birthDate: '1940' },
+    { id: 'rama', name: 'Rama Devi', birthDate: '1962' },
+    { id: 'nameless', name: null, birthDate: '1910' },
+    { id: 'anita', name: 'Anita Kumar', birthDate: '1962' },
+  ],
+  relationships: [],
+});
+
+const ids = (query, limit) => searchPeople(graph, query, limit).map((p) => p.id);
+
+test('a name that starts with the query comes before one that merely contains it', () => {
+  // Typing "ram" should offer Ram Lal before Sitaram, which is the whole reason for ranking.
+  assert.deepStrictEqual(ids('ram'), ['ram', 'rama', 'sitaram']);
+});
+
+test('the same query always gives the same list', () => {
+  // Ties break on name rather than on file order, which is export order and means nothing.
+  assert.deepStrictEqual(ids('ram'), ids('ram'));
+});
+
+test('somebody with no name recorded can still be found', () => {
+  // They are drawn as "Unknown", and without this there is no way to search for them at all.
+  assert.deepStrictEqual(ids('unknown'), ['nameless']);
+  assert.deepStrictEqual(ids('unnamed'), ['nameless']);
+});
+
+test('a year finds whoever was born or died then', () => {
+  // How somebody looks for a person whose name they cannot spell.
+  assert.deepStrictEqual(ids('1962'), ['anita', 'rama']);
+  assert.deepStrictEqual(ids('1999'), ['ram']);
+});
+
+test('one character is enough', () => {
+  // The desktop's own version waited for two, so searching for a person called "Om" found nobody.
+  assert.ok(ids('r').includes('ram'));
+});
+
+test('an empty query asks for nothing and gets nothing', () => {
+  assert.deepStrictEqual(ids(''), []);
+  assert.deepStrictEqual(ids('   '), []);
+});
+
+test('the limit is honoured', () => {
+  assert.strictEqual(ids('a', 2).length, 2);
+});
+
+test('no graph is not a crash', () => {
+  // The bar exists before a tree is open.
+  assert.deepStrictEqual(searchPeople(null, 'ram'), []);
+});


### PR DESCRIPTION
Closes #121. Phase 2's surface — the engine was already complete and had nowhere to be asked from.

Two pickers, the answer, the chain of people, and the chart cut down to the line joining them, with the whole tree back when the question is closed. `Ctrl+R`, or the `R` key, **seeded from whoever is selected** — *"how is this person related to…"* is the question somebody has in mind when they reach for it.

The markup and class names are the website's, because `.relate`, `.r-term` and `.r-chain` are already styled in `playground.css` and this app loads it. Same engine, same panel, one less thing that can drift.

## Three sentences, and deliberately none

| | |
|---|---|
| a blood relationship | *"Priya is Ankit's **first cousin**."* |
| a marriage at the far end | *"Madhu is married to Ankit's **first cousin once removed**."* — "Ankit's first cousin once removed's wife" is a possessive chain nobody says out loud |
| a relative of somebody's spouse | *"Rekha is the **mother** of Ankit's wife."* |
| none of those | **no sentence at all** |

That last row is pinned by a test rather than left to judgement. *"Connected only through marriage"* was tried on the website and was worse than nothing: every relative anybody had married into the family came back under one flat phrase, so the phrase stopped meaning anything. The chain says it exactly instead.

Names are never concatenated into markup — `sentenceFor` returns parts and the renderer builds elements, so a person called `<b>` is a person and not a tag. The smoke test checks that on a real file.

## The toolbar button that isn't there

A decision, not an omission, and I only found out by building it.

The website has a **Relate** button because a browser tab has nowhere else to put it. This bar already carries what the website's does *and* the editing tools, and it is **full**. Measured on a 1095px window:

```
header with the button:  92.6px      header without it:  56px
```

That is with a **26px icon** — the first attempt, a text button, was flex-squashed to 36px of clipped text. I could not verify the wide-window case either: this screen caps the window at 1095 CSS px, so shipping a control I cannot see at the size it is meant for is exactly the mistake 0.4.0 made.

So it comes out, the menu keeps it — the affordance a browser tab does not have — and **the smoke test now pins the bar at one row**, so putting a button back is a decision somebody makes on purpose rather than a header that quietly grows.

The help paragraph retires once two people are chosen: three lines of advice about a thing already done, pushing the chain below the fold — the chain being exactly what those lines promised would explain a connection no single word covers.

## `searchPeople` moves to the engine

The website had it; the desktop had a weaker one of its own — names only, two characters before it would answer, results in file order — and this panel needed two more. Three implementations of *"find me a person"* is how two of them stop agreeing about who is in the file.

The bar search inherits the ranking as a consequence: a name that **starts** with the query now beats one that merely contains it, somebody with no name recorded is findable by typing "unknown", and a year finds whoever was born or died then. 8 tests.

## Lifecycle

The question ends when the tree it was about does — a new tree, an opened tree, a closed one. Two ids from a previous file would either name nobody or, since ids are stable across a save, name two people in the new one and answer confidently about a family nobody asked about. A person deleted mid-question is dropped rather than answered about, and an edit re-asks the question, because an edit can change the answer.

## Verification

- **The packaged app**, run unconfined through `systemd-run --user`: seeded from the selection, editor stands down, picker offers people, chain clickable, and two people the file does not connect told that *the record* is silent — not that they are unrelated, which no file can know.
- Both themes screenshotted.
- `cd desktop && npm test` — **176**. `node --test "site/playground/*.test.mjs"` — **36**.
- **`kinship-golden.txt` does not move**: nothing here touches `model.js`.
- `check_layout.mjs`, `check_writer.mjs` pass. `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)