### PR TITLE
refactor(kinship): one search for a shared ancestor, in one place

### DIFF
--- a/site/playground/ancestors.test.mjs
+++ b/site/playground/ancestors.test.mjs
@@ -1,0 +1,146 @@
+/*
+ * The shared-ancestor search, after being written once instead of twice.
+ *
+ * `relate` and `bloodTerm` each carried their own copy of the same loop -- the same walk up, the
+ * same scoring, the same tie-break, character for character. Two copies of a tie-break rule is one
+ * copy waiting to be changed alone, and the one inside `bloodTerm` is the one that names in-laws,
+ * so a divergence there would be visible only on affinal relationships and nowhere else.
+ *
+ * `kinship-golden.txt` is the real gate for this refactor: 753 lines that must not move. These
+ * tests are the readable half, and they cover the two things the golden cannot -- that the memo
+ * introduced here is per-graph, and that it survives being asked twice.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { buildGraph, relate, restrictedGraph } from './model.js';
+
+/** Two brothers joined only by an explicit sibling edge, each with a child. */
+const unrecordedParent = () => buildGraph({
+  people: [
+    { id: 'a', name: 'A', gender: 'MALE' },
+    { id: 'b', name: 'B', gender: 'MALE' },
+    { id: 'a-son', name: 'A Son', gender: 'MALE' },
+    { id: 'b-son', name: 'B Son', gender: 'MALE' },
+  ],
+  relationships: [
+    { from: 'a', to: 'b', type: 'SIBLING' },
+    { from: 'a', to: 'a-son', type: 'PARENT' },
+    { from: 'b', to: 'b-son', type: 'PARENT' },
+  ],
+});
+
+test('a parent nobody wrote down still makes cousins of two children', () => {
+  /*
+   * What the stand-in is for. Without somebody to measure through, an aunt reachable only through
+   * her brother comes back as merely "related" -- the gap in the record swallowing a word the
+   * family uses every day.
+   */
+  const graph = unrecordedParent();
+  assert.strictEqual(relate(graph, 'a-son', 'b-son').term, 'first cousin');
+  assert.strictEqual(relate(graph, 'a', 'b').term, 'brother');
+});
+
+test('asking twice about the same graph gives the same answer', () => {
+  // The memo is filled by the first call. If it were wrong to reuse, this is where it would show.
+  const graph = unrecordedParent();
+  const once = relate(graph, 'a-son', 'b-son');
+  const twice = relate(graph, 'a-son', 'b-son');
+  assert.strictEqual(once.term, twice.term);
+  assert.strictEqual(once.via, twice.via);
+});
+
+test('one graph’s stand-ins do not answer for another graph', () => {
+  /*
+   * The risk the memo introduces, pinned. It is hung off the graph rather than kept in a module
+   * cache precisely so that it lives exactly as long as the graph does -- `buildGraph` makes a new
+   * one on every edit, and a cache that outlived an edit would answer about a tree that no longer
+   * exists.
+   *
+   * Here the second graph has the *same ids* and no sibling edge at all, so a leaked stand-in would
+   * make cousins of two people the file says nothing about.
+   */
+  const withEdge = unrecordedParent();
+  assert.strictEqual(relate(withEdge, 'a-son', 'b-son').term, 'first cousin');
+
+  const withoutEdge = buildGraph({
+    people: withEdge.doc.people,
+    relationships: withEdge.doc.relationships.filter((r) => r.type !== 'SIBLING'),
+  });
+  assert.strictEqual(relate(withoutEdge, 'a-son', 'b-son').term, null);
+  assert.strictEqual(relate(withoutEdge, 'a', 'b').term, null);
+});
+
+test('a cut-down graph works out its own stand-ins', () => {
+  // `restrictedGraph` goes back through `buildGraph`, so it cannot inherit a stale memo -- but the
+  // relation finder draws its chart from one, so it is worth saying so out loud.
+  const graph = unrecordedParent();
+  relate(graph, 'a-son', 'b-son');
+  const cut = restrictedGraph(graph, ['a', 'b', 'a-son', 'b-son']);
+  assert.strictEqual(relate(cut, 'a-son', 'b-son').term, 'first cousin');
+});
+
+test('the nearest shared ancestor is the one measured through', () => {
+  /*
+   * A family that married within itself shares more than one ancestor. Measured through the far
+   * one, two people who are plainly cousins come back as something nobody says.
+   */
+  const graph = buildGraph({
+    people: [
+      { id: 'old', name: 'Old', gender: 'MALE' },
+      { id: 'gran', name: 'Gran', gender: 'MALE' },
+      { id: 'other', name: 'Other', gender: 'MALE' },
+      { id: 'p1', name: 'P1', gender: 'MALE' },
+      { id: 'p2', name: 'P2', gender: 'MALE' },
+      { id: 'x', name: 'X', gender: 'MALE' },
+      { id: 'y', name: 'Y', gender: 'MALE' },
+    ],
+    relationships: [
+      { from: 'old', to: 'gran', type: 'PARENT' },
+      { from: 'old', to: 'other', type: 'PARENT' },
+      { from: 'gran', to: 'p1', type: 'PARENT' },
+      { from: 'gran', to: 'p2', type: 'PARENT' },
+      { from: 'other', to: 'p2', type: 'PARENT' },
+      { from: 'p1', to: 'x', type: 'PARENT' },
+      { from: 'p2', to: 'y', type: 'PARENT' },
+    ],
+  });
+
+  // Through `gran` they are first cousins; through `old` they would be something further out.
+  assert.strictEqual(relate(graph, 'x', 'y').term, 'first cousin');
+  assert.strictEqual(relate(graph, 'x', 'y').via, 'gran');
+});
+
+test('where two ancestors are equally near, the symmetric one wins', () => {
+  /*
+   * The second half of the tie-break, and the reason it is not just "fewest steps". Two routes of
+   * the same total length can be 1-up-3-down or 2-up-2-down; the first names an uncle's line and
+   * the second names cousins, and only one of those is what the family calls them.
+   */
+  const graph = buildGraph({
+    people: [
+      { id: 'top', name: 'Top', gender: 'MALE' },
+      { id: 'l1', name: 'L1', gender: 'MALE' }, { id: 'l2', name: 'L2', gender: 'MALE' },
+      { id: 'r1', name: 'R1', gender: 'MALE' }, { id: 'r2', name: 'R2', gender: 'MALE' },
+    ],
+    relationships: [
+      { from: 'top', to: 'l1', type: 'PARENT' },
+      { from: 'top', to: 'r1', type: 'PARENT' },
+      { from: 'l1', to: 'l2', type: 'PARENT' },
+      { from: 'r1', to: 'r2', type: 'PARENT' },
+    ],
+  });
+
+  // 2 up, 2 down through `top`: first cousins, said the way a family says it.
+  assert.strictEqual(relate(graph, 'l2', 'r2').term, 'first cousin');
+});
+
+test('two people who share nobody get no term at all', () => {
+  const graph = buildGraph({
+    people: [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }],
+    relationships: [],
+  });
+  assert.strictEqual(relate(graph, 'a', 'b').term, null);
+  assert.strictEqual(relate(graph, 'a', 'b').kind, 'none');
+});

--- a/site/playground/model.js
+++ b/site/playground/model.js
@@ -386,21 +386,85 @@ function standInAncestors(graph) {
   return groupOf;
 }
 
-/** Ancestors of a person, with the number of generations up to each. */
-function ancestorDistances(graph, id, standIns) {
-  const dist = new Map([[id, 0]]);
+/**
+ * The stand-ins for one graph, worked out once.
+ *
+ * `standInAncestors` walks every explicit sibling edge in the file and unions them into groups. It
+ * was being called on every `relate`, and again inside `bloodTerm` for the same graph, which on a
+ * large tree is the same union-find run over and over to produce the same answer.
+ *
+ * Hung off the graph rather than kept in a module-level cache, so it lives exactly as long as the
+ * graph does. `buildGraph` makes a new one on every edit, and a cache that outlived an edit would
+ * answer about a tree that no longer exists.
+ */
+function standInsFor(graph) {
+  if (!graph.__standIns) {
+    Object.defineProperty(graph, '__standIns', {
+      value: standInAncestors(graph), enumerable: false, writable: false,
+    });
+  }
+  return graph.__standIns;
+}
+
+/**
+ * Ancestors of a person: how many generations up each one is, and the way there.
+ *
+ * The route is what this adds. The arithmetic that names an English relationship needs only two
+ * numbers -- steps up and steps down -- and throws the path away, but Hindi asks questions the
+ * numbers cannot answer: which side of the family, and through whom. मामा and चाचा are both
+ * "uncle" at (2, 1); which word is right depends on whether the route ran through a mother or a
+ * father.
+ *
+ * Nothing reads `route` yet. It is here so that the search happens once, in one place, rather than
+ * being written a third time when the Hindi vocabulary lands.
+ */
+function ancestorRoutes(graph, id, standIns) {
+  const routes = new Map([[id, { up: 0, route: [] }]]);
   const queue = [id];
   while (queue.length) {
     const current = queue.shift();
-    const step = dist.get(current) + 1;
+    const here = routes.get(current);
     const above = graph.parents(current).map((p) => p.id);
     const standIn = standIns.get(current);
     if (standIn !== undefined) above.push(standIn);
     for (const parent of above) {
-      if (!dist.has(parent)) { dist.set(parent, step); queue.push(parent); }
+      if (routes.has(parent)) continue;
+      routes.set(parent, { up: here.up + 1, route: [...here.route, parent] });
+      queue.push(parent);
     }
   }
-  return dist;
+  return routes;
+}
+
+/**
+ * The ancestor two people are best measured through, or null if they share none.
+ *
+ * "Best" is the nearest -- fewest steps in total -- and where two are equally near, the most
+ * symmetric pair of distances. That second rule matters in a family that has married within itself:
+ * two people can share a grandfather on one side and a great-great-grandmother on another, and
+ * naming the relationship through the nearer one is what makes them cousins rather than something
+ * nobody says.
+ *
+ * This loop was written out twice, here and in `bloodTerm`, character for character. Two copies of
+ * a tie-break rule is one copy waiting to be changed alone.
+ */
+function nearestSharedAncestor(graph, fromId, toId, standIns) {
+  const mine = ancestorRoutes(graph, fromId, standIns);
+  const theirs = ancestorRoutes(graph, toId, standIns);
+
+  let best = null;
+  for (const [ancestor, here] of mine) {
+    const there = theirs.get(ancestor);
+    if (there === undefined) continue;
+    const u = here.up;
+    const d = there.up;
+    const score = u + d;
+    if (!best || score < best.score
+        || (score === best.score && Math.abs(u - d) < Math.abs(best.u - best.d))) {
+      best = { ancestor, u, d, score, ascent: here.route, descent: there.route };
+    }
+  }
+  return best;
 }
 
 /**
@@ -416,22 +480,9 @@ export function relate(graph, fromId, toId) {
   const to = graph.people.get(toId);
   if (!graph.people.get(fromId) || !to) return { kind: 'none' };
 
-  let term = null;
-  const standIns = standInAncestors(graph);
-  const mine = ancestorDistances(graph, fromId, standIns);
-  const theirs = ancestorDistances(graph, toId, standIns);
-  let best = null;
-  for (const [ancestor, u] of mine) {
-    const d = theirs.get(ancestor);
-    if (d === undefined) continue;
-    // Prefer the nearest shared ancestor, then the most symmetric pair of distances.
-    const score = u + d;
-    if (!best || score < best.score
-        || (score === best.score && Math.abs(u - d) < Math.abs(best.u - best.d))) {
-      best = { ancestor, u, d, score };
-    }
-  }
-  if (best) term = kinshipTerm(best.u, best.d, to);
+  const standIns = standInsFor(graph);
+  const best = nearestSharedAncestor(graph, fromId, toId, standIns);
+  const term = best ? kinshipTerm(best.u, best.d, to) : null;
 
   const path = shortestPath(graph, fromId, toId);
   if (!path) return { kind: 'none', term, path, via: best?.ancestor ?? null };
@@ -450,18 +501,7 @@ export function relate(graph, fromId, toId) {
 
 /** The blood term between two people, ignoring the line the search happened to take. */
 function bloodTerm(graph, fromId, toId, standIns, other) {
-  const mine = ancestorDistances(graph, fromId, standIns);
-  const theirs = ancestorDistances(graph, toId, standIns);
-  let best = null;
-  for (const [ancestor, u] of mine) {
-    const d = theirs.get(ancestor);
-    if (d === undefined) continue;
-    const score = u + d;
-    if (!best || score < best.score
-        || (score === best.score && Math.abs(u - d) < Math.abs(best.u - best.d))) {
-      best = { ancestor, u, d, score };
-    }
-  }
+  const best = nearestSharedAncestor(graph, fromId, toId, standIns);
   return best ? kinshipTerm(best.u, best.d, other) : null;
 }
 


### PR DESCRIPTION
Part of #124 — **stage 5a**, the first of five. `model.js` and the Hindi vocabulary never change in the same PR, and every stage before the last is proved against the golden.

## The duplication

The walk up the family and the scoring that picks which ancestor to measure through were written out **twice** — once in `relate`, again in `bloodTerm` — the same loop, the same tie-break, character for character.

Two copies of a tie-break rule is one copy waiting to be changed alone. And the copy inside `bloodTerm` is the one that names **in-laws**, so a divergence there would show on affinal relationships and nowhere else — the hardest kind to notice.

`nearestSharedAncestor` is now the only place that decides: nearest first, then the most symmetric pair of distances. That second rule earns its keep in a family that married within itself, where two people share a grandfather on one side and a great-great-grandmother on another — naming the relationship through the nearer one is what makes them cousins rather than something nobody says.

## `ancestorDistances` → `ancestorRoutes`

It keeps the way there as well as the distance. **Nothing reads the route yet**, and that is the point of adding it now.

The arithmetic that names an English relationship needs two numbers — steps up, steps down — and throws the path away. Hindi asks what the numbers cannot answer: मामा and चाचा are both "uncle" at `(2, 1)`, and which word is right depends on whether the route ran through a mother or a father. Putting it here means the search happens once, rather than being written a third time when the vocabulary lands.

## The memo, and the risk it introduces

`standInAncestors` was run on every `relate` **and again** inside `bloodTerm` — on a large tree, the same union-find over every explicit sibling edge, repeatedly, for the same answer.

It is now memoised **on the graph**, not in a module cache, so it lives exactly as long as the graph does. `buildGraph` makes a new one on every edit, and a cache that outlived an edit would answer about a tree that no longer exists.

That risk is pinned rather than argued: a test builds a second graph with the **same ids** and no sibling edge, where a leaked stand-in would make first cousins of two people the file says nothing about.

## The gate

**`kinship-golden.txt` is byte-identical.** That is what this stage has to prove, and `git diff --exit-code` on it passes.

The website's own summary is unchanged too:

```
274 of 506 get a sentence (230 a word, 23 "married to", 21 "of the spouse"); 68 show the chain alone; 164 not connected
```

- `node --test "site/playground/*.test.mjs"` — **40 → 47**.
- `cd desktop && npm test` — 203.
- `check_layout.mjs`, `check_writer.mjs` pass. `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)