### PR TITLE
feat(desktop): settings, and a menu that cannot go stale

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -19,6 +19,13 @@ const path = require('node:path');
 const { chooseUpdate } = require('./update');
 const { writeTreeFile } = require('./atomic');
 const { installationId } = require('./identity');
+const {
+  DEFAULT_SETTINGS,
+  normalise: normaliseSettings,
+  applyChange: applySettingChange,
+  mayCheckForUpdates,
+  shouldOffer,
+} = require('./settings');
 
 /*
  * A window needs somewhere to be.
@@ -97,21 +104,34 @@ const stateFile = () => path.join(app.getPath('userData'), 'session.json');
 const settingsFile = () => path.join(app.getPath('userData'), 'settings.json');
 
 /*
- * What the reader has switched on. Both off until they do.
- *
- * The same two the app offers, and off for the same reason: this app makes no network request of
- * any kind unless somebody has asked it to, and a default of "on" would quietly make that untrue
- * for everybody who never opened this menu.
+ * What the reader has chosen. The rules about it live in settings.js, which is pure and tested;
+ * this side only reads and writes the file.
  */
-const DEFAULT_SETTINGS = { checkForUpdates: false, betaReleases: false };
 let settings = { ...DEFAULT_SETTINGS };
 
 async function readSettings() {
   try {
-    return { ...DEFAULT_SETTINGS, ...JSON.parse(await fs.readFile(settingsFile(), 'utf8')) };
+    return normaliseSettings(JSON.parse(await fs.readFile(settingsFile(), 'utf8')));
   } catch {
-    return { ...DEFAULT_SETTINGS };
+    return normaliseSettings(null);
   }
+}
+
+/**
+ * Applies one change, writes it, and rebuilds the menu.
+ *
+ * The rebuild is the point. A menu checkbox's `checked:` is a snapshot taken when the menu was
+ * built, so the moment a second surface can change the same value the two disagree -- switch betas
+ * on in the preferences dialog and the menu goes on saying they are off until the app restarts.
+ * Every change goes through here, from either surface, and the menu is rebuilt from the result.
+ */
+async function changeSetting(key, value, win) {
+  const before = settings;
+  settings = applySettingChange(settings, key, value);
+  if (JSON.stringify(before) === JSON.stringify(settings)) return settings;
+  await writeSettings();
+  if (win && !win.isDestroyed()) buildMenu(win);
+  return settings;
 }
 
 async function writeSettings() {
@@ -287,6 +307,11 @@ async function checkForUpdates(win, { quiet = false } = {}) {
     linuxFormat: process.env.APPIMAGE ? 'appimage' : null,
   });
 
+  // The answer is remembered so the preferences dialog can say when the app last looked. Cleared
+  // again by settings.js the moment update checking is switched off, so a remembered result can
+  // never outlive the setting that produced it.
+  await changeSetting('lastCheckedAt', Date.now(), win);
+
   if (found.kind !== 'newer') {
     if (!quiet) {
       await dialog.showMessageBox(win, {
@@ -321,17 +346,33 @@ async function checkForUpdates(win, { quiet = false } = {}) {
     return;
   }
 
+  /*
+   * A version the reader has already declined is not raised again.
+   *
+   * Without this the automatic check offers the same release on every launch until they take it,
+   * which teaches people to dismiss the dialog without reading it -- and the one release that
+   * matters is then dismissed the same way. Only the quiet check is silenced: asking from the menu
+   * always gets an answer, because a question deserves one.
+   */
+  if (quiet && !shouldOffer(settings, found.version)) return;
+
   const answer = await dialog.showMessageBox(win, {
     type: 'info',
     message: `f-tree ${found.version} is available.`,
     detail: `${found.notes ? found.notes.slice(0, 700) + '\n\n' : ''}`
       + `${found.file.name} · ${(found.file.size / 1048576).toFixed(1)} MB`
       + `${found.file.sha256 ? '' : '\n\nGitHub has published no checksum for this file.'}`,
-    buttons: ['Download', 'Release notes', 'Not now'],
+    buttons: ['Download', 'Release notes', 'Skip this version', 'Not now'],
     defaultId: 0,
-    cancelId: 2,
+    cancelId: 3,
   });
   if (answer.response === 1) { shell.openExternal(found.notesUrl); return; }
+  if (answer.response === 2) {
+    // "Not now" and "skip" are different answers and the app should not conflate them: one is
+    // about today, the other about this release.
+    await changeSetting('skippedVersion', found.version, win);
+    return;
+  }
   if (answer.response !== 0) return;
 
   let got;
@@ -467,13 +508,16 @@ function buildMenu(win) {
         { label: 'Check for updates now…', click: () => checkForUpdates(win) },
         { type: 'separator' },
         {
+          label: 'Preferences…',
+          accelerator: 'CmdOrCtrl+,',
+          click: () => win.webContents.send('menu:command', 'settings:open'),
+        },
+        { type: 'separator' },
+        {
           label: 'Check for updates automatically',
           type: 'checkbox',
           checked: settings.checkForUpdates,
-          click: async (item) => {
-            settings.checkForUpdates = item.checked;
-            await writeSettings();
-          },
+          click: async (item) => { await changeSetting('checkForUpdates', item.checked, win); },
         },
         {
           label: 'Offer me beta releases',
@@ -485,8 +529,7 @@ function buildMenu(win) {
               item.checked = false;
               return;
             }
-            settings.betaReleases = item.checked;
-            await writeSettings();
+            await changeSetting('betaReleases', item.checked, win);
           },
         },
         { type: 'separator' },
@@ -678,6 +721,27 @@ ipcMain.handle('app:version', () => app.getVersion());
  * written without one claims the empty origin -- see identity.js.
  */
 ipcMain.handle('app:installationId', () => installationId(app.getPath('userData')));
+
+/*
+ * Settings, both ways.
+ *
+ * Writing goes through `changeSetting` -- the same path the menu uses -- so the cross-setting rules
+ * apply whichever surface made the change, and the menu is rebuilt from the result. A checkbox
+ * whose `checked:` was a snapshot is exactly how two surfaces start disagreeing.
+ */
+ipcMain.handle('settings:get', () => ({ ...settings }));
+
+ipcMain.handle('settings:set', async (event, { key, value }) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+
+  // The one setting that asks before it is on rather than after. Refusing here means the dialog is
+  // told what the value actually became, rather than assuming its own.
+  if (key === 'betaReleases' && value === true && !settings.betaReleases) {
+    if (!(await confirmBeta(win))) return { ...settings };
+  }
+
+  return { ...(await changeSetting(key, value, win)) };
+});
 ipcMain.handle('tree:choose', async (event) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   return chooseInto(win);
@@ -1077,6 +1141,163 @@ async function runCompactSmoke(win, check) {
  * back when the question is closed, and -- the one worth having -- that two people the file does
  * not connect are told exactly that rather than shown an empty box.
  */
+/*
+ * The preferences dialog, and the thing it exists to stop.
+ *
+ * The defect this was built for is not "there is no settings screen" -- it is that a native menu
+ * checkbox's `checked:` is a snapshot taken when the menu was built. One surface over one value is
+ * fine forever; two is fine until somebody uses the second one. So what is asserted here is not
+ * "the dialog opens" but "changing it here changed the menu too", and the cross-setting rules that
+ * would otherwise be silently wrong.
+ */
+async function runSettingsSmoke(win, check) {
+  const { Menu } = require('electron');
+  const page = (fn, ...args) => win.webContents.executeJavaScript(
+    `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
+  const settle = (ms = 350) => new Promise((r) => setTimeout(r, ms));
+
+  console.log('\n  -- preferences --');
+
+  /** What the *menu* currently believes, read from the real application menu. */
+  const menuSays = (label) => {
+    const walk = (items) => {
+      for (const item of items) {
+        if (item.label === label) return item.checked;
+        if (item.submenu) {
+          const found = walk(item.submenu.items);
+          if (found !== undefined) return found;
+        }
+      }
+      return undefined;
+    };
+    return walk(Menu.getApplicationMenu().items);
+  };
+
+  win.webContents.send('menu:command', 'settings:open');
+  await settle(600);
+
+  const opened = await page(() => ({
+    open: document.getElementById('prefs').open === true,
+    rows: document.querySelectorAll('#prefs .prefs-row').length,
+    notes: [...document.querySelectorAll('#prefs .prefs-note')]
+      .filter((n) => n.textContent.trim()).length,
+  }));
+  check('the preferences dialog opens', opened.open, String(opened.open));
+
+  /*
+   * It fits in the window the app actually opens at.
+   *
+   * A settings screen that scrolls hides settings, and the ones it hides are the ones at the
+   * bottom -- here, the two that reach the network, which are exactly what a reader came to check.
+   *
+   * Asserted as a budget rather than by measuring the visible area, because a screen smaller than
+   * the app's default window makes that measurement a fact about the test machine. The dialog's
+   * width is fixed, so its content height is not: at the default 900px window, `.review[open]`
+   * gives `min(84vh, 760px)` = 756px, less the head and foot, leaving about 584px for settings.
+   * 560 keeps a margin and still fails if a row is added carelessly.
+   */
+  const BUDGET = 560;
+  const fits = await page(() => {
+    const body = document.querySelector('#prefs .prefs-body');
+    return { scroll: body.scrollHeight, width: Math.round(body.getBoundingClientRect().width) };
+  });
+  check('every setting fits the window the app opens at, without scrolling',
+    fits.scroll <= BUDGET,
+    `${fits.scroll}px of settings against a ${BUDGET}px budget, at ${fits.width}px wide`);
+  check('every setting says what it does', opened.rows > 0 && opened.notes > 0,
+    `${opened.rows} rows, ${opened.notes} explained`);
+
+  // Both surfaces start agreeing.
+  check('the menu and the dialog start in step',
+    menuSays('Check for updates automatically') === false, String(menuSays('Check for updates automatically')));
+
+  /*
+   * The regression this file exists for: change it in the dialog, and read the menu.
+   *
+   * Before the rebuild, the menu went on showing what it was built with until the app restarted.
+   */
+  await page(() => {
+    const box = document.getElementById('pref-updates');
+    box.checked = true;
+    box.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await settle(600);
+
+  check('turning a setting on in the dialog updates the menu',
+    menuSays('Check for updates automatically') === true,
+    String(menuSays('Check for updates automatically')));
+
+  const afterOn = await page(() => ({
+    beta: document.getElementById('pref-beta').disabled,
+    note: document.getElementById('pref-updates-note').textContent.trim(),
+  }));
+  check('a setting that can now do something becomes available', !afterOn.beta,
+    `beta disabled: ${afterOn.beta}`);
+  check('the dialog says when the app last looked', /Last looked/.test(afterOn.note), afterOn.note);
+
+  // And the cross-setting rule, end to end: turning it off forgets what was remembered.
+  await page(() => {
+    const box = document.getElementById('pref-updates');
+    box.checked = false;
+    box.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await settle(600);
+
+  const afterOff = await page(async () => {
+    const s = await window.ftreeDesktop.settings();
+    return {
+      lastChecked: s.lastCheckedAt,
+      skipped: s.skippedVersion,
+      note: document.getElementById('pref-updates-note').textContent.trim(),
+      beta: document.getElementById('pref-beta').disabled,
+    };
+  });
+  check('turning update checking off forgets what the last check found',
+    afterOff.lastChecked === 0 && afterOff.skipped === null,
+    `lastCheckedAt ${afterOff.lastChecked}, skipped ${afterOff.skipped}`);
+  check('and the menu follows it back down',
+    menuSays('Check for updates automatically') === false,
+    String(menuSays('Check for updates automatically')));
+  check('betas go unavailable again with nothing to check', afterOff.beta, String(afterOff.beta));
+
+  // Photographs off means the chart is handed none, rather than asked to ignore them.
+  await page(() => {
+    const box = document.getElementById('pref-photos');
+    box.checked = false;
+    box.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await settle(700);
+  const photos = await page(async () => (await window.ftreeDesktop.settings()).photosOnChart);
+  check('photographs can be turned off', photos === false, String(photos));
+
+  if (process.env.FTREE_SMOKE_SHOT_PREFS) {
+    const shot = process.env.FTREE_SMOKE_SHOT_PREFS;
+    await fs.writeFile(shot, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${shot}`);
+
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(400);
+    const other = shot.replace(/(\.png)?$/, '-other-theme.png');
+    await fs.writeFile(other, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${other}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(300);
+  }
+
+  // The theme is one store now, and the menu is rebuilt from it.
+  const themed = await page(async () => {
+    document.getElementById('theme-btn').click();
+    await new Promise((r) => setTimeout(r, 400));
+    const s = await window.ftreeDesktop.settings();
+    return { setting: s.theme, painted: document.documentElement.getAttribute('data-theme') };
+  });
+  check('the theme is kept with every other setting, not in its own store',
+    themed.setting === themed.painted, JSON.stringify(themed));
+
+  await page(() => document.getElementById('prefs').close());
+  await settle(300);
+}
+
 async function runRelateSmoke(win, check) {
   const page = (fn, ...args) => win.webContents.executeJavaScript(
     `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
@@ -1467,6 +1688,8 @@ async function runSmoke(win, file) {
 
   if (process.env.FTREE_SMOKE_RELATE) await runRelateSmoke(win, check);
 
+  if (process.env.FTREE_SMOKE_SETTINGS) await runSettingsSmoke(win, check);
+
   if (process.env.FTREE_SMOKE_IMPORT) await runImportSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_SHOT) {
@@ -1489,7 +1712,7 @@ app.whenReady().then(async () => {
   }
 
   // Only if asked, and quietly: starting the app never costs a dialog for having nothing to say.
-  if (settings.checkForUpdates) {
+  if (mayCheckForUpdates(settings)) {
     checkForUpdates(window_, { quiet: true }).catch(() => {});
   }
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
     "smoke": "electron . --no-sandbox",
     "pack:linux": "electron-builder --linux",
     "pack:win": "electron-builder --win nsis",
-    "test": "node --test update.test.js atomic.test.js identity.test.js suite.test.js \"renderer/*.test.js\" \"../site/playground/*.test.mjs\"",
+    "test": "node --test update.test.js atomic.test.js identity.test.js settings.test.js suite.test.js \"renderer/*.test.js\" \"../site/playground/*.test.mjs\"",
     "test:package": "node --test package.test.js"
   },
   "devDependencies": {

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -14,6 +14,17 @@ contextBridge.exposeInMainWorld('ftreeDesktop', {
   version: () => ipcRenderer.invoke('app:version'),
 
   /**
+   * What the reader has chosen, and one way to change it.
+   *
+   * `set` returns the settings as they *became*, not as they were asked to be. Two reasons: the
+   * cross-setting rules can change more than the one key that was set -- turning updates off also
+   * clears what the last check found -- and turning betas on asks a question the reader can answer
+   * no to. A dialog that assumed its own value would then show the opposite of the truth.
+   */
+  settings: () => ipcRenderer.invoke('settings:get'),
+  setSetting: (key, value) => ipcRenderer.invoke('settings:set', { key, value }),
+
+  /**
    * This installation's own id, stamped into a tree started here.
    *
    * Not cosmetic: a tree written with an empty origin cannot be told apart from every other

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -156,7 +156,18 @@ function rebuild({ refit = false } = {}) {
  * The chart expects something archive-shaped. Photos live in memory here because the file is
  * rewritten on save, so this hands them over from the map rather than re-reading a ZIP.
  */
+/**
+ * The photographs the chart is allowed to draw.
+ *
+ * When the setting is off the chart is handed an archive with nothing in it, rather than the real
+ * one and an instruction to ignore it. That is how Android does it and it is the safer shape: "the
+ * reader turned photographs off" becomes a fact the drawing code *cannot* forget, instead of a flag
+ * it has to remember to check in every place it draws a card.
+ */
 function archiveShim() {
+  if (prefs && prefs.photosOnChart === false) {
+    return { has: () => false, read: async () => undefined };
+  }
   return {
     has: (name) => state.photos.has(name),
     read: async (name) => state.photos.get(name),
@@ -189,6 +200,101 @@ function setView(view) {
   if (view === 'chart') chart.resize();
   else if (view === 'compact') renderCompact();
   else renderPeople();
+}
+
+/* ------------------------------------------------------------------ preferences */
+
+/**
+ * What the reader has chosen, as this page last heard it.
+ *
+ * The main process owns the file and the rules; this is a copy to draw with. Every write goes back
+ * through `setSetting`, and what comes back is what the settings *became* -- which is not always
+ * what was asked for, because the cross-setting rules can change more than the one key, and because
+ * turning betas on asks a question that can be answered no.
+ */
+let prefs = null;
+
+function paintPrefs() {
+  if (!prefs) return;
+  $('pref-words').value = prefs.familyWords;
+  $('pref-photos').checked = prefs.photosOnChart;
+  $('pref-theme').value = prefs.theme;
+  $('pref-updates').checked = prefs.checkForUpdates;
+  $('pref-beta').checked = prefs.betaReleases;
+
+  /*
+   * Betas are unavailable while checking is off, rather than merely useless.
+   *
+   * They are separate settings answering different questions -- whether the app may ask GitHub
+   * anything, and which answer it will accept -- so betas with checking off does nothing at all. A
+   * live checkbox that does nothing is a worse explanation than a greyed one next to a line saying
+   * no request is made.
+   */
+  $('pref-beta').disabled = !prefs.checkForUpdates;
+
+  // Inert until the Hindi vocabulary lands (#124). Said plainly rather than hidden: a setting that
+  // is present and does nothing is worse than one that admits it is not ready.
+  $('pref-words-note').textContent = prefs.familyWords === 'hi'
+    ? 'Hindi kinship words are not built yet — the relation finder still answers in English.'
+    : 'The words the relation finder uses.';
+
+  $('pref-updates-note').textContent = prefs.checkForUpdates
+    ? `Last looked ${whenChecked(prefs.lastCheckedAt)}.`
+    : 'Off. The app makes no network request of any kind until this is on.';
+}
+
+/** When the updater last got an answer, in words rather than as a timestamp. */
+function whenChecked(at) {
+  if (!at) return 'never';
+  const days = Math.floor((Date.now() - at) / 86_400_000);
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 30) return `${days} days ago`;
+  return new Date(at).toLocaleDateString();
+}
+
+/** Puts a changed setting into effect on this page. */
+function applyPrefs({ redraw = false } = {}) {
+  if (!prefs) return;
+  document.documentElement.setAttribute('data-theme', prefs.theme);
+  chart?.setTheme(prefs.theme);
+
+  // The pre-paint cache, refreshed from the truth. See the note on the inline script in
+  // index.html: nothing can be asked of the settings file before the first paint.
+  try {
+    localStorage.setItem('ftree.desktop', JSON.stringify({ theme: prefs.theme }));
+  } catch { /* blocked storage costs one launch in the system's colours, not the setting */ }
+
+  if (redraw && state.graph) rebuild();
+}
+
+async function setPref(key, value) {
+  if (!shell?.setSetting) return;
+  const before = prefs;
+  prefs = await shell.setSetting(key, value);
+  // Photographs change what the chart is given, so that one needs a rebuild; the rest do not.
+  applyPrefs({ redraw: before?.photosOnChart !== prefs.photosOnChart });
+  paintPrefs();
+}
+
+function openPrefs() {
+  paintPrefs();
+  $('prefs').showModal();
+  $('prefs-head').focus();
+}
+
+function wirePrefs() {
+  const dialog = $('prefs');
+  if (!dialog) return;
+
+  $('prefs-done').addEventListener('click', () => dialog.close());
+  $('pref-words').addEventListener('change', (e) => setPref('familyWords', e.target.value));
+  $('pref-theme').addEventListener('change', (e) => setPref('theme', e.target.value));
+  $('pref-photos').addEventListener('change', (e) => setPref('photosOnChart', e.target.checked));
+  $('pref-updates').addEventListener('change', (e) => setPref('checkForUpdates', e.target.checked));
+  // The answer to this one can be no -- the main process asks first -- so the checkbox is repainted
+  // from what came back rather than left showing what was clicked.
+  $('pref-beta').addEventListener('change', (e) => setPref('betaReleases', e.target.checked));
 }
 
 /* ------------------------------------------------------------------ how two people are related */
@@ -1336,7 +1442,15 @@ function wireChrome() {
     const next = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
     document.documentElement.setAttribute('data-theme', next);
     chart.setTheme(next);
-    try { localStorage.setItem('ftree.desktop', JSON.stringify({ theme: next })); } catch { /* fine */ }
+    /*
+     * Written to the settings file, which is now the only copy that counts.
+     *
+     * The theme used to live in the page's own storage while every other setting lived in a file
+     * the main process owns. Two stores meant the preferences dialog could not show the theme
+     * without asking the page. `applyPrefs` keeps the localStorage mirror up to date for the sake
+     * of the pre-paint script, and nothing else reads it.
+     */
+    setPref('theme', next);
   });
 
   const search = $('search');
@@ -1387,6 +1501,7 @@ function wireShell() {
     if (command === 'view:chart') { setView('chart'); return; }
     if (command === 'view:compact') { setView('compact'); return; }
     if (command === 'view:relate') { setView('chart'); openRelate(); return; }
+    if (command === 'settings:open') { openPrefs(); return; }
     if (command === 'view:index') { setView('index'); return; }
     if (command === 'search') { $('search').focus(); return; }
     if (command === 'theme') { $('theme-btn').click(); return; }
@@ -1435,8 +1550,22 @@ async function boot() {
 
   wireChrome();
   wireRelate();
+  wirePrefs();
   wireShell();
   wireKeys();
+
+  /*
+   * Settings before the first draw.
+   *
+   * The theme especially: reading it after the chart exists means a window that flashes light and
+   * then goes dark on every launch, for everybody who chose dark.
+   */
+  if (shell?.settings) {
+    try {
+      prefs = await shell.settings();
+      applyPrefs();
+    } catch { /* the page already has the defaults on it */ }
+  }
 
   if (shell) {
     document.body.dataset.shell = 'desktop';

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -908,3 +908,96 @@
  * single word covers.
  */
 .editor .relate[data-answered='true'] .relate-help { display: none; }
+
+/* ------------------------------------------------------------------ preferences */
+
+/*
+ * The preferences dialog borrows the review dialog's shell -- same box, same head, same foot -- so
+ * the two questions this app asks look like the same app asking. What it adds is the row: a label,
+ * the control it belongs to, and a line saying what the choice actually does.
+ *
+ * That third element is the reason these are rows rather than a list of checkboxes. "Offer me beta
+ * releases" is not self-explanatory, and neither is what happens to a version you skipped when you
+ * change channel. A settings screen that only names its switches makes the reader guess.
+ */
+
+/* `[open]` to match the specificity of `.editor .review[open]`, which would otherwise win and
+   give this the import dialog's 760px. A settings dialog wants to be narrower than a merge review:
+   there is nothing here to compare side by side. */
+.editor .prefs[open] { width: min(500px, calc(100vw - 48px)); }
+
+.editor .prefs-body {
+  display: block;
+  padding: 4px 0;
+}
+
+.editor .prefs-group + .prefs-group { border-top: 1px solid var(--rule); }
+
+.editor .prefs-heading {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+  color: var(--brass);
+  margin: 0;
+  padding: 17px 20px 7px;
+}
+
+.editor .prefs-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 2px 16px;
+  padding: 9px 20px 10px;
+}
+
+.editor .prefs-row + .prefs-row { border-top: 1px solid var(--rule); }
+
+.editor .prefs-label {
+  font-family: var(--serif);
+  font-size: 15px;
+  color: var(--ink);
+  cursor: pointer;
+}
+
+/* The explanation belongs under the label, not beside the control. */
+.editor .prefs-note {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-faint);
+  margin: 0;
+  max-width: 52ch;
+}
+
+.editor .prefs-control {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink);
+  background: var(--raised);
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  padding: 6px 11px;
+  cursor: pointer;
+}
+
+.editor .prefs-check {
+  width: 17px;
+  height: 17px;
+  accent-color: var(--forest);
+  cursor: pointer;
+}
+
+/*
+ * A setting that cannot do anything says so by being unavailable.
+ *
+ * Betas with update checking off makes no request -- they answer different questions, and neither
+ * can start one on its own. A live checkbox that changes nothing is a worse explanation than a
+ * greyed one beside a line saying no request is made.
+ */
+.editor .prefs-check:disabled,
+.editor .prefs-control:disabled { opacity: .38; cursor: default; }
+
+.editor .prefs-row:has(.prefs-check:disabled) .prefs-label { color: var(--ink-faint); }

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -20,6 +20,12 @@
 /*
  * The theme, before the first paint. app.js is a module and therefore deferred, so leaving this
  * to it would flash a bone-white screen at somebody who asked for dark.
+ *
+ * This reads a *cache*, not the setting. The theme lives in the settings file with everything else,
+ * which is the only copy the preferences dialog and the menu consult -- but that file is read over
+ * IPC, which is asynchronous, and there is no asking it anything before the first paint. So the
+ * chosen theme is mirrored here on every launch and every change, and this reads the mirror. A
+ * cleared cache costs one launch in the system's colours, not a lost setting.
  */
 (function () {
   var theme = null;
@@ -235,6 +241,79 @@
       <div class="review-actions">
         <button type="button" class="btn quiet" id="review-cancel">Cancel</button>
         <button type="button" class="btn primary" id="review-confirm">Import</button>
+      </div>
+    </div>
+  </dialog>
+
+  <!-- ------------------------------------------------------------ preferences -->
+  <!--
+    Modelled on the review dialog above, and a <dialog> for the same reason: it is a question about
+    the whole app rather than about anything on the page behind it.
+
+    Every control here is also in the native menu, and both go through the same `settings:set`, so
+    the menu is rebuilt whenever this changes something. A menu checkbox's `checked:` is a snapshot
+    taken when the menu was built, and two surfaces over one value is exactly how that snapshot
+    starts lying.
+  -->
+  <dialog class="review prefs" id="prefs" aria-labelledby="prefs-title">
+    <div class="review-head" id="prefs-head" tabindex="-1">
+      <h2 class="review-title" id="prefs-title">Preferences</h2>
+      <p class="review-lead">Kept on this machine, with the trees. Nothing here is sent anywhere.</p>
+    </div>
+
+    <div class="review-body prefs-body">
+      <section class="prefs-group">
+        <h3 class="prefs-heading">Reading</h3>
+
+        <div class="prefs-row">
+          <label class="prefs-label" for="pref-words">Family words</label>
+          <select id="pref-words" class="prefs-control">
+            <option value="en">English</option>
+            <option value="hi">हिन्दी</option>
+          </select>
+          <p class="prefs-note" id="pref-words-note"></p>
+        </div>
+
+        <div class="prefs-row">
+          <label class="prefs-label" for="pref-photos">Photographs on the chart</label>
+          <input type="checkbox" id="pref-photos" class="prefs-check">
+          <p class="prefs-note">
+            Off draws names only, which a large family reads faster.
+          </p>
+        </div>
+
+        <div class="prefs-row">
+          <label class="prefs-label" for="pref-theme">Appearance</label>
+          <select id="pref-theme" class="prefs-control">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </div>
+      </section>
+
+      <section class="prefs-group">
+        <h3 class="prefs-heading">Updates</h3>
+
+        <div class="prefs-row">
+          <label class="prefs-label" for="pref-updates">Check for updates</label>
+          <input type="checkbox" id="pref-updates" class="prefs-check">
+          <p class="prefs-note" id="pref-updates-note"></p>
+        </div>
+
+        <div class="prefs-row">
+          <label class="prefs-label" for="pref-beta">Offer me beta releases</label>
+          <input type="checkbox" id="pref-beta" class="prefs-check">
+          <p class="prefs-note">
+            Unfinished builds, offered early. Turning this off or on forgets any version you skipped.
+          </p>
+        </div>
+      </section>
+    </div>
+
+    <div class="review-foot">
+      <p class="review-outcome" id="prefs-outcome" aria-live="polite"></p>
+      <div class="review-actions">
+        <button type="button" class="btn primary" id="prefs-done">Done</button>
       </div>
     </div>
   </dialog>

--- a/desktop/settings.js
+++ b/desktop/settings.js
@@ -1,0 +1,127 @@
+/*
+ * What the reader has chosen, and the rules about what one choice does to another.
+ *
+ * Pure: no disk, no Electron, no menu. `main.js` reads and writes the file; this decides what a
+ * settings object may become. Written that way because the interesting part is not storage -- it is
+ * that some of these settings are not independent of each other, and the places that get that wrong
+ * are places nobody looks at twice.
+ *
+ * Ported from `app/.../update/UpdatePreferences.kt`, with its reasoning. Two of the rules there
+ * exist for failures that are invisible until they bite:
+ *
+ *   turning update checking off clears the remembered result, because "leaving a remembered result
+ *   behind would let a stale banner outlive the setting";
+ *
+ *   changing channel clears the skipped version, because "a version skipped on one channel means
+ *   nothing on the other: leaving it behind would silently hide the first release the reader has
+ *   just asked to be offered".
+ */
+
+/**
+ * Off until switched on, deliberately, for the two that reach the network.
+ *
+ * This app makes no request of any kind unless somebody has asked it to, and a default of "on"
+ * would quietly make that untrue for everybody who never opened the menu. The rest are about how
+ * the app looks and reads, and default to what most readers want.
+ */
+const DEFAULTS = Object.freeze({
+  /** English or Hindi kinship words. Inert until the Hindi vocabulary lands (#124). */
+  familyWords: 'en',
+  /** Whether the chart draws photographs at all. */
+  photosOnChart: true,
+  /** 'light' or 'dark'. */
+  theme: 'light',
+  checkForUpdates: false,
+  betaReleases: false,
+  /** When the updater last got an answer, as epoch milliseconds. 0 means never. */
+  lastCheckedAt: 0,
+  /** A version the reader has dismissed; they are not asked about it again. */
+  skippedVersion: null,
+});
+
+
+
+/** The settings this app knows about, and what counts as a value for each. */
+const SHAPE = {
+  familyWords: (v) => (v === 'hi' ? 'hi' : 'en'),
+  photosOnChart: (v) => v !== false,
+  theme: (v) => (v === 'dark' ? 'dark' : 'light'),
+  checkForUpdates: (v) => v === true,
+  betaReleases: (v) => v === true,
+  lastCheckedAt: (v) => (Number.isFinite(v) && v > 0 ? Math.floor(v) : 0),
+  skippedVersion: (v) => (typeof v === 'string' && v.trim() ? v.trim() : null),
+};
+
+/**
+ * A stored object made safe to use.
+ *
+ * Every value is put through its own rule rather than trusted, and anything unrecognised is
+ * dropped. The file lives in a directory the reader can edit, and a settings file that has been
+ * hand-edited into nonsense -- or written by a newer version of the app -- should give an app that
+ * starts with sensible defaults rather than one that behaves strangely.
+ */
+function normalise(stored) {
+  const raw = stored && typeof stored === 'object' ? stored : {};
+  const out = {};
+  for (const [key, clean] of Object.entries(SHAPE)) {
+    out[key] = key in raw ? clean(raw[key]) : DEFAULTS[key];
+  }
+  return out;
+}
+
+/**
+ * Applies a change, with the rules one setting has on another.
+ *
+ * Returns a whole new settings object rather than mutating, so the caller can compare and decide
+ * whether anything needs writing or rebuilding.
+ */
+function applyChange(current, key, value) {
+  if (!(key in SHAPE)) return normalise(current);
+
+  const next = { ...normalise(current), [key]: SHAPE[key](value) };
+
+  if (key === 'checkForUpdates' && next.checkForUpdates === false) {
+    // Leaving a remembered result behind would let a stale banner outlive the setting.
+    next.lastCheckedAt = 0;
+    next.skippedVersion = null;
+  }
+
+  if (key === 'betaReleases' && next.betaReleases !== normalise(current).betaReleases) {
+    /*
+     * A version skipped on one channel means nothing on the other.
+     *
+     * Somebody who skipped 0.5.0 on the stable channel and then asks for betas is asking to be
+     * offered what is new. Leaving the skip behind would silently withhold the first release they
+     * turned this on for, and they would have no way of telling why.
+     */
+    next.skippedVersion = null;
+  }
+
+  return next;
+}
+
+/**
+ * Whether the updater may make a request at all.
+ *
+ * The beta setting is separate from this rather than being a third state of it, because they answer
+ * different questions: whether the app may ask GitHub anything, and which answer it will accept.
+ * Turning betas on while checking is off does nothing, which is the honest arrangement -- no
+ * setting here can start a request on its own.
+ */
+function mayCheckForUpdates(settings) {
+  return normalise(settings).checkForUpdates === true;
+}
+
+/** Whether a found version should be offered, or has already been declined. */
+function shouldOffer(settings, version) {
+  const { skippedVersion } = normalise(settings);
+  return !skippedVersion || skippedVersion !== version;
+}
+
+module.exports = {
+  DEFAULT_SETTINGS: DEFAULTS,
+  normalise,
+  applyChange,
+  mayCheckForUpdates,
+  shouldOffer,
+};

--- a/desktop/settings.test.js
+++ b/desktop/settings.test.js
@@ -1,0 +1,172 @@
+/*
+ * The rules one setting has on another, and what a settings file is allowed to become.
+ *
+ * The cross-setting cases are ported from `app/.../update/UpdatePreferences.kt`. They matter more
+ * than they look: each one exists for a failure that is silent. A stale banner outliving the
+ * setting that produced it, or a release withheld because of a decision the reader made about a
+ * different channel, are both things somebody would report as "the updater is broken" without ever
+ * being able to say why.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  DEFAULT_SETTINGS, normalise, applyChange, mayCheckForUpdates, shouldOffer,
+} = require('./settings.js');
+
+// ------------------------------------------------------------------ defaults
+
+test('the two settings that reach the network are off until switched on', () => {
+  // This app makes no request of any kind unless somebody has asked it to, and a default of "on"
+  // would quietly make that untrue for everybody who never opened the menu.
+  assert.strictEqual(DEFAULT_SETTINGS.checkForUpdates, false);
+  assert.strictEqual(DEFAULT_SETTINGS.betaReleases, false);
+});
+
+test('the rest default to what most readers want', () => {
+  assert.strictEqual(DEFAULT_SETTINGS.familyWords, 'en');
+  assert.strictEqual(DEFAULT_SETTINGS.photosOnChart, true);
+  assert.strictEqual(DEFAULT_SETTINGS.theme, 'light');
+});
+
+test('the defaults cannot be edited by accident', () => {
+  // Frozen, so a caller that keeps a reference and writes to it changes nothing. Asserted as "the
+  // value did not move" rather than "it threw": these modules are CommonJS and therefore sloppy
+  // mode, where a write to a frozen object is ignored in silence rather than raising.
+  DEFAULT_SETTINGS.checkForUpdates = true;
+  assert.strictEqual(DEFAULT_SETTINGS.checkForUpdates, false);
+});
+
+// ------------------------------------------------------------------ reading a stored file
+
+test('a settings file edited into nonsense gives sensible defaults, not strange behaviour', () => {
+  // It lives in a directory the reader can open. It can also have been written by a newer version
+  // of this app and then opened by an older one.
+  const wild = normalise({
+    familyWords: 'klingon',
+    photosOnChart: 'yes please',
+    theme: 42,
+    checkForUpdates: 'true',
+    betaReleases: 1,
+    lastCheckedAt: -5,
+    skippedVersion: '   ',
+    somethingFromTheFuture: { nested: true },
+  });
+
+  assert.strictEqual(wild.familyWords, 'en');
+  assert.strictEqual(wild.theme, 'light');
+  // The string "true" is not true: only a real boolean turns a network setting on.
+  assert.strictEqual(wild.checkForUpdates, false);
+  assert.strictEqual(wild.betaReleases, false);
+  assert.strictEqual(wild.lastCheckedAt, 0);
+  assert.strictEqual(wild.skippedVersion, null);
+  assert.ok(!('somethingFromTheFuture' in wild), 'unknown keys are dropped');
+});
+
+test('"photos on the chart" is on unless it was explicitly turned off', () => {
+  // The odd one out: it defaults to true, so a missing or unreadable value must not read as false
+  // and silently strip every photograph from somebody's chart.
+  assert.strictEqual(normalise({}).photosOnChart, true);
+  assert.strictEqual(normalise({ photosOnChart: undefined }).photosOnChart, true);
+  assert.strictEqual(normalise({ photosOnChart: false }).photosOnChart, false);
+});
+
+test('nothing at all is still a usable settings object', () => {
+  assert.deepStrictEqual(normalise(null), { ...DEFAULT_SETTINGS });
+  assert.deepStrictEqual(normalise(undefined), { ...DEFAULT_SETTINGS });
+  assert.deepStrictEqual(normalise('a string'), { ...DEFAULT_SETTINGS });
+});
+
+// ------------------------------------------------------------------ the cross-setting rules
+
+test('turning update checking off forgets what the last check found', () => {
+  // "Leaving a remembered result behind would let a stale banner outlive the setting."
+  const before = normalise({
+    checkForUpdates: true, lastCheckedAt: 1_700_000_000_000, skippedVersion: 'desktop-v9.9.9',
+  });
+  const after = applyChange(before, 'checkForUpdates', false);
+
+  assert.strictEqual(after.checkForUpdates, false);
+  assert.strictEqual(after.lastCheckedAt, 0);
+  assert.strictEqual(after.skippedVersion, null);
+});
+
+test('turning it back on does not resurrect the old result', () => {
+  const off = applyChange(
+    normalise({ checkForUpdates: true, lastCheckedAt: 123, skippedVersion: 'desktop-v1.0.0' }),
+    'checkForUpdates', false,
+  );
+  const on = applyChange(off, 'checkForUpdates', true);
+
+  assert.strictEqual(on.checkForUpdates, true);
+  assert.strictEqual(on.lastCheckedAt, 0);
+  assert.strictEqual(on.skippedVersion, null);
+});
+
+test('changing channel forgets a version skipped on the other one', () => {
+  /*
+   * "A version skipped on one channel means nothing on the other: leaving it behind would silently
+   * hide the first release the reader has just asked to be offered."
+   *
+   * Somebody who skipped 0.5.0 on stable and then asks for betas is asking to see what is new. The
+   * skip would withhold exactly that, and they would have no way of telling why.
+   */
+  const stable = normalise({ betaReleases: false, skippedVersion: 'desktop-v0.5.0' });
+  assert.strictEqual(applyChange(stable, 'betaReleases', true).skippedVersion, null);
+
+  const beta = normalise({ betaReleases: true, skippedVersion: 'desktop-v0.6.0-beta.1' });
+  assert.strictEqual(applyChange(beta, 'betaReleases', false).skippedVersion, null);
+});
+
+test('setting the channel to what it already is does not clear a skip', () => {
+  // Rebuilding the menu re-applies values. A no-op write must stay a no-op, or a reader who opens
+  // the preferences dialog and closes it would be asked again about a version they declined.
+  const settings = normalise({ betaReleases: true, skippedVersion: 'desktop-v0.6.0-beta.1' });
+  assert.strictEqual(
+    applyChange(settings, 'betaReleases', true).skippedVersion,
+    'desktop-v0.6.0-beta.1',
+  );
+});
+
+test('an unrelated setting leaves the update state alone', () => {
+  const settings = normalise({
+    checkForUpdates: true, lastCheckedAt: 999, skippedVersion: 'desktop-v1.2.3',
+  });
+  const after = applyChange(settings, 'theme', 'dark');
+
+  assert.strictEqual(after.theme, 'dark');
+  assert.strictEqual(after.lastCheckedAt, 999);
+  assert.strictEqual(after.skippedVersion, 'desktop-v1.2.3');
+});
+
+test('a change to something this app does not know about changes nothing', () => {
+  const settings = normalise({ theme: 'dark' });
+  assert.deepStrictEqual(applyChange(settings, 'nonsense', true), settings);
+});
+
+test('applying a change does not mutate what it was given', () => {
+  const settings = normalise({ checkForUpdates: true, lastCheckedAt: 5 });
+  applyChange(settings, 'checkForUpdates', false);
+  assert.strictEqual(settings.lastCheckedAt, 5, 'the original is untouched');
+});
+
+// ------------------------------------------------------------------ what the updater asks
+
+test('betas turned on while checking is off still makes no request', () => {
+  // The honest arrangement: no setting here can start a request on its own.
+  assert.strictEqual(mayCheckForUpdates(normalise({ betaReleases: true })), false);
+  assert.strictEqual(
+    mayCheckForUpdates(normalise({ checkForUpdates: true, betaReleases: false })), true,
+  );
+});
+
+test('a version the reader has declined is not offered again', () => {
+  const settings = normalise({ skippedVersion: 'desktop-v0.5.0' });
+  assert.strictEqual(shouldOffer(settings, 'desktop-v0.5.0'), false);
+  assert.strictEqual(shouldOffer(settings, 'desktop-v0.5.1'), true);
+});
+
+test('with nothing skipped, everything is offered', () => {
+  assert.strictEqual(shouldOffer(normalise({}), 'desktop-v0.5.0'), true);
+});

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -27,6 +27,44 @@ which multiply a chart's width far faster than they add to what it tells you. Cl
 the reading to that person. Where the record goes further than the reading, it says so and offers
 to go on.
 
+## Settings
+
+`Updates > Preferences…`, on `Ctrl+,`. Family words, photographs on the chart, appearance, and the
+two update settings. Every one of them is also in the native menu, and **both surfaces go through
+the same `settings:set`**, which rebuilds the menu from the result.
+
+That rebuild is the point rather than a detail. A native menu checkbox's `checked:` is a snapshot
+taken when the menu was built: one surface over one value is fine forever, and two is fine until
+somebody uses the second one. Before this, switching betas on in a dialog would have left the menu
+saying they were off until the app restarted.
+
+The rules live in `desktop/settings.js` — pure, no disk and no Electron, ported from
+`update/UpdatePreferences.kt` with its reasoning. Some settings are not independent of each other:
+
+| | |
+|---|---|
+| turning update checking **off** | clears the last-checked time and any skipped version — *"leaving a remembered result behind would let a stale banner outlive the setting"* |
+| changing **channel** | clears the skipped version — *"a version skipped on one channel means nothing on the other: leaving it behind would silently hide the first release the reader has just asked to be offered"* |
+
+Both `lastCheckedAt` and `skippedVersion` are new here. The desktop stored neither, so its update
+dialog's "Not now" remembered nothing and the same release was offered on every launch until it was
+taken — which teaches people to dismiss the dialog unread, and then the one release that matters is
+dismissed the same way. **Skip this version** is now a separate answer from **Not now**: one is about
+today, the other about this release. Only the automatic check honours a skip; asking from the menu
+always gets an answer, because a question deserves one.
+
+The two settings that reach the network are off until switched on. This app makes no request of any
+kind unless somebody has asked it to, and a default of "on" would quietly make that untrue for
+everybody who never opened the menu. Betas and checking are separate settings rather than three
+states of one, because they answer different questions — whether the app may ask GitHub anything,
+and which answer it will accept — so betas with checking off makes no request at all, and the
+checkbox is greyed rather than merely useless.
+
+The theme lives in that file too, with everything else. `localStorage` keeps a mirror of it, and
+only for the inline script that sets the theme before the first paint: the settings file is read
+over IPC and there is no asking it anything that early. A cleared mirror costs one launch in the
+system's colours, not a lost setting.
+
 ## How two people are related
 
 `View > How are two people related?`, on `Ctrl+R`, or the `R` key. Pick two people; the answer is a


### PR DESCRIPTION
Closes #122. Phase 3.

There was no settings surface at all, and the renderer could neither read nor write one. Updates and the beta channel existed only as native menu checkboxes whose `checked:` values are **snapshots taken when the menu was built** — fine forever with one surface, and fine right up until there are two.

So the dialog is half the work and the rebuild is the other half. Both surfaces go through the same `settings:set`, which applies the rules, writes the file, and rebuilds the menu from the result. The smoke test asserts the regression directly — change it in the dialog, then read the **real application menu**:

```
ok   the menu and the dialog start in step  false
ok   turning a setting on in the dialog updates the menu  true
ok   and the menu follows it back down  false
```

## The correction this makes to its own plan

The plan said to carry across `UpdatePreferences`' cross-setting rules. **Neither value they act on existed on the desktop** — no `lastCheckedAt`, no `skippedVersion`, and `chooseUpdate` took no skipped version. Writing those clauses would have been two lines that clear nothing while reading as though the behaviour were covered.

So the values they are about now exist ([flagged on #122 before building](https://github.com/thisisankit27/f-tree/issues/122)). The update dialog gains **Skip this version** beside **Not now** — different answers that should not be conflated: one is about today, the other about this release. Without it the automatic check offers the same release every launch until it is taken, which teaches people to dismiss the dialog unread — and then the one release that matters is dismissed the same way. Only the quiet check honours a skip; asking from the menu always gets an answer.

## The rules

`desktop/settings.js`: pure, no disk, no Electron, ported from `update/UpdatePreferences.kt` with its reasoning.

| | |
|---|---|
| updates **off** | clears last-checked and any skipped version — *"leaving a remembered result behind would let a stale banner outlive the setting"* |
| **channel** changes | clears the skipped version — *"a version skipped on one channel means nothing on the other: leaving it behind would silently hide the first release the reader has just asked to be offered"* |

Setting the channel to what it already is does **not** clear a skip — rebuilding the menu re-applies values, and a no-op write must stay a no-op.

A settings file lives in a directory the reader can open, and may have been written by a newer version of this app. Every value goes through its own rule and unknown keys are dropped, so a file edited into nonsense gives sensible defaults rather than strange behaviour. **The string `"true"` is not `true`**: only a real boolean turns a network setting on.

## Smaller decisions

- **Betas are greyed while checking is off**, not merely useless. They answer different questions — whether the app may ask GitHub anything, and which answer it will accept. A live checkbox that changes nothing explains that worse than a disabled one beside a line saying no request is made.
- **Photographs off passes the chart no archive at all**, rather than the real one and an instruction to ignore it — as Android does. *"The reader turned photographs off"* should be a fact the drawing code cannot forget.
- **Family words** is present and says plainly that Hindi is not built yet (#124). A setting that is there and does nothing is worse than one that admits it is not ready.
- **The theme moves into the same file.** `localStorage` keeps a mirror, and only for the inline script that paints before `app.js` loads — the settings file is read over IPC and there is nothing to ask that early. A cleared mirror costs one launch in the system's colours, not a lost setting.

## Verification

- **The packaged app**, unconfined: **69 smoke assertions**, including compact, relate, settings, import and the edit/save round trip.
- The dialog is asserted to fit the window the app opens at, **as a height budget** rather than by measuring the visible area — this screen is smaller than the app's default window, so measuring here would be a fact about the machine. `426px of settings against a 560px budget`. A settings screen that scrolls hides settings, and the ones it hides are at the bottom: the two that reach the network.
- Both themes screenshotted.
- `npm test` **181 → 196**; engine 40. `suite.test.js` from #118 caught `settings.test.js` going unwired, which is exactly what it is for.
- **`kinship-golden.txt` unmoved.** `check_layout.mjs`, `check_writer.mjs` pass. `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)