### PR TITLE
feat(desktop): author a photograph, not only carry one

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -729,6 +729,42 @@ ipcMain.handle('app:installationId', () => installationId(app.getPath('userData'
  * apply whichever surface made the change, and the menu is rebuilt from the result. A checkbox
  * whose `checked:` was a snapshot is exactly how two surfaces start disagreeing.
  */
+/*
+ * A picked image, as bytes.
+ *
+ * Bytes rather than a path, for the same reason the app copies rather than references: a path is a
+ * promise about somebody else's filesystem that this app cannot keep. The reader may move the
+ * picture, rename the folder, or unplug the drive it was on, and a tree full of pictures that
+ * silently stop loading is worse than one with none.
+ *
+ * The renderer does the rest. It has a canvas and this side does not, and adding an image codec to
+ * the process that holds the file handles is not a trade worth making.
+ */
+ipcMain.handle('photo:choose', async (event) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const chosen = await dialog.showOpenDialog(win, {
+    title: 'Choose a photograph',
+    properties: ['openFile'],
+    filters: [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'webp', 'gif', 'bmp'] }],
+  });
+  if (chosen.canceled || !chosen.filePaths.length) return null;
+
+  const file = chosen.filePaths[0];
+  try {
+    const bytes = await fs.readFile(file);
+    return { name: path.basename(file), bytes: bytes.buffer.slice(
+      bytes.byteOffset, bytes.byteOffset + bytes.byteLength) };
+  } catch (error) {
+    await dialog.showMessageBox(win, {
+      type: 'error',
+      message: 'That picture could not be read.',
+      detail: error.message,
+      buttons: ['OK'],
+    });
+    return null;
+  }
+});
+
 ipcMain.handle('settings:get', () => ({ ...settings }));
 
 ipcMain.handle('settings:set', async (event, { key, value }) => {
@@ -1150,6 +1186,196 @@ async function runCompactSmoke(win, check) {
  * "the dialog opens" but "changing it here changed the menu too", and the cross-setting rules that
  * would otherwise be silently wrong.
  */
+/*
+ * Putting a face on somebody, and getting the same file the phone would have written.
+ *
+ * The picker cannot be clicked from here, so the bytes are handed straight to the renderer's own
+ * encoder -- everything after that is the real path: the real canvas, the real crop, the real
+ * `state.photos`, the real save. What is asserted is the part that has to match Android exactly,
+ * because the same tree is carried back and forth: 512px square, JPEG, and never scaled up.
+ */
+async function runPhotoSmoke(win, check) {
+  const page = (fn, ...args) => win.webContents.executeJavaScript(
+    `(${fn.toString()})(${args.map((a) => JSON.stringify(a)).join(',')})`);
+  const settle = (ms = 400) => new Promise((r) => setTimeout(r, ms));
+
+  console.log('\n  -- a photograph --');
+
+  // A wide picture, so the square has to be cut and the framing has something to do.
+  const made = await page(async () => {
+    const source = document.createElement('canvas');
+    source.width = 1200;
+    source.height = 600;
+    const ctx = source.getContext('2d');
+    ctx.fillStyle = '#2a5138';
+    ctx.fillRect(0, 0, 1200, 600);
+    ctx.fillStyle = '#f7f6f1';
+    ctx.fillRect(900, 100, 200, 200);
+    const blob = await new Promise((r) => source.toBlob(r, 'image/png'));
+    window.__pickedPhoto = new Uint8Array(await blob.arrayBuffer());
+    return window.__pickedPhoto.length;
+  });
+  check('a picture was made to pick', made > 0, `${made} bytes`);
+
+  const stored = await page(async () => {
+    const photo = await import('./photo.js');
+    const bitmap = await photo.decode(window.__pickedPhoto);
+    const bytes = await photo.encode(bitmap, 1);          // dragged all the way to the right
+    const centre = await photo.encode(bitmap, 0.5);
+    const shot = await createImageBitmap(new Blob([bytes], { type: 'image/jpeg' }));
+    return {
+      width: shot.width,
+      height: shot.height,
+      jpeg: bytes[0] === 0xff && bytes[1] === 0xd8,      // SOI marker
+      size: bytes.length,
+      // The drag has to actually change the picture, or it is decoration.
+      moved: bytes.length !== centre.length || !bytes.every((b, i) => b === centre[i]),
+    };
+  });
+
+  check('a photograph is stored 512px square, as PhotoStore does',
+    stored.width === 512 && stored.height === 512, `${stored.width}x${stored.height}`);
+  check('and as a JPEG', stored.jpeg, `${stored.size} bytes`);
+  check('the framing actually changes what is kept', stored.moved, String(stored.moved));
+
+  // Never scaled up: a 200px picture stays 200px rather than being stored four times as heavy for
+  // no more detail than it started with.
+  const small = await page(async () => {
+    const photo = await import('./photo.js');
+    const source = document.createElement('canvas');
+    source.width = 200;
+    source.height = 200;
+    source.getContext('2d').fillRect(0, 0, 200, 200);
+    const blob = await new Promise((r) => source.toBlob(r, 'image/png'));
+    const bitmap = await photo.decode(new Uint8Array(await blob.arrayBuffer()));
+    const bytes = await photo.encode(bitmap, 0.5);
+    const shot = await createImageBitmap(new Blob([bytes], { type: 'image/jpeg' }));
+    return { width: shot.width, height: shot.height };
+  });
+  check('a small photograph is left at its own size, not blown up to 512',
+    small.width === 200 && small.height === 200, `${small.width}x${small.height}`);
+
+  /*
+   * Onto a person, and off again.
+   *
+   * The pruning is what matters on the way out: a removed photograph must stop being written into
+   * every future save, or the file grows with pictures of nobody.
+   */
+  const attached = await page(async () => {
+    const photo = await import('./photo.js');
+    const bitmap = await photo.decode(window.__pickedPhoto);
+    const bytes = await photo.encode(bitmap, 0.5);
+    const row = document.querySelector('#index-list .index-row');
+    row?.click();
+    await new Promise((r) => setTimeout(r, 250));
+    window.__setPhotoForTest(bytes);
+    await new Promise((r) => setTimeout(r, 350));
+    const face = document.querySelector('#panel .photo-face img');
+    return {
+      shown: Boolean(face),
+      entries: window.__photoCountForTest(),
+      used: window.__photoUsedForTest(),
+    };
+  });
+
+  check('the person panel shows the face', attached.shown, String(attached.shown));
+  check('the photograph is stored in the tree', attached.entries > 0,
+    `${attached.entries} entries, ${attached.used} in use`);
+
+  if (process.env.FTREE_SMOKE_SHOT_PHOTO) {
+    const shot = process.env.FTREE_SMOKE_SHOT_PHOTO;
+    await fs.writeFile(shot, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${shot}`);
+
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(400);
+    const other = shot.replace(/(\.png)?$/, '-other-theme.png');
+    await fs.writeFile(other, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${other}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(300);
+  }
+
+  const roundTrip = await page(() => window.__photoRoundTripForTest());
+  check('a photograph added here is written into the .ftree and reads back',
+    roundTrip.inArchive && roundTrip.size > 0,
+    `${roundTrip.named} — ${roundTrip.size} bytes, ${roundTrip.count} photos in the archive`);
+
+  /*
+   * The framing dialog, which the picker cannot be clicked to reach.
+   *
+   * Worth opening for its own sake: it is the one surface here with an interaction in it, and the
+   * drag has to be shown to move something. Arrow keys are used rather than synthesised pointer
+   * events, because the keyboard path is the one that would otherwise never be exercised.
+   */
+  const framed = await page(async () => {
+    const opened = await window.__openFrameForTest(window.__pickedPhoto);
+    await new Promise((r) => setTimeout(r, 350));
+    const stage = document.getElementById('frame-stage');
+    const before = window.__frameOffsetForTest();
+    stage.focus();
+    stage.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 150));
+    return {
+      opened,
+      open: document.getElementById('frame').open === true,
+      before,
+      after: window.__frameOffsetForTest(),
+      outcome: document.getElementById('frame-outcome').textContent.trim(),
+      focused: document.activeElement === stage,
+    };
+  });
+
+  check('the framing dialog opens on a picked picture', framed.opened && framed.open,
+    JSON.stringify({ opened: framed.opened, open: framed.open }));
+  check('it says what will be kept', /square/.test(framed.outcome), framed.outcome);
+  check('the framing can be moved with the keyboard, not only dragged',
+    framed.focused && framed.after < framed.before,
+    `${framed.before} -> ${framed.after}, focused ${framed.focused}`);
+
+  if (process.env.FTREE_SMOKE_SHOT_FRAME) {
+    const shot = process.env.FTREE_SMOKE_SHOT_FRAME;
+    await fs.writeFile(shot, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${shot}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(400);
+    const other = shot.replace(/(\.png)?$/, '-other-theme.png');
+    await fs.writeFile(other, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${other}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(300);
+  }
+
+  await page(() => document.getElementById('frame-cancel').click());
+  await settle(400);
+  const cancelled = await page(() => document.getElementById('frame').open === true);
+  check('cancelling the framing changes nothing', !cancelled, String(cancelled));
+
+  const removed = await page(async () => {
+    window.__setPhotoForTest(null);
+    await new Promise((r) => setTimeout(r, 350));
+    return {
+      face: Boolean(document.querySelector('#panel .photo-face img')),
+      used: window.__photoUsedForTest(),
+    };
+  });
+  check('removing it takes the face off the person', !removed.face, String(removed.face));
+
+  /*
+   * One fewer, not none.
+   *
+   * The first version of this asserted zero and failed on a correct app: `sample-family.ftree`
+   * already carries four photographs belonging to other people, and `photosStillUsed` is a question
+   * about the whole tree rather than about this edit. What matters is that the one just removed
+   * stops being written, and that the other four keep being written.
+   */
+  check('the removed photograph stops being written into every future save',
+    removed.used === attached.used - 1,
+    `${attached.used} in use before, ${removed.used} after`);
+  check('and nobody else’s photograph is dropped with it', removed.used > 0,
+    `${removed.used} still in use`);
+}
+
 async function runSettingsSmoke(win, check) {
   const { Menu } = require('electron');
   const page = (fn, ...args) => win.webContents.executeJavaScript(
@@ -1689,6 +1915,8 @@ async function runSmoke(win, file) {
   if (process.env.FTREE_SMOKE_RELATE) await runRelateSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_SETTINGS) await runSettingsSmoke(win, check);
+
+  if (process.env.FTREE_SMOKE_PHOTO) await runPhotoSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_IMPORT) await runImportSmoke(win, check);
 

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -21,6 +21,19 @@ contextBridge.exposeInMainWorld('ftreeDesktop', {
    * clears what the last check found -- and turning betas on asks a question the reader can answer
    * no to. A dialog that assumed its own value would then show the opposite of the truth.
    */
+  /**
+   * True only when the app was started by the smoke harness.
+   *
+   * The page hangs a few test hooks on `window` when this is set -- reaching into module scope from
+   * `executeJavaScript` is otherwise impossible, because app.js is a module. Read from the
+   * environment of the *main* process, which a page cannot set, so a build somebody is using never
+   * carries them.
+   */
+  smoke: Boolean(process.env.FTREE_SMOKE),
+
+  /** Opens the picture picker and hands back the bytes, or null if nobody chose one. */
+  choosePhoto: () => ipcRenderer.invoke('photo:choose'),
+
   settings: () => ipcRenderer.invoke('settings:get'),
   setSetting: (key, value) => ipcRenderer.invoke('settings:set', { key, value }),
 

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -21,7 +21,7 @@
  */
 
 import { openArchive, parseDocument, ArchiveError } from '../../site/playground/archive.js';
-import { buildGraph, displayName, lifespan, relationsOf } from '../../site/playground/model.js';
+import { buildGraph, displayName, lifespan, initials, relationsOf } from '../../site/playground/model.js';
 import { layoutArchive } from '../../site/playground/layout.js';
 import { Chart } from '../../site/playground/chart.js';
 import { compactFamily } from '../../site/playground/compact.js';
@@ -35,6 +35,7 @@ import { planImport, applyImport, ImportRefused } from './import.js';
 import { MatchTier } from './matching.js';
 import { renderBands } from './bands.js';
 import { sentenceFor, unrelatedWording, paintSentence, nameNode } from './relation.js';
+import { decode, encode, asImageUrl, freeName, squareCrop } from './photo.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
 
@@ -119,6 +120,10 @@ function reflectDirty() {
  * editing every time you typed their name would be its own bug.
  */
 function rebuild({ refit = false } = {}) {
+  // Every photograph drawn last time is handed back before any is drawn again; otherwise a page
+  // that redraws on every edit keeps every face it has ever shown alive in memory.
+  releasePhotos();
+
   const doc = state.tree.toExchange();
   state.graph = buildGraph(doc);
   state.layout = layoutArchive(state.graph, { orientation: 'rows' });
@@ -200,6 +205,279 @@ function setView(view) {
   if (view === 'chart') chart.resize();
   else if (view === 'compact') renderCompact();
   else renderPeople();
+}
+
+/* ------------------------------------------------------------------ photographs */
+
+/**
+ * Object URLs handed out for showing stored bytes, so they can be handed back.
+ *
+ * A page that makes one of these per render and never revokes them keeps every photograph it has
+ * ever drawn alive in memory, which on a tree of any size is the difference between an app and a
+ * leak.
+ */
+const shownPhotos = new Set();
+
+function photoUrl(name) {
+  const bytes = state.photos.get(name);
+  if (!bytes) return null;
+  const url = asImageUrl(bytes);
+  shownPhotos.add(url);
+  return url;
+}
+
+function releasePhotos() {
+  for (const url of shownPhotos) URL.revokeObjectURL(url);
+  shownPhotos.clear();
+}
+
+/** The face in the person panel, and the way to change it. */
+function photoField(person) {
+  const box = document.createElement('div');
+  box.className = 'photo-field';
+
+  const url = person.photo ? photoUrl(person.photo) : null;
+
+  if (url) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'photo-face';
+    // Uncropped when opened: every other place shows this inside a circle, and a square cut from a
+    // group photograph is often the wrong square.
+    button.title = 'See the whole photograph';
+    const img = document.createElement('img');
+    img.src = url;
+    img.alt = `${displayName(person)}`;
+    button.append(img);
+    button.addEventListener('click', () => openPhotoView(person, url));
+    box.append(button);
+  } else {
+    const empty = document.createElement('div');
+    empty.className = 'photo-face empty';
+    empty.setAttribute('aria-hidden', 'true');
+    empty.textContent = initials(person);
+    box.append(empty);
+  }
+
+  const actions = document.createElement('div');
+  actions.className = 'photo-actions';
+
+  const choose = document.createElement('button');
+  choose.type = 'button';
+  choose.className = 'btn quiet';
+  choose.textContent = person.photo ? 'Replace' : 'Add a photograph';
+  choose.addEventListener('click', () => choosePhotoFor(person.id));
+  actions.append(choose);
+
+  if (person.photo) {
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'btn quiet';
+    remove.textContent = 'Remove';
+    remove.addEventListener('click', () => setPhoto(person.id, null));
+    actions.append(remove);
+  }
+
+  box.append(actions);
+  return box;
+}
+
+function openPhotoView(person, url) {
+  $('photo-view-img').src = url;
+  $('photo-view-img').alt = `Photograph of ${displayName(person)}`;
+  $('photo-view-who').textContent = displayName(person);
+  $('photo-view').showModal();
+}
+
+/**
+ * Writes a photograph onto a person, or takes one off.
+ *
+ * The bytes are stored under a name nothing else is using; the old entry is left to
+ * `photosStillUsed` to prune on the next save, because a photograph is only unused once nobody
+ * points at it, and that is a question about the whole tree rather than about this edit.
+ */
+function setPhoto(id, bytes) {
+  const person = state.tree.people.find((p) => p.id === id);
+  if (!person) return;
+
+  let name = null;
+  if (bytes) {
+    name = freeName(new Set(state.photos.keys()));
+    if (!name) { toast('That photograph could not be stored.', 'bad'); return; }
+    state.photos.set(name, bytes);
+  }
+
+  // `updatePerson` leaves every field it is not given alone, so naming only `photo` here cannot
+  // wipe the dates or the notes this panel is not currently showing.
+  const result = state.tree.updatePerson(id, { photo: name });
+  if (!result?.ok) {
+    toast(REFUSALS[result?.reason] ?? 'That photograph could not be set.', 'bad');
+    return;
+  }
+  rebuild();
+  toast(bytes ? 'Photograph added. Undo with Ctrl+Z.' : 'Photograph removed. Undo with Ctrl+Z.');
+}
+
+/** The framing step: pick a file, choose what the circle shows, then store it. */
+async function choosePhotoFor(id) {
+  if (!shell?.choosePhoto) return;
+
+  const picked = await shell.choosePhoto();
+  if (!picked) return;
+
+  const bitmap = await decode(picked.bytes);
+  if (!bitmap) { toast('That file is not a picture this app can read.', 'bad'); return; }
+
+  openFrame(bitmap, id, picked.name);
+}
+
+/** How far along the long edge the square sits, 0 to 1. Reset for every new picture. */
+let framing = { bitmap: null, personId: null, offset: 0.5, url: null };
+
+function paintFrame() {
+  const { bitmap, offset } = framing;
+  if (!bitmap) return;
+  const stage = $('frame-stage');
+  const img = $('frame-img');
+
+  // The stage shows a square; the picture slides behind it. Expressed as a percentage so the
+  // drawing follows the same fraction the crop will use, at whatever size the dialog happens to be.
+  const landscape = bitmap.width >= bitmap.height;
+  stage.dataset.orientation = landscape ? 'landscape' : 'portrait';
+  img.style.objectPosition = landscape ? `${offset * 100}% 50%` : `50% ${offset * 100}%`;
+
+  const crop = squareCrop(bitmap.width, bitmap.height, offset);
+  $('frame-outcome').textContent = crop.size === Math.max(bitmap.width, bitmap.height)
+    ? 'Already square — nothing to frame.'
+    : `${bitmap.width} × ${bitmap.height}, kept as ${Math.min(crop.size, 512)}px square.`;
+}
+
+function openFrame(bitmap, personId, fileName) {
+  releaseFraming();
+  framing = { bitmap, personId, offset: 0.5, url: asImageUrl(null) };
+
+  const img = $('frame-img');
+  img.src = bitmapUrl(bitmap);
+  img.alt = fileName ?? '';
+  paintFrame();
+  $('frame').showModal();
+  $('frame-head').focus();
+}
+
+/** A drawable URL for the picked image, kept so it can be revoked when the dialog closes. */
+function bitmapUrl(bitmap) {
+  const canvas = document.createElement('canvas');
+  canvas.width = bitmap.width;
+  canvas.height = bitmap.height;
+  canvas.getContext('2d').drawImage(bitmap, 0, 0);
+  const url = canvas.toDataURL('image/png');
+  framing.url = url;
+  return url;
+}
+
+function releaseFraming() {
+  framing.bitmap?.close?.();
+  framing = { bitmap: null, personId: null, offset: 0.5, url: null };
+}
+
+/*
+ * Hooks for the smoke harness, and only for it.
+ *
+ * The picker is a native dialog that cannot be clicked from a test, so the harness hands bytes
+ * straight to the encoder and then needs a way to put the result on somebody and read back what the
+ * tree holds. `shell.smoke` comes from the main process's own environment, which a page cannot set,
+ * so a build somebody is using never carries any of this.
+ */
+function exposeTestHooks() {
+  if (!shell?.smoke) return;
+  window.__setPhotoForTest = (bytes) => setPhoto(state.selected, bytes);
+  window.__openFrameForTest = async (bytes) => {
+    const bitmap = await decode(bytes);
+    if (bitmap) openFrame(bitmap, state.selected, 'a-photograph.png');
+    return Boolean(bitmap);
+  };
+  window.__frameOffsetForTest = () => framing.offset;
+
+  /*
+   * Write the tree and read it back, through the real writer and the real reader.
+   *
+   * The point of authoring a photograph is that it ends up in the file. Everything else here checks
+   * the app's own state, which would look perfect while the archive went out empty.
+   */
+  window.__photoRoundTripForTest = async () => {
+    // `bytesForTree` hands back the bytes *and* what it counted, not the bytes alone.
+    const { bytes } = await bytesForTree(state.tree, photosStillUsed());
+    const archive = await openArchive(bytes.buffer.slice(
+      bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    const doc = parseDocument(await archive.readText('tree.json'));
+    const person = doc.people.find((p) => p.id === state.selected);
+    const entries = archive.names().filter((n) => n.startsWith('photos/'));
+    return {
+      named: person?.photo ?? null,
+      inArchive: person?.photo ? entries.includes(person.photo) : false,
+      count: entries.length,
+      size: person?.photo ? (await archive.read(person.photo))?.byteLength ?? 0 : 0,
+    };
+  };
+  window.__photoCountForTest = () => state.photos.size;
+  window.__photoUsedForTest = () => photosStillUsed().size;
+}
+
+function wirePhotos() {
+  const frame = $('frame');
+  if (!frame) return;
+  exposeTestHooks();
+
+  $('photo-view-close').addEventListener('click', () => $('photo-view').close());
+  $('frame-cancel').addEventListener('click', () => frame.close());
+  frame.addEventListener('close', releaseFraming);
+
+  $('frame-save').addEventListener('click', async () => {
+    const { bitmap, personId, offset } = framing;
+    if (!bitmap) { frame.close(); return; }
+    const bytes = await encode(bitmap, offset);
+    frame.close();
+    if (!bytes) { toast('That photograph could not be stored.', 'bad'); return; }
+    setPhoto(personId, bytes);
+  });
+
+  // Dragging across the stage moves the square along the long edge. Pointer events rather than
+  // mouse ones, so a trackpad and a touchscreen both work.
+  const stage = $('frame-stage');
+  let dragging = null;
+  stage.addEventListener('pointerdown', (event) => {
+    if (!framing.bitmap) return;
+    dragging = { x: event.clientX, y: event.clientY, from: framing.offset };
+    stage.setPointerCapture(event.pointerId);
+  });
+  stage.addEventListener('pointermove', (event) => {
+    if (!dragging || !framing.bitmap) return;
+    const box = stage.getBoundingClientRect();
+    const landscape = framing.bitmap.width >= framing.bitmap.height;
+    const moved = landscape
+      ? (event.clientX - dragging.x) / box.width
+      : (event.clientY - dragging.y) / box.height;
+    // Dragging right shows what is further right, so the offset moves against the pointer.
+    framing.offset = Math.min(1, Math.max(0, dragging.from - moved));
+    paintFrame();
+  });
+  const stop = () => { dragging = null; };
+  stage.addEventListener('pointerup', stop);
+  stage.addEventListener('pointercancel', stop);
+
+  // The keyboard reaches it too: a drag is not the only way somebody uses this app.
+  stage.tabIndex = 0;
+  stage.addEventListener('keydown', (event) => {
+    if (!framing.bitmap) return;
+    const step = event.shiftKey ? 0.2 : 0.05;
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      framing.offset = Math.max(0, framing.offset - step);
+    } else if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      framing.offset = Math.min(1, framing.offset + step);
+    } else return;
+    event.preventDefault();
+    paintFrame();
+  });
 }
 
 /* ------------------------------------------------------------------ preferences */
@@ -760,6 +1038,12 @@ function field({ label, id, value = '', type = 'text', wide = false, hint = null
 function personForm(person) {
   const form = document.createElement('div');
   form.className = 'form-grid';
+
+  // The face first, because it is how somebody recognises they have the right person open before
+  // reading a word of the form.
+  const photo = photoField(person);
+  photo.classList.add('field', 'wide');
+  form.append(photo);
 
   form.append(field({
     label: 'Name', id: 'f-name', value: person.name ?? '', wide: true,
@@ -1551,6 +1835,7 @@ async function boot() {
   wireChrome();
   wireRelate();
   wirePrefs();
+  wirePhotos();
   wireShell();
   wireKeys();
 

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -1001,3 +1001,143 @@
 .editor .prefs-control:disabled { opacity: .38; cursor: default; }
 
 .editor .prefs-row:has(.prefs-check:disabled) .prefs-label { color: var(--ink-faint); }
+
+/* ------------------------------------------------------------------ photographs */
+
+/*
+ * A face is shown in a circle everywhere in this app, and stored as a square.
+ *
+ * The circle is a matter of display, not of storage: a round image would have to be a PNG with an
+ * alpha channel, several times the size of the JPEG, to save a shape that every place showing it
+ * already draws for itself. So the stored file is the square, and `border-radius` does the rest.
+ */
+
+/*
+ * The face beside its two buttons, on the form's own left edge.
+ *
+ * Stated in full because this element also carries `.field`, which sets a column direction for
+ * every other row of the form -- inheriting that quietly gave a centred stack that broke the left
+ * edge every other label lines up on.
+ */
+.editor .photo-field {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 14px;
+  margin-bottom: 4px;
+}
+
+.editor .photo-face {
+  width: 64px;
+  height: 64px;
+  flex: none;
+  padding: 0;
+  border: 1px solid var(--rule);
+  border-radius: 50%;
+  overflow: hidden;
+  background: var(--bone-dim);
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+}
+
+.editor .photo-face img { width: 100%; height: 100%; object-fit: cover; display: block; }
+
+.editor .photo-face:hover, .editor .photo-face:focus-visible {
+  border-color: var(--forest);
+  outline: none;
+}
+
+/* No photograph: initials, as the chart draws them, rather than an empty hole or a stock avatar. */
+.editor .photo-face.empty {
+  cursor: default;
+  font-family: var(--serif);
+  font-size: 21px;
+  font-weight: 600;
+  color: var(--ink-faint);
+}
+
+.editor .photo-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.editor .photo-actions .btn { font-size: 12px; padding: 7px 13px; }
+
+/* ------------------------------------------------------------ a photograph, whole */
+
+.editor .photo-view[open] {
+  border: 1px solid var(--rule);
+  border-radius: 14px;
+  background: var(--raised);
+  color: var(--ink);
+  padding: 16px;
+  max-width: min(560px, calc(100vw - 48px));
+  box-shadow: var(--shadow);
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+}
+
+.editor .photo-view::backdrop { background: rgba(10, 28, 18, .58); backdrop-filter: blur(2px); }
+
+/*
+ * Uncropped, and that is the whole point of this dialog.
+ *
+ * Every other surface squares the picture into a circle. A square cut from a group photograph is
+ * often the wrong square, and this is where somebody checks what the file actually holds.
+ */
+.editor .photo-view img {
+  max-width: 100%;
+  max-height: min(62vh, 460px);
+  border-radius: 6px;
+  display: block;
+}
+
+.editor .photo-view-who {
+  font-family: var(--serif);
+  font-size: 15px;
+  color: var(--ink-soft);
+  margin: 0;
+}
+
+/* ------------------------------------------------------------ framing */
+
+.editor .frame[open] { width: min(440px, calc(100vw - 48px)); }
+.editor .frame-body { display: grid; place-items: center; padding: 20px; }
+
+/*
+ * The stage is the square that will be kept, and the picture slides behind it.
+ *
+ * Deliberately not a crop tool: there is no zoom and no free rectangle. The square is always the
+ * largest that fits, and dragging only chooses where along the long edge it sits -- enough to move
+ * a face out of a corner, and well short of rebuilding an image editor.
+ */
+.editor .frame-stage {
+  position: relative;
+  width: min(300px, 60vw);
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 8px;
+  background: var(--bone-dim);
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+
+.editor .frame-stage:active { cursor: grabbing; }
+.editor .frame-stage:focus-visible { outline: 2px solid var(--forest); outline-offset: 2px; }
+
+.editor .frame-stage img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  pointer-events: none;
+}
+
+/* The circle the face will actually be shown in, drawn over the square being kept. */
+.editor .frame-mask {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  box-shadow: 0 0 0 9999px rgba(10, 28, 18, .34);
+  pointer-events: none;
+}

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -245,6 +245,43 @@
     </div>
   </dialog>
 
+  <!-- ------------------------------------------------------------ a photograph, whole -->
+  <!--
+    Uncropped, on purpose. Every other place this app shows a face shows it inside a circle, and a
+    square cut from a group photograph is often the wrong square. This is where somebody checks.
+  -->
+  <dialog class="photo-view" id="photo-view" aria-label="Photograph">
+    <img id="photo-view-img" alt="">
+    <p class="photo-view-who" id="photo-view-who"></p>
+    <button type="button" class="btn quiet" id="photo-view-close">Close</button>
+  </dialog>
+
+  <!-- ------------------------------------------------------------ framing a photograph -->
+  <!--
+    Not a crop dialog. The square is always the largest that fits and the drag only decides where
+    along the long edge it sits, which is enough to move a face out of a corner and stops well short
+    of rebuilding an image editor.
+  -->
+  <dialog class="review frame" id="frame" aria-labelledby="frame-title">
+    <div class="review-head" id="frame-head" tabindex="-1">
+      <h2 class="review-title" id="frame-title">Frame the photograph</h2>
+      <p class="review-lead" id="frame-lead">Drag to choose what the circle shows.</p>
+    </div>
+    <div class="review-body frame-body">
+      <div class="frame-stage" id="frame-stage">
+        <img id="frame-img" alt="" draggable="false">
+        <div class="frame-mask" aria-hidden="true"></div>
+      </div>
+    </div>
+    <div class="review-foot">
+      <p class="review-outcome" id="frame-outcome" aria-live="polite"></p>
+      <div class="review-actions">
+        <button type="button" class="btn quiet" id="frame-cancel">Cancel</button>
+        <button type="button" class="btn primary" id="frame-save">Use this photograph</button>
+      </div>
+    </div>
+  </dialog>
+
   <!-- ------------------------------------------------------------ preferences -->
   <!--
     Modelled on the review dialog above, and a <dialog> for the same reason: it is a question about

--- a/desktop/renderer/photo.js
+++ b/desktop/renderer/photo.js
@@ -1,0 +1,119 @@
+/*
+ * Turning a picked image into the photograph a .ftree carries.
+ *
+ * The numbers here are not this app's to choose. `PhotoStore.STORED_EDGE` is 512 and `QUALITY` is
+ * 85, and a desktop-written file has to be indistinguishable from a phone-written one -- not for
+ * tidiness, but because the same tree gets carried back and forth between them, and a photograph
+ * that changes size and weight every time it crosses is a file that grows without anybody adding
+ * anything.
+ *
+ * The geometry is separated from the canvas so it can be tested. Which square comes out of an image
+ * is arithmetic; drawing it is not.
+ */
+
+/** `PhotoStore.STORED_EDGE` -- a face at 512px is sharper than any circle this app draws can show. */
+export const STORED_EDGE = 512;
+
+/** `PhotoStore.QUALITY`. */
+export const QUALITY = 85;
+
+/**
+ * The square to cut, given the image and how far the reader has dragged it.
+ *
+ * The square is always the largest that fits -- the shorter edge -- and the drag only decides
+ * *where along the longer edge* it sits. That is the whole interaction: a portrait can be moved up
+ * to the face and a group photo across to one person, and nothing else is offered, because
+ * anything else is a crop dialog and this is not one.
+ *
+ * `offset` is a fraction from 0 to 1 of the travel available, so it survives the image being
+ * displayed at any size. Clamped rather than trusted, as `saveCrop` clamps: a square that runs off
+ * the edge of the picture would be transparent there, and this format has no alpha.
+ */
+export function squareCrop(width, height, offset = 0.5) {
+  const size = Math.max(0, Math.min(width, height));
+  if (!size) return { x: 0, y: 0, size: 0 };
+
+  const fraction = Number.isFinite(offset) ? Math.min(1, Math.max(0, offset)) : 0.5;
+  const slack = Math.max(width, height) - size;
+  const along = Math.round(slack * fraction);
+
+  return width >= height
+    ? { x: along, y: 0, size }
+    : { x: 0, y: along, size };
+}
+
+/**
+ * Whether the square needs scaling on the way in, and to what.
+ *
+ * `saveCrop` scales down and never up: a 200px photograph stays 200px rather than being blown up to
+ * 512 and stored four times as heavy for no more detail than it started with.
+ */
+export function storedEdge(cropSize) {
+  return cropSize <= STORED_EDGE ? cropSize : STORED_EDGE;
+}
+
+/**
+ * A name for a photograph nobody else in this tree is using.
+ *
+ * `photos/<uuid>.jpg`, matching what the app writes and what the importer expects. The collision
+ * check is not superstition -- import can bring photographs in under names chosen by another
+ * machine, and two people quietly sharing an entry means replacing one person's face replaces the
+ * other's too.
+ */
+export function freeName(taken, uuid = () => crypto.randomUUID()) {
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const name = `photos/${uuid()}.jpg`;
+    if (!taken.has(name)) return name;
+  }
+  // Eight collisions on a v4 uuid is not a thing that happens; refusing beats overwriting a face.
+  return null;
+}
+
+/* ------------------------------------------------------------------ the canvas half */
+
+/** Decodes bytes into something drawable, or null if it is not an image this machine can read. */
+export async function decode(bytes) {
+  const blob = new Blob([bytes]);
+  try {
+    return await createImageBitmap(blob);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Cuts the framed square out and encodes it exactly as the phone would.
+ *
+ * Square about the drag, longest edge 512, JPEG at quality 85. The circle every surface draws is a
+ * matter of display, not of storage: a round image would have to be a PNG with an alpha channel,
+ * several times the size, to save a shape that everything showing it already draws for itself.
+ */
+export async function encode(bitmap, offset = 0.5) {
+  const crop = squareCrop(bitmap.width, bitmap.height, offset);
+  if (!crop.size) return null;
+
+  const edge = storedEdge(crop.size);
+  const canvas = document.createElement('canvas');
+  canvas.width = edge;
+  canvas.height = edge;
+
+  const context = canvas.getContext('2d');
+  // Nothing here has an alpha channel and JPEG cannot carry one, so a transparent source would
+  // otherwise come out black rather than white.
+  context.fillStyle = '#ffffff';
+  context.fillRect(0, 0, edge, edge);
+  context.imageSmoothingQuality = 'high';
+  context.drawImage(bitmap, crop.x, crop.y, crop.size, crop.size, 0, 0, edge, edge);
+
+  const blob = await new Promise((resolve) => {
+    canvas.toBlob(resolve, 'image/jpeg', QUALITY / 100);
+  });
+  if (!blob) return null;
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+/** A data URL for showing stored bytes, since the page cannot reach the file they came from. */
+export function asImageUrl(bytes) {
+  if (!bytes) return null;
+  return URL.createObjectURL(new Blob([bytes], { type: 'image/jpeg' }));
+}

--- a/desktop/renderer/photo.test.js
+++ b/desktop/renderer/photo.test.js
@@ -1,0 +1,87 @@
+/*
+ * The arithmetic behind a stored photograph.
+ *
+ * The canvas work cannot be tested without a browser, but which square comes out of an image can,
+ * and so can the two rules that make a desktop-written file the same as a phone-written one: 512px
+ * on the longest edge, and never scaled up.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { squareCrop, storedEdge, freeName, STORED_EDGE, QUALITY } from './photo.js';
+
+test('the constants are the app’s, not this file’s', () => {
+  // PhotoStore.kt:186 and :191. A tree carried between a phone and a laptop should not change
+  // weight every time it crosses.
+  assert.strictEqual(STORED_EDGE, 512);
+  assert.strictEqual(QUALITY, 85);
+});
+
+test('a square image is taken whole, wherever it is dragged', () => {
+  assert.deepStrictEqual(squareCrop(600, 600, 0), { x: 0, y: 0, size: 600 });
+  assert.deepStrictEqual(squareCrop(600, 600, 1), { x: 0, y: 0, size: 600 });
+});
+
+test('a landscape image is cut to its height and slid across', () => {
+  // The square is always the largest that fits; the drag only says where along the long edge.
+  assert.deepStrictEqual(squareCrop(1000, 400, 0), { x: 0, y: 0, size: 400 });
+  assert.deepStrictEqual(squareCrop(1000, 400, 0.5), { x: 300, y: 0, size: 400 });
+  assert.deepStrictEqual(squareCrop(1000, 400, 1), { x: 600, y: 0, size: 400 });
+});
+
+test('a portrait image is cut to its width and slid up or down', () => {
+  // The case the drag exists for: a face is rarely in the middle of a portrait.
+  assert.deepStrictEqual(squareCrop(400, 1000, 0), { x: 0, y: 0, size: 400 });
+  assert.deepStrictEqual(squareCrop(400, 1000, 1), { x: 0, y: 600, size: 400 });
+});
+
+test('the default is the centre', () => {
+  assert.deepStrictEqual(squareCrop(1000, 400), { x: 300, y: 0, size: 400 });
+});
+
+test('a drag past either end is clamped, not obeyed', () => {
+  // A square running off the edge would be transparent there, and this format has no alpha.
+  assert.deepStrictEqual(squareCrop(1000, 400, -3), { x: 0, y: 0, size: 400 });
+  assert.deepStrictEqual(squareCrop(1000, 400, 99), { x: 600, y: 0, size: 400 });
+  assert.deepStrictEqual(squareCrop(1000, 400, NaN), { x: 300, y: 0, size: 400 });
+});
+
+test('an image with no pixels asks for no square', () => {
+  assert.deepStrictEqual(squareCrop(0, 0), { x: 0, y: 0, size: 0 });
+  assert.deepStrictEqual(squareCrop(500, 0), { x: 0, y: 0, size: 0 });
+});
+
+test('a big photograph is cut down to 512', () => {
+  assert.strictEqual(storedEdge(4000), 512);
+  assert.strictEqual(storedEdge(513), 512);
+});
+
+test('a small photograph is left alone rather than blown up', () => {
+  // Scaling up stores four times the bytes for none of the detail it started with.
+  assert.strictEqual(storedEdge(200), 200);
+  assert.strictEqual(storedEdge(512), 512);
+});
+
+test('a photograph gets a name nobody else in the tree is using', () => {
+  const name = freeName(new Set());
+  assert.match(name, /^photos\/[0-9a-f-]{36}\.jpg$/);
+});
+
+test('a name already taken is not handed out twice', () => {
+  /*
+   * Not superstition. Import brings photographs in under names chosen by another machine, so the
+   * set really can already hold one -- and two people sharing an entry means replacing one
+   * person's face replaces the other's as well.
+   */
+  const ids = ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'];
+  let i = 0;
+  const name = freeName(new Set([`photos/${ids[0]}.jpg`]), () => ids[i++]);
+  assert.strictEqual(name, `photos/${ids[1]}.jpg`);
+});
+
+test('it gives up rather than overwriting somebody’s face', () => {
+  // Eight collisions on a v4 uuid does not happen; if it somehow did, refusing beats replacing.
+  const always = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+  assert.strictEqual(freeName(new Set([`photos/${always}.jpg`]), () => always), null);
+});

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -27,6 +27,42 @@ which multiply a chart's width far faster than they add to what it tells you. Cl
 the reading to that person. Where the record goes further than the reading, it says so and offers
 to go on.
 
+## Photographs
+
+A face in the person panel, and **click it to see the photograph whole** — every other surface shows
+it inside a circle, and a square cut from a group photograph is often the wrong square, so this is
+where somebody checks what the file actually holds.
+
+Add, replace or remove from the same panel. The picker returns **bytes, not a path**: a path is a
+promise about somebody else's filesystem that this app cannot keep, and a tree full of pictures that
+silently stop loading is worse than one with none.
+
+The renderer does the encoding, and the numbers are not this app's to choose:
+
+| | |
+|---|---|
+| square about the drag, longest edge | **512px** — `PhotoStore.STORED_EDGE` |
+| JPEG quality | **85** — `PhotoStore.QUALITY` |
+| smaller than 512 | left alone, never scaled up |
+
+A desktop-written file has to be indistinguishable from a phone-written one, because the same tree is
+carried back and forth and a photograph that changes size and weight every crossing is a file that
+grows without anybody adding anything.
+
+**Framing is not cropping.** The square is always the largest that fits, and dragging only chooses
+where along the long edge it sits — enough to move a face out of a corner, and well short of
+rebuilding an image editor. Arrow keys do it too. The circle drawn over the square is the shape every
+surface will show it in; it is not stored that way, because a round image would need a PNG with an
+alpha channel, several times the size, to save a shape that everything showing it already draws.
+
+Stored as `photos/<uuid>.jpg` under a name nothing else in the tree is using — import brings
+photographs in under names chosen by another machine, and two people sharing an entry means replacing
+one person's face replaces the other's. `photosStillUsed()` prunes on save, so a removed photograph
+stops riding along in every future write.
+
+Honours **Photographs on the chart**: when it is off the chart is passed *no archive at all*, rather
+than the real one and an instruction to ignore it.
+
 ## Settings
 
 `Updates > Preferences…`, on `Ctrl+,`. Family words, photographs on the chart, appearance, and the


### PR DESCRIPTION
Closes #123. Phase 4.

The app **preserved** photographs through a load and a save and **drew** them on the chart, and could not put one there: no picker, no field in the person form, no `<img>` anywhere, and the person panel showed no face even when the archive held one.

Now there is a face in the panel, **click it to see the photograph whole**, and add / replace / remove from the same place. Uncropped when opened, because every other surface squares it into a circle and a square cut from a group photograph is often the wrong square — this is where somebody checks what the file actually holds.

## The numbers are not this app's to choose

| | |
|---|---|
| longest edge | **512px** — `PhotoStore.STORED_EDGE` (`PhotoStore.kt:186`) |
| JPEG quality | **85** — `PhotoStore.QUALITY` (`:191`) |
| smaller than 512 | left alone, **never scaled up** |

A desktop-written file has to be indistinguishable from a phone-written one — not for tidiness, but because the same tree is carried back and forth, and a photograph that changes size and weight every crossing is a file that grows without anybody adding anything.

The picker returns **bytes, not a path**, for the reason `PhotoStore` copies rather than references: a path is a promise about somebody else's filesystem that this app cannot keep.

## Framing is not cropping

The square is always the largest that fits; dragging only chooses **where along the long edge** it sits. Enough to move a face out of a corner, and well short of rebuilding an image editor. Arrow keys do it too, so the keyboard path is not an afterthought.

The geometry is separated from the canvas and tested as a table — which square comes out of an image is arithmetic; drawing it is not. 12 tests, including that a drag past either end is **clamped rather than obeyed**: a square running off the edge would be transparent there, and JPEG has no alpha.

## What the smoke test proves

A native picker cannot be clicked, so bytes go straight to the **real** encoder — and everything after that is the real path: real canvas, real crop, real `state.photos`, real writer.

```
ok   a photograph is stored 512px square, as PhotoStore does  512x512
ok   the framing actually changes what is kept  true
ok   a small photograph is left at its own size, not blown up to 512  200x200
ok   a photograph added here is written into the .ftree and reads back
       photos/a1e8edfe-…jpg — 2367 bytes, 5 photos in the archive
ok   the framing can be moved with the keyboard, not only dragged  0.5 -> 0.45
ok   the removed photograph stops being written into every future save  5 in use before, 4 after
ok   and nobody else's photograph is dropped with it  4 still in use
```

That fourth one is the claim that matters most: everything else checks the app's own state, which would look perfect while the archive went out empty.

## Two mistakes worth recording

- **`editPerson` does not exist.** The method is `updatePerson`, which leaves unnamed fields alone — so setting only `photo` cannot wipe the dates the panel is not currently showing.
- **The pruning check first asserted zero photographs in use after a removal, and failed on a correct app.** `sample-family.ftree` already carries four belonging to other people, and `photosStillUsed` is a question about the whole tree rather than about one edit. The claim is *one fewer*, and that nobody else's is dropped.

## Also

- Honours **Photographs on the chart** from #131: when off, the chart is passed **no archive at all** rather than the real one and an instruction to ignore it. *"The reader turned photographs off"* should be a fact the drawing code cannot forget.
- Object URLs are revoked on every rebuild — a page that makes one per render and never hands it back keeps every face it has ever drawn alive in memory.
- Test hooks reach module scope only when the **main process's own environment** says this is a smoke run. A page cannot set that, so a build somebody is using never carries them.

## Verification

- **The packaged app**, unconfined: **76 smoke assertions** across compact, relate, settings, photos and import.
- Both new surfaces — the panel face and the framing dialog — screenshotted in both themes.
- `npm test` **196 → 208**; engine 40 unchanged.
- **The engine is untouched and `kinship-golden.txt` does not move.** `check_layout.mjs`, `check_writer.mjs` pass. `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)