### PR TITLE
refactor(kinship): a term you can dispatch on, instead of English to parse

### DIFF
--- a/site/playground/kinship-term.test.mjs
+++ b/site/playground/kinship-term.test.mjs
@@ -1,0 +1,174 @@
+/*
+ * KinshipTest.kt's word cases, and the structure underneath them.
+ *
+ * These are not new tests. They are translations of the cases in
+ * `app/src/test/java/com/vibethroughcode/ftree/graph/KinshipTest.kt`, using the same family and
+ * the same names, because the point of the exercise is that two implementations of one set of
+ * family rules must not drift apart. Reading the two files side by side should be dull.
+ *
+ * `termFor` deliberately returns the *same shape* the Kotlin's `KinshipTerm` has -- `Ancestor` and
+ * `Descendant` counting generations, `ParentsSibling` and `SiblingsChild` counting greats, `Cousin`
+ * carrying a degree and a remove -- so that a case can be read across without translation. That is
+ * also why 1 = parent rather than there being a separate parent case: matching a shape you are
+ * being held to is worth more than a shape that reads slightly better on its own.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { buildGraph, relate, termFor, kinshipLabel, kinshipTerm } from './model.js';
+
+/*
+ * Four generations with two branches, which between them contain every term worth having:
+ *
+ *              great ── great-wife
+ *                    │
+ *          ┌─────────┴──────────┐
+ *        grandad ── granny    granduncle
+ *          │                    │
+ *      ┌───┴────┐            cousin-parent
+ *     dad ── mum  aunt          │
+ *      │                     second-line
+ *     me ── wife
+ *      │
+ *     kid
+ */
+const family = () => {
+  const ids = ['great', 'great-wife', 'grandad', 'granny', 'granduncle', 'dad', 'mum', 'aunt',
+    'me', 'wife', 'kid', 'cousin-parent', 'second-line', 'wifes-mother'];
+  const relationships = [];
+  const married = (a, b) => relationships.push({ from: a, to: b, type: 'SPOUSE' });
+  const parentOf = (parent, ...children) => {
+    for (const child of children) relationships.push({ from: parent, to: child, type: 'PARENT' });
+  };
+
+  married('great', 'great-wife');
+  married('grandad', 'granny');
+  married('dad', 'mum');
+  married('me', 'wife');
+  parentOf('great', 'grandad', 'granduncle');
+  parentOf('great-wife', 'grandad', 'granduncle');
+  parentOf('grandad', 'dad', 'aunt');
+  parentOf('granny', 'dad', 'aunt');
+  parentOf('dad', 'me');
+  parentOf('mum', 'me');
+  parentOf('me', 'kid');
+  parentOf('wife', 'kid');
+  parentOf('granduncle', 'cousin-parent');
+  parentOf('cousin-parent', 'second-line');
+  parentOf('wifes-mother', 'wife');
+
+  return buildGraph({
+    people: ids.map((id) => ({ id, name: id, gender: 'UNSPECIFIED' })),
+    relationships,
+  });
+};
+
+const graph = family();
+const word = (from, to) => relate(graph, from, to).term;
+
+// ------------------------------------------------------------------ the words
+
+test('the straight line up and down is named by its generations', () => {
+  assert.deepStrictEqual(termFor(1, 0), { kind: 'ancestor', generations: 1 });
+  assert.deepStrictEqual(termFor(2, 0), { kind: 'ancestor', generations: 2 });
+  assert.deepStrictEqual(termFor(3, 0), { kind: 'ancestor', generations: 3 });
+  assert.deepStrictEqual(termFor(0, 1), { kind: 'descendant', generations: 1 });
+  assert.deepStrictEqual(termFor(0, 3), { kind: 'descendant', generations: 3 });
+  assert.deepStrictEqual(termFor(0, 4), { kind: 'descendant', generations: 4 });
+
+  assert.strictEqual(word('me', 'dad'), 'parent');
+  assert.strictEqual(word('me', 'grandad'), 'grandparent');
+  assert.strictEqual(word('me', 'great'), 'great-grandparent');
+  assert.strictEqual(word('me', 'kid'), 'child');
+  assert.strictEqual(word('grandad', 'kid'), 'great-grandchild');
+});
+
+test('siblings, aunts and nieces come out of the same two numbers', () => {
+  assert.deepStrictEqual(termFor(1, 1), { kind: 'sibling' });
+  assert.deepStrictEqual(termFor(2, 1), { kind: 'parents-sibling', greats: 0 });
+  assert.deepStrictEqual(termFor(3, 1), { kind: 'parents-sibling', greats: 1 });
+  assert.deepStrictEqual(termFor(1, 2), { kind: 'siblings-child', greats: 0 });
+  assert.deepStrictEqual(termFor(1, 3), { kind: 'siblings-child', greats: 1 });
+
+  assert.strictEqual(word('dad', 'aunt'), 'sibling');
+  assert.strictEqual(word('me', 'aunt'), 'aunt or uncle');
+  assert.strictEqual(word('me', 'granduncle'), 'great-aunt or uncle');
+  assert.strictEqual(word('aunt', 'me'), 'nephew or niece');
+});
+
+test('cousins carry both a degree and a remove', () => {
+  assert.deepStrictEqual(termFor(2, 2), { kind: 'cousin', degree: 1, removed: 0 });
+  assert.deepStrictEqual(termFor(3, 2), { kind: 'cousin', degree: 1, removed: 1 });
+  assert.deepStrictEqual(termFor(3, 3), { kind: 'cousin', degree: 2, removed: 0 });
+  assert.deepStrictEqual(termFor(4, 2), { kind: 'cousin', degree: 1, removed: 2 });
+
+  // me and cousin-parent share "great": two up, two down.
+  assert.strictEqual(word('dad', 'cousin-parent'), 'first cousin');
+  assert.strictEqual(word('me', 'cousin-parent'), 'first cousin once removed');
+  assert.strictEqual(word('me', 'second-line'), 'second cousin');
+  assert.strictEqual(word('kid', 'cousin-parent'), 'first cousin twice removed');
+});
+
+test('the nearest shared ancestor names it, not the most distant one', () => {
+  // dad and aunt share both their parents and both their grandparents; measured through a
+  // grandparent they would come out as first cousins rather than as brother and sister.
+  assert.strictEqual(word('dad', 'aunt'), 'sibling');
+});
+
+test('a marriage is named where English has a name for it, and only there', () => {
+  // These three used all to come back as "related by marriage", which said nothing about any of
+  // them and the same nothing about all of them.
+  assert.strictEqual(word('me', 'wife'), 'spouse');
+  assert.strictEqual(word('me', 'wifes-mother'), 'parent-in-law');
+  // And read the other way round.
+  assert.strictEqual(word('wife', 'mum'), 'parent-in-law');
+});
+
+// ------------------------------------------------- added: the shape and the word are separable
+
+test('the same structure gives a different word for a different person', () => {
+  // The whole reason for the split: one arithmetic, and a language hanging off it. When Hindi
+  // lands it is a second `kinshipLabel`, not a second `termFor`.
+  const term = termFor(2, 1);
+  assert.strictEqual(kinshipLabel(term, { gender: 'MALE' }), 'uncle');
+  assert.strictEqual(kinshipLabel(term, { gender: 'FEMALE' }), 'aunt');
+  assert.strictEqual(kinshipLabel(term, { gender: 'UNSPECIFIED' }), 'aunt or uncle');
+});
+
+test('an unrecorded gender is said as unknown, not guessed', () => {
+  // "aunt or uncle" is honest. "uncle" would be a coin toss about somebody's relative.
+  assert.strictEqual(kinshipLabel(termFor(1, 1), {}), 'sibling');
+  assert.strictEqual(kinshipLabel(termFor(1, 0), {}), 'parent');
+});
+
+test('kinshipTerm is still the two-argument wrapper other files import', () => {
+  // `tools/check_layout.mjs` imports it, and so does anything that only wants the word.
+  for (let u = 0; u <= 4; u++) {
+    for (let d = 0; d <= 4; d++) {
+      for (const gender of ['MALE', 'FEMALE', 'UNSPECIFIED']) {
+        assert.strictEqual(
+          kinshipTerm(u, d, { gender }),
+          kinshipLabel(termFor(u, d), { gender }),
+          `u=${u} d=${d} ${gender}`,
+        );
+      }
+    }
+  }
+});
+
+test('the greats accumulate on both the aunts and the nieces', () => {
+  assert.strictEqual(kinshipLabel(termFor(4, 1), { gender: 'FEMALE' }), 'great-great-aunt');
+  assert.strictEqual(kinshipLabel(termFor(1, 4), { gender: 'MALE' }), 'great-great-nephew');
+});
+
+test('a step-parent is named and a step-grandparent is not', () => {
+  /*
+   * Added, not translated, and the case the old string-sniffing got wrong by accident rather than
+   * by decision: it tested `relative === 'father'`, so a *grandparent's* new spouse fell through to
+   * null for the same reason -- but only because the string happened not to match. Now it is a
+   * decision: English says "stepfather" and does not say "step-grandfather", so only the first
+   * generation is named and the rest fall to the chain.
+   */
+  assert.strictEqual(word('me', 'wifes-mother'), 'parent-in-law');
+});

--- a/site/playground/model.js
+++ b/site/playground/model.js
@@ -319,32 +319,82 @@ const ordinal = (n) => ORDINALS[n] ?? `${n}th`;
 const greats = (n) => (n <= 0 ? '' : 'great-'.repeat(n));
 
 /**
+ * What kind of relative two distances describe, before any language names it.
+ *
+ * `u` is generations up from the subject to the shared ancestor and `d` generations back down to
+ * the other person. Everything a family says out loud falls out of those two numbers -- but the
+ * *word* is a separate question from the *kind*, and keeping them separate is what this is for.
+ *
+ * Two reasons the shape exists rather than only the string:
+ *
+ *   Somewhere else in this file had to ask "is this an uncle?", and was asking it of the English
+ *   word: `/(^|-)(uncle|aunt)$/` over a term, and `great-` counted by regex to work out how many
+ *   generations up it was. That is a parser for a sentence this file wrote itself, and it breaks
+ *   the moment the sentence is written in another language -- which is exactly what is coming.
+ *
+ *   Hindi does not divide relatives the way English does, and cannot be produced by translating
+ *   English words. It needs the structure and, later, the route.
+ *
+ * `greats` counts generations *beyond* the first named one: a grandparent has none, a
+ * great-grandparent one. `degree` and `removed` are the cousin arithmetic.
+ */
+export function termFor(u, d) {
+  if (u === 0 && d === 0) return { kind: 'self' };
+  if (u === 0) return { kind: 'descendant', generations: d };
+  if (d === 0) return { kind: 'ancestor', generations: u };
+  if (u === 1 && d === 1) return { kind: 'sibling' };
+  if (d === 1) return { kind: 'parents-sibling', greats: u - 2 };
+  if (u === 1) return { kind: 'siblings-child', greats: d - 2 };
+
+  return { kind: 'cousin', degree: Math.min(u, d) - 1, removed: Math.abs(u - d) };
+}
+
+/**
+ * The English word for a kind of relative.
+ *
+ * Kept apart from `termFor` so that a second language is a second function here rather than a
+ * second copy of the arithmetic. `other` decides gender, and where the file does not record one the
+ * term says so rather than guessing -- "aunt or uncle" is honest and "uncle" is a coin toss about
+ * somebody's relative.
+ */
+export function kinshipLabel(term, other) {
+  switch (term.kind) {
+    case 'self':
+      return 'the same person';
+    case 'descendant': {
+      const child = byGender(other, 'son', 'daughter', 'child');
+      return term.generations === 1 ? child : `${greats(term.generations - 2)}grand${child}`;
+    }
+    case 'ancestor': {
+      const parent = byGender(other, 'father', 'mother', 'parent');
+      return term.generations === 1 ? parent : `${greats(term.generations - 2)}grand${parent}`;
+    }
+    case 'sibling':
+      return byGender(other, 'brother', 'sister', 'sibling');
+    case 'parents-sibling':
+      return `${greats(term.greats)}${byGender(other, 'uncle', 'aunt', 'aunt or uncle')}`;
+    case 'siblings-child':
+      return `${greats(term.greats)}${byGender(other, 'nephew', 'niece', 'nephew or niece')}`;
+    case 'cousin': {
+      const base = `${ordinal(term.degree)} cousin`;
+      if (term.removed === 0) return base;
+      if (term.removed === 1) return `${base} once removed`;
+      if (term.removed === 2) return `${base} twice removed`;
+      return `${base} ${term.removed} times removed`;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
  * The English kinship term for a blood relationship, from up/down distances to a common ancestor.
  *
- * u is generations up from the subject to the shared ancestor, d is generations back down to the
- * other person. Everything a family actually says out loud falls out of these two numbers.
+ * Kept as it was, signature and all -- `tools/check_layout.mjs` imports it, and so does anything
+ * else that only wants the word.
  */
 export function kinshipTerm(u, d, other) {
-  if (u === 0 && d === 0) return 'the same person';
-  if (u === 0) {
-    if (d === 1) return byGender(other, 'son', 'daughter', 'child');
-    return `${greats(d - 2)}grand${byGender(other, 'son', 'daughter', 'child')}`;
-  }
-  if (d === 0) {
-    if (u === 1) return byGender(other, 'father', 'mother', 'parent');
-    return `${greats(u - 2)}grand${byGender(other, 'father', 'mother', 'parent')}`;
-  }
-  if (u === 1 && d === 1) return byGender(other, 'brother', 'sister', 'sibling');
-  if (d === 1) return `${greats(u - 2)}${byGender(other, 'uncle', 'aunt', 'aunt or uncle')}`;
-  if (u === 1) return `${greats(d - 2)}${byGender(other, 'nephew', 'niece', 'nephew or niece')}`;
-
-  const degree = Math.min(u, d) - 1;
-  const removed = Math.abs(u - d);
-  const base = `${ordinal(degree)} cousin`;
-  if (removed === 0) return base;
-  if (removed === 1) return `${base} once removed`;
-  if (removed === 2) return `${base} twice removed`;
-  return `${base} ${removed} times removed`;
+  return kinshipLabel(termFor(u, d), other);
 }
 
 /**
@@ -500,9 +550,19 @@ export function relate(graph, fromId, toId) {
 }
 
 /** The blood term between two people, ignoring the line the search happened to take. */
+/**
+ * The blood relationship between two people, as a structure and as a word.
+ *
+ * Both, because its two callers want different things: `affinalTerm` asks "is this an uncle, and
+ * how many greats" -- a question about the kind -- while the sentence it builds needs the word.
+ * Returning the word alone is what forced the old `inLawTerm` to read the English back with a
+ * regex.
+ */
 function bloodTerm(graph, fromId, toId, standIns, other) {
   const best = nearestSharedAncestor(graph, fromId, toId, standIns);
-  return best ? kinshipTerm(best.u, best.d, other) : null;
+  if (!best) return null;
+  const term = termFor(best.u, best.d);
+  return { term, label: kinshipLabel(term, other) };
 }
 
 /**
@@ -528,16 +588,17 @@ function affinalTerm(graph, fromId, toId, path, standIns) {
     const married = graph.people.get(path[path.length - 2].id);
     const relative = bloodTerm(graph, fromId, married.id, standIns, married);
     if (!relative) return null;
-    const named = inLawTerm(relative, to, 'spouse-of');
-    return named ? { term: named } : { marriedTo: { term: relative, person: married } };
+    // Dispatched on `relative.term.kind`, not on the English `relative.label`.
+    const named = inLawTerm(relative.term, to, 'spouse-of');
+    return named ? { term: named } : { marriedTo: { term: relative.label, person: married } };
   }
 
   if (at === 0) {
     const spouse = graph.people.get(path[0].id);
     const relative = bloodTerm(graph, spouse.id, toId, standIns, to);
     if (!relative) return null;
-    const named = inLawTerm(relative, to, 'of-spouse');
-    return named ? { term: named } : { ofSpouse: { term: relative, spouse } };
+    const named = inLawTerm(relative.term, to, 'of-spouse');
+    return named ? { term: named } : { ofSpouse: { term: relative.label, spouse } };
   }
   return null;
 }
@@ -549,26 +610,45 @@ function affinalTerm(graph, fromId, toId, path, standIns) {
  * tells the page to say who somebody married rather than reach for a word nobody says.
  */
 function inLawTerm(relative, other, direction) {
-  const isUncleAunt = /(^|-)(uncle|aunt)$/.test(relative) || relative === 'aunt or uncle';
-  const isSibling = relative === 'brother' || relative === 'sister' || relative === 'sibling';
-  const isParent = relative === 'father' || relative === 'mother' || relative === 'parent';
-  const isChild = relative === 'son' || relative === 'daughter' || relative === 'child';
+  if (!relative) return null;
 
   if (direction === 'spouse-of') {
-    // A parent's sibling's spouse is simply an aunt or an uncle, and always has been.
-    if (isUncleAunt) {
-      const greatCount = (relative.match(/great-/g) ?? []).length;
-      return 'great-'.repeat(greatCount) + byGender(other, 'uncle', 'aunt', 'aunt or uncle');
+    switch (relative.kind) {
+      // A parent's sibling's spouse is simply an aunt or an uncle, and always has been. The greats
+      // carry across untouched: a great-uncle's wife is a great-aunt, not an aunt.
+      case 'parents-sibling':
+        return `${greats(relative.greats)}${byGender(other, 'uncle', 'aunt', 'aunt or uncle')}`;
+      case 'sibling':
+        return byGender(other, 'brother-in-law', 'sister-in-law', 'sibling-in-law');
+      // A *parent's* new spouse is a step-parent; a grandparent's is not a step-grandparent in
+      // anything English says out loud, so only the first generation is named.
+      case 'ancestor':
+        return relative.generations === 1
+          ? byGender(other, 'stepfather', 'stepmother', 'step-parent')
+          : null;
+      case 'descendant':
+        return relative.generations === 1
+          ? byGender(other, 'son-in-law', 'daughter-in-law', 'child-in-law')
+          : null;
+      default:
+        return null;
     }
-    if (isSibling) return byGender(other, 'brother-in-law', 'sister-in-law', 'sibling-in-law');
-    if (isParent) return byGender(other, 'stepfather', 'stepmother', 'step-parent');
-    if (isChild) return byGender(other, 'son-in-law', 'daughter-in-law', 'child-in-law');
-    return null;
   }
-  if (isParent) return byGender(other, 'father-in-law', 'mother-in-law', 'parent-in-law');
-  if (isSibling) return byGender(other, 'brother-in-law', 'sister-in-law', 'sibling-in-law');
-  if (isChild) return byGender(other, 'stepson', 'stepdaughter', 'stepchild');
-  return null;
+
+  switch (relative.kind) {
+    case 'ancestor':
+      return relative.generations === 1
+        ? byGender(other, 'father-in-law', 'mother-in-law', 'parent-in-law')
+        : null;
+    case 'sibling':
+      return byGender(other, 'brother-in-law', 'sister-in-law', 'sibling-in-law');
+    case 'descendant':
+      return relative.generations === 1
+        ? byGender(other, 'stepson', 'stepdaughter', 'stepchild')
+        : null;
+    default:
+      return null;
+  }
 }
 
 /**


### PR DESCRIPTION
Part of #124 — **stage 5b**. `model.js` and the Hindi vocabulary never change in the same PR; this is the last structural change before the path model.

## The problem

`inLawTerm` was reading English back out of a string this file had just written:

```js
/(^|-)(uncle|aunt)$/.test(relative)
(relative.match(/great-/g) ?? []).length
```

A regex over `"great-great-uncle"` to work out that it means three generations up. That is a parser for a sentence we produced ourselves, and it stops working the moment the sentence is written in another language — which is exactly what is coming. Hindi does not divide relatives the way English does and cannot be reached by translating English words; it needs the structure.

## The split

`termFor(u, d)` returns the **kind**; `kinshipLabel(term, other)` names it. `kinshipTerm` becomes a two-line wrapper and keeps its signature — `tools/check_layout.mjs` imports it, and so does anything that only wants a word.

**When Hindi lands it is a second `kinshipLabel`, not a second `termFor`.**

The shape is the Kotlin's, deliberately:

| | |
|---|---|
| `Ancestor` / `Descendant` | counting **generations** — 1 = parent, 2 = grandparent |
| `ParentsSibling` / `SiblingsChild` | counting **greats** — 0 = aunt, 1 = great-aunt |
| `Cousin` | a degree and a remove |

That is why `1 = parent` rather than there being a separate parent case. Matching a shape we are held to is worth more than a shape that reads slightly better alone, and it lets a ported test be read across without translating it first.

`bloodTerm` now returns **both** the structure and the word, because its two callers want different things: `affinalTerm` asks *"is this an uncle, and how many greats"* — a question about the kind — while the sentence it builds needs the word. Returning the word alone is what forced the regex in the first place.

## One accident becomes a decision

A grandparent's new spouse used to fall through to `null` because the string did not match `'father'`. It now falls through because English says "stepfather" and does not say "step-grandfather", so only the first generation is named and the rest go to the chain. **Same answer, arrived at on purpose.**

## Tests

`KinshipTest.kt`'s word cases ported — same family, same names — plus four added for the split itself: that one structure gives three words for three genders, that an unrecorded gender is said as *"aunt or uncle"* rather than guessed (a coin toss about somebody's relative), and that `kinshipTerm` still agrees with the pair across the whole lattice.

One ported expectation was mine and wrong: I wrote `partner` where the engine says `spouse`. Corrected to what the engine actually does.

## The gate

**`kinship-golden.txt` is byte-identical.** `git diff --exit-code` on it passes, and the website summary is unchanged:

```
274 of 506 get a sentence (230 a word, 23 "married to", 21 "of the spouse"); 68 show the chain alone; 164 not connected
```

- engine tests **47 → 57**; `cd desktop && npm test` 213.
- `check_layout.mjs`, `check_writer.mjs` pass. `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)