### PR TITLE
feat(kinship): the Hindi vocabulary, 65 terms with the tables that hold it

### DIFF
--- a/site/playground/kinship-hi.js
+++ b/site/playground/kinship-hi.js
@@ -1,0 +1,103 @@
+/*
+ * The Hindi family vocabulary: how each term is spelled, and what it means in English.
+ *
+ * Generated from `app/src/main/res/values/kinship_hi.xml`, which is where a Hindi speaker reviews
+ * the whole word list as a flat list without reading any code. `kinship-hi.test.mjs` reads that XML
+ * and asserts this table matches it exactly, so the two cannot drift -- and the parity test is the
+ * reason this file is a table rather than something clever.
+ *
+ * The word and its gloss live in one entry on purpose. They were two resources on the phone,
+ * `kin_hi_bua` and `kin_hi_bua_gloss`, and two lists of 65 things are two lists that can lose their
+ * alignment. Here a term is one object or it is nothing.
+ *
+ * The glosses are more precise than English's own kinship words, deliberately. English says "uncle"
+ * five different ways; the gloss says which one, so a younger relative who does not know फूफा can
+ * still read the answer, and nothing is lost by reading it in English.
+ *
+ * `needsBirthYears` marks the three descriptive terms the app falls back to when the record cannot
+ * settle a birth order. They are correct as they stand -- "पिता के भाई" is what he is -- and the
+ * screen uses the flag to offer the reader a way to sharpen them.
+ */
+
+export const HINDI_WORDS = Object.freeze({
+  SELF: { word: 'स्वयं', gloss: "themselves" },
+  PITA: { word: 'पिता', gloss: "father" },
+  MATA: { word: 'माता', gloss: "mother" },
+  DADA: { word: 'दादा', gloss: "father's father" },
+  DADI: { word: 'दादी', gloss: "father's mother" },
+  NANA: { word: 'नाना', gloss: "mother's father" },
+  NANI: { word: 'नानी', gloss: "mother's mother" },
+  PARDADA: { word: 'परदादा', gloss: "father's grandfather" },
+  PARDADI: { word: 'परदादी', gloss: "father's grandmother" },
+  PARNANA: { word: 'परनाना', gloss: "mother's grandfather" },
+  PARNANI: { word: 'परनानी', gloss: "mother's grandmother" },
+  BETA: { word: 'बेटा', gloss: "son" },
+  BETI: { word: 'बेटी', gloss: "daughter" },
+  POTA: { word: 'पोता', gloss: "son's son" },
+  POTI: { word: 'पोती', gloss: "son's daughter" },
+  NATI: { word: 'नाती', gloss: "daughter's son" },
+  NATIN: { word: 'नातिन', gloss: "daughter's daughter" },
+  PARPOTA: { word: 'परपोता', gloss: "son's grandson" },
+  PARPOTI: { word: 'परपोती', gloss: "son's granddaughter" },
+  PARNATI: { word: 'परनाती', gloss: "daughter's grandson" },
+  PARNATIN: { word: 'परनातिन', gloss: "daughter's granddaughter" },
+  BHAI: { word: 'भाई', gloss: "brother" },
+  BEHEN: { word: 'बहन', gloss: "sister" },
+  TAU: { word: 'ताऊ', gloss: "father's elder brother" },
+  CHACHA: { word: 'चाचा', gloss: "father's younger brother" },
+  FATHERS_BROTHER: { word: 'पिता के भाई', gloss: "father's brother", needsBirthYears: true },
+  TAI: { word: 'ताई', gloss: "father's elder brother's wife" },
+  CHACHI: { word: 'चाची', gloss: "father's younger brother's wife" },
+  FATHERS_BROTHERS_WIFE: { word: 'पिता के भाई की पत्नी', gloss: "father's brother's wife", needsBirthYears: true },
+  BUA: { word: 'बुआ', gloss: "father's sister" },
+  PHUPHA: { word: 'फूफा', gloss: "father's sister's husband" },
+  MAMA: { word: 'मामा', gloss: "mother's brother" },
+  MAMI: { word: 'मामी', gloss: "mother's brother's wife" },
+  MAUSI: { word: 'मौसी', gloss: "mother's sister" },
+  MAUSA: { word: 'मौसा', gloss: "mother's sister's husband" },
+  BHATIJA: { word: 'भतीजा', gloss: "brother's son" },
+  BHATIJI: { word: 'भतीजी', gloss: "brother's daughter" },
+  BHANJA: { word: 'भांजा', gloss: "sister's son" },
+  BHANJI: { word: 'भांजी', gloss: "sister's daughter" },
+  CHACHERA_BHAI: { word: 'चचेरा भाई', gloss: "father's brother's son" },
+  CHACHERI_BEHEN: { word: 'चचेरी बहन', gloss: "father's brother's daughter" },
+  PHUPHERA_BHAI: { word: 'फुफेरा भाई', gloss: "father's sister's son" },
+  PHUPHERI_BEHEN: { word: 'फुफेरी बहन', gloss: "father's sister's daughter" },
+  MAMERA_BHAI: { word: 'ममेरा भाई', gloss: "mother's brother's son" },
+  MAMERI_BEHEN: { word: 'ममेरी बहन', gloss: "mother's brother's daughter" },
+  MAUSERA_BHAI: { word: 'मौसेरा भाई', gloss: "mother's sister's son" },
+  MAUSERI_BEHEN: { word: 'मौसेरी बहन', gloss: "mother's sister's daughter" },
+  PATI: { word: 'पति', gloss: "husband" },
+  PATNI: { word: 'पत्नी', gloss: "wife" },
+  SASUR: { word: 'ससुर', gloss: "father-in-law" },
+  SAAS: { word: 'सास', gloss: "mother-in-law" },
+  JIJA: { word: 'जीजा', gloss: "sister's husband" },
+  BHABHI: { word: 'भाभी', gloss: "brother's wife" },
+  BAHU: { word: 'बहू', gloss: "son's wife" },
+  DAMAD: { word: 'दामाद', gloss: "daughter's husband" },
+  SALA: { word: 'साला', gloss: "wife's brother" },
+  SALI: { word: 'साली', gloss: "wife's sister" },
+  JETH: { word: 'जेठ', gloss: "husband's elder brother" },
+  DEVAR: { word: 'देवर', gloss: "husband's younger brother" },
+  HUSBANDS_BROTHER: { word: 'पति के भाई', gloss: "husband's brother", needsBirthYears: true },
+  NANAD: { word: 'ननद', gloss: "husband's sister" },
+  SAUTELA_PITA: { word: 'सौतेला पिता', gloss: "stepfather" },
+  SAUTELI_MATA: { word: 'सौतेली माता', gloss: "stepmother" },
+  SAUTELA_BETA: { word: 'सौतेला बेटा', gloss: "stepson" },
+  SAUTELI_BETI: { word: 'सौतेली बेटी', gloss: "stepdaughter" },
+});
+
+/** Every term this vocabulary spells. */
+export const HINDI_TERMS = Object.freeze(Object.keys(HINDI_WORDS));
+
+/**
+ * The word and gloss for a term, or null where Hindi has no word for the relationship.
+ *
+ * Null is a real answer here rather than a gap: Hindi genuinely has no single word for a
+ * second cousin, or for a relative reached through two marriages, and the honest thing is to fall
+ * back to the English term the rest of the app already gives -- which is what a Hindi speaker would
+ * reach for in the same conversation.
+ */
+export function hindiWord(term) {
+  return (term && HINDI_WORDS[term]) || null;
+}

--- a/site/playground/kinship-hi.test.mjs
+++ b/site/playground/kinship-hi.test.mjs
@@ -1,0 +1,116 @@
+/*
+ * The vocabulary, held to the file a Hindi speaker actually reviews.
+ *
+ * `app/src/main/res/values/kinship_hi.xml` is the phone's copy and the one a Hindi speaker reads as
+ * a flat list without wading through code. This test reads that XML and asserts the JavaScript
+ * table matches it exactly -- every term, every spelling, every gloss.
+ *
+ * It is the reason `kinship-hi.js` is a generated table rather than something clever. A second
+ * implementation of somebody's family vocabulary is a thing that can drift, and a misspelled kinship
+ * word is not a cosmetic bug: it is the app telling a family it knows how they speak and being
+ * wrong about it.
+ *
+ * Nothing under `app/` is written by this test. It only reads.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { HINDI_WORDS, HINDI_TERMS, hindiWord } from './kinship-hi.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const XML = path.join(here, '..', '..', 'app', 'src', 'main', 'res', 'values', 'kinship_hi.xml');
+
+/** The phone's vocabulary, as `{ TERM: { word, gloss } }`. */
+async function fromResources() {
+  const xml = await readFile(XML, 'utf8');
+  const entries = [...xml.matchAll(/<string name="kin_hi_([a-z_]+)"[^>]*>([\s\S]*?)<\/string>/g)];
+
+  const terms = {};
+  for (const [, name, raw] of entries) {
+    // Android escapes an apostrophe in a resource string; the word itself does not carry the slash.
+    const value = raw.replace(/\\'/g, "'").trim();
+    const gloss = name.endsWith('_gloss');
+    const key = (gloss ? name.slice(0, -6) : name).toUpperCase();
+    terms[key] ??= {};
+    terms[key][gloss ? 'gloss' : 'word'] = value;
+  }
+  return terms;
+}
+
+test('every term the phone spells is spelled here, identically', async () => {
+  const theirs = await fromResources();
+
+  for (const [term, { word, gloss }] of Object.entries(theirs)) {
+    const ours = hindiWord(term);
+    assert.ok(ours, `${term} is in the resources and not in the table`);
+    assert.strictEqual(ours.word, word, `${term} is spelled differently`);
+    assert.strictEqual(ours.gloss, gloss, `${term} is glossed differently`);
+  }
+});
+
+test('and this table spells nothing the phone does not', async () => {
+  // The other direction, which the loop above cannot see. A term invented here would be a word this
+  // app says and the phone does not, for the same family.
+  const theirs = await fromResources();
+  const extra = HINDI_TERMS.filter((term) => !(term in theirs));
+  assert.deepStrictEqual(extra, []);
+});
+
+test('there are 65 terms, and both lists agree on that', async () => {
+  const theirs = await fromResources();
+  assert.strictEqual(HINDI_TERMS.length, 65);
+  assert.strictEqual(Object.keys(theirs).length, 65);
+});
+
+test('a word and its gloss cannot lose each other', () => {
+  /*
+   * They were two resources on the phone -- `kin_hi_bua` and `kin_hi_bua_gloss` -- and two lists of
+   * 65 things are two lists that can fall out of alignment. Here a term is one object or it is
+   * nothing.
+   */
+  for (const term of HINDI_TERMS) {
+    const entry = HINDI_WORDS[term];
+    assert.ok(entry.word?.length, `${term} has no word`);
+    assert.ok(entry.gloss?.length, `${term} has no gloss`);
+  }
+});
+
+test('the three descriptive terms are the ones that ask for birth years', () => {
+  /*
+   * ताऊ is the elder brother and चाचा the younger, and with no birth years there is no way to tell.
+   * These three are the fallbacks, and they are correct as they stand -- "पिता के भाई" is what he is
+   * -- so the flag is for offering the reader a way to sharpen them, not for apologising.
+   */
+  const flagged = HINDI_TERMS.filter((t) => HINDI_WORDS[t].needsBirthYears);
+  assert.deepStrictEqual(flagged.sort(), [
+    'FATHERS_BROTHER', 'FATHERS_BROTHERS_WIFE', 'HUSBANDS_BROTHER',
+  ]);
+});
+
+test('the glosses say which uncle, where English will not', () => {
+  // English says "uncle" five ways. The gloss says which one, so a younger relative who does not
+  // know फूफा can still read the answer.
+  assert.strictEqual(hindiWord('TAU').gloss, "father's elder brother");
+  assert.strictEqual(hindiWord('CHACHA').gloss, "father's younger brother");
+  assert.strictEqual(hindiWord('MAMA').gloss, "mother's brother");
+  assert.strictEqual(hindiWord('PHUPHA').gloss, "father's sister's husband");
+  assert.strictEqual(hindiWord('MAUSA').gloss, "mother's sister's husband");
+});
+
+test('a term nobody has is null rather than a guess', () => {
+  assert.strictEqual(hindiWord('SECOND_COUSIN_TWICE_REMOVED'), null);
+  assert.strictEqual(hindiWord(null), null);
+  assert.strictEqual(hindiWord(undefined), null);
+});
+
+test('the table cannot be edited by accident', () => {
+  // Frozen. Asserted as "the value did not move" rather than "it threw", because these modules are
+  // strict-mode ESM in some runtimes and sloppy in others and the claim is about the value.
+  const before = HINDI_WORDS.PITA.word;
+  try { HINDI_WORDS.PITA = { word: 'x', gloss: 'x' }; } catch { /* strict mode throws */ }
+  assert.strictEqual(HINDI_WORDS.PITA.word, before);
+});

--- a/site/playground/kinship-hindi-everypair.test.mjs
+++ b/site/playground/kinship-hindi-everypair.test.mjs
@@ -1,0 +1,346 @@
+/*
+ * Every member related to every other, in Hindi.
+ *
+ * A vocabulary this size cannot be checked by reading it. The hand-written cases in
+ * `kinship-hindi.test.mjs` prove the rules on the shapes somebody thought of; this proves them on
+ * every shape a family contains, by asking a question the code cannot answer twice the same way by
+ * accident:
+ *
+ *   **if B is A's मामा, then A must be B's भांजा or भांजी.**
+ *
+ * The two answers are computed independently, from opposite ends of the graph, through different
+ * branches of the rules. A mistake in "which side of the family" or "who links them" makes them
+ * disagree, and there is no way to satisfy the whole table by luck. Cousins are the sharpest test of
+ * all: a फुफेरा भाई must see you as his ममेरा भाई, never as another फुफेरा -- the relationship
+ * inverts as it crosses.
+ *
+ * A translation of `app/src/test/java/com/vibethroughcode/ftree/graph/HindiEveryPairTest.kt`,
+ * including its two honest excuses and its honest denominator.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { buildGraph, relate } from './model.js';
+import { hindiTerm } from './kinship-hindi.js';
+import { HINDI_WORDS } from './kinship-hi.js';
+
+/* ------------------------------------------------------------------ what must come back */
+
+/** If B is A's key, A must be one of the values from B. */
+const RECIPROCAL = (() => {
+  const map = new Map();
+  const pair = (a, b) => {
+    for (const term of a) map.set(term, new Set(b));
+    for (const term of b) map.set(term, new Set(a));
+  };
+
+  const parents = ['PITA', 'MATA'];
+  const children = ['BETA', 'BETI'];
+  const siblings = ['BHAI', 'BEHEN'];
+  const fathersSiblings = ['TAU', 'CHACHA', 'FATHERS_BROTHER', 'BUA'];
+  const mothersSiblings = ['MAMA', 'MAUSI'];
+  const brothersChildren = ['BHATIJA', 'BHATIJI'];
+  const sistersChildren = ['BHANJA', 'BHANJI'];
+
+  pair(parents, children);
+  pair(siblings, siblings);
+  pair(['DADA', 'DADI'], ['POTA', 'POTI']);
+  pair(['NANA', 'NANI'], ['NATI', 'NATIN']);
+  // A father's sibling sees you as their brother's child; a mother's, as their sister's.
+  pair(fathersSiblings, brothersChildren);
+  pair(mothersSiblings, sistersChildren);
+  /*
+   * Cousins invert as they cross: your father's sister's son is, to him, your mother's brother's
+   * son. The two that come through a same-sex sibling stay themselves.
+   */
+  pair(['PHUPHERA_BHAI', 'PHUPHERI_BEHEN'], ['MAMERA_BHAI', 'MAMERI_BEHEN']);
+  pair(['CHACHERA_BHAI', 'CHACHERI_BEHEN'], ['CHACHERA_BHAI', 'CHACHERI_BEHEN']);
+  pair(['MAUSERA_BHAI', 'MAUSERI_BEHEN'], ['MAUSERA_BHAI', 'MAUSERI_BEHEN']);
+  // Through marriage.
+  pair(['PATI'], ['PATNI']);
+  pair(['SASUR', 'SAAS'], ['DAMAD', 'BAHU']);
+  pair(['JIJA'], ['SALA', 'SALI']);
+  pair(['BHABHI'], ['JETH', 'DEVAR', 'HUSBANDS_BROTHER', 'NANAD']);
+
+  return map;
+})();
+
+/**
+ * Whether Hindi has a word for this *shape* of relationship at all.
+ *
+ * English names every blood relation however far out -- "second cousin twice removed" -- by building
+ * a phrase out of two numbers. Hindi does not work that way: it has a precise word for each of the
+ * relationships a family talks about and nothing beyond them, which is why a raw percentage over
+ * every pair in a six-generation tree says more about the tree's depth than about the vocabulary.
+ * This is the honest denominator.
+ */
+function hindiCovers(term) {
+  if (!term) return false;
+  switch (term.kind) {
+    case 'self': case 'sibling': case 'spouse': return true;
+    case 'ancestor': case 'descendant': return term.generations <= 3;
+    case 'parents-sibling': case 'siblings-child': return term.greats === 0;
+    case 'cousin': return term.degree === 1 && term.removed === 0;
+    case 'spouse-of': {
+      const r = term.relative;
+      if (r?.kind === 'sibling') return true;
+      if (r?.kind === 'parents-sibling') return r.greats === 0;
+      if (r?.kind === 'ancestor' || r?.kind === 'descendant') return r.generations === 1;
+      return false;
+    }
+    case 'of-spouse': {
+      const r = term.relative;
+      if (r?.kind === 'sibling') return true;
+      if (r?.kind === 'ancestor' || r?.kind === 'descendant') return r.generations === 1;
+      return false;
+    }
+    default: return false;
+  }
+}
+
+const hindiOf = (graph, from, to) => {
+  const found = relate(graph, from, to);
+  if (found.kind !== 'related' || !found.kinship) return null;
+  return hindiTerm(
+    found.kinship,
+    graph.people.get(from)?.gender ?? 'UNSPECIFIED',
+    graph.people.get(to)?.gender ?? 'UNSPECIFIED',
+  );
+};
+
+/* ------------------------------------------------------------------ the two honest excuses */
+
+/**
+ * Whether an unrecorded gender explains why no word came back.
+ *
+ * Hindi has no gender-neutral kinship word -- there is no neuter for भाई or बहन -- so a person whose
+ * gender nobody wrote down genuinely has no term, and saying nothing is the right answer. That is a
+ * fact about the record rather than a fault in the rules, and separating the two is what lets this
+ * test still fail on the second.
+ */
+function genderIsMissing(graph, from, to) {
+  const found = relate(graph, from, to);
+  if (found.kind !== 'related' || !found.path) return false;
+  const involved = [from, ...found.path.map((step) => step.id)];
+  return involved.some((id) => {
+    const gender = graph.people.get(id)?.gender;
+    return gender !== 'MALE' && gender !== 'FEMALE';
+  });
+}
+
+/**
+ * Marriages the record states inconsistently -- both partners written down with the same gender.
+ *
+ * Almost always one gender entered wrongly rather than anything about the marriage. Every Hindi
+ * in-law word names both partners (जीजा married a sister, भाभी married a brother), so a line running
+ * through such a marriage genuinely has no word and the rules are right to decline. Separated out so
+ * a mistake in somebody's tree cannot be mistaken for a mistake in the vocabulary -- and named,
+ * because they are worth fixing.
+ */
+function contradictoryMarriages(graph) {
+  const bad = new Set();
+  for (const [id, spouses] of graph.spousesOf) {
+    for (const spouse of spouses.values()) {
+      const one = graph.people.get(id)?.gender;
+      const two = graph.people.get(spouse.id)?.gender;
+      if (one && one === two && one !== 'UNSPECIFIED' && one !== 'OTHER') {
+        bad.add([id, spouse.id].sort().join(' '));
+      }
+    }
+  }
+  return bad;
+}
+
+/** Whether the line joining two people passes through one of those marriages. */
+function crossesContradiction(graph, from, to, bad) {
+  if (!bad.size) return false;
+  const found = relate(graph, from, to);
+  if (found.kind !== 'related' || !found.path) return false;
+  let previous = from;
+  return found.path.some((step) => {
+    const crosses = step.via === 'spouse' && bad.has([previous, step.id].sort().join(' '));
+    previous = step.id;
+    return crosses;
+  });
+}
+
+/* ------------------------------------------------------------------------------- the sweep */
+
+function sweep(graph) {
+  const ids = [...graph.people.keys()];
+  const report = {
+    pairs: 0, related: 0, coverable: 0, named: 0, descriptive: 0,
+    excusedByGender: 0, excusedByContradiction: 0,
+    breaches: [], counts: new Map(),
+  };
+  const bad = contradictoryMarriages(graph);
+  const name = (id) => graph.people.get(id)?.name ?? id;
+
+  for (const a of ids) {
+    for (const b of ids) {
+      if (a === b) continue;
+      report.pairs++;
+
+      const found = relate(graph, a, b);
+      if (found.kind === 'related' && found.kinship?.term) {
+        report.related++;
+        if (hindiCovers(found.kinship.term)) report.coverable++;
+      }
+
+      const forward = hindiOf(graph, a, b);
+      if (!forward) continue;
+      report.named++;
+      if (HINDI_WORDS[forward]?.needsBirthYears) report.descriptive++;
+      report.counts.set(forward, (report.counts.get(forward) ?? 0) + 1);
+
+      const expected = RECIPROCAL.get(forward);
+      if (!expected) continue;
+
+      const back = hindiOf(graph, b, a);
+      if (back === null && genderIsMissing(graph, b, a)) {
+        report.excusedByGender++;
+      } else if (crossesContradiction(graph, a, b, bad) || crossesContradiction(graph, b, a, bad)) {
+        report.excusedByContradiction++;
+      } else if (back === null) {
+        report.breaches.push(
+          `${name(b)} is ${name(a)}'s ${forward}, and nothing comes back the other way `
+          + '- yet every gender on that line is recorded');
+      } else if (!expected.has(back)) {
+        report.breaches.push(
+          `${name(b)} is ${name(a)}'s ${forward}, so ${name(a)} should be one of `
+          + `[${[...expected].join(', ')}] to ${name(b)} - got ${back}`);
+      }
+    }
+  }
+  return report;
+}
+
+/**
+ * The built-in family: four generations, both sides recorded, every kind of aunt and uncle with
+ * children of their own, and marriages at both ends.
+ */
+function family() {
+  const people = [];
+  const relationships = [];
+  const add = (id, gender, born) => people.push({ id, name: id, gender, birthDate: born });
+  const kids = (a, b, ...children) => {
+    for (const child of children) {
+      relationships.push({ from: a, to: child, type: 'PARENT' });
+      relationships.push({ from: b, to: child, type: 'PARENT' });
+    }
+  };
+
+  add('dada', 'MALE', '1930'); add('dadi', 'FEMALE', '1934');
+  add('nana', 'MALE', '1932'); add('nani', 'FEMALE', '1936');
+  add('tau', 'MALE', '1952'); add('tai', 'FEMALE', '1955');
+  add('dad', 'MALE', '1958'); add('mum', 'FEMALE', '1960');
+  add('chacha', 'MALE', '1963'); add('chachi', 'FEMALE', '1966');
+  add('bua', 'FEMALE', '1955'); add('phupha', 'MALE', '1952');
+  add('mama', 'MALE', '1956'); add('mami', 'FEMALE', '1959');
+  add('mausi', 'FEMALE', '1962'); add('mausa', 'MALE', '1960');
+  add('me', 'MALE', '1985'); add('wife', 'FEMALE', '1987');
+  add('brother', 'MALE', '1988'); add('bhabhi', 'FEMALE', '1989');
+  add('sister', 'FEMALE', '1990'); add('jija', 'MALE', '1986');
+  add('son', 'MALE', '2012'); add('daughter', 'FEMALE', '2015');
+  add('sasur', 'MALE', '1958'); add('saas', 'FEMALE', '1961');
+  add('sala', 'MALE', '1990'); add('sali', 'FEMALE', '1992');
+  for (const [id, gender] of [
+    ['tau-son', 'MALE'], ['tau-daughter', 'FEMALE'],
+    ['chacha-son', 'MALE'], ['chacha-daughter', 'FEMALE'],
+    ['bua-son', 'MALE'], ['bua-daughter', 'FEMALE'],
+    ['mama-son', 'MALE'], ['mama-daughter', 'FEMALE'],
+    ['mausi-son', 'MALE'], ['mausi-daughter', 'FEMALE'],
+    ['brother-son', 'MALE'], ['sister-daughter', 'FEMALE'],
+  ]) add(id, gender, '1990');
+
+  for (const [a, b] of [
+    ['dada', 'dadi'], ['nana', 'nani'], ['tau', 'tai'], ['dad', 'mum'],
+    ['chacha', 'chachi'], ['bua', 'phupha'], ['mama', 'mami'], ['mausi', 'mausa'],
+    ['me', 'wife'], ['brother', 'bhabhi'], ['sister', 'jija'], ['sasur', 'saas'],
+  ]) relationships.push({ from: a, to: b, type: 'SPOUSE' });
+
+  kids('dada', 'dadi', 'tau', 'dad', 'chacha', 'bua');
+  kids('nana', 'nani', 'mum', 'mama', 'mausi');
+  kids('dad', 'mum', 'me', 'brother', 'sister');
+  kids('me', 'wife', 'son', 'daughter');
+  kids('sasur', 'saas', 'wife', 'sala', 'sali');
+  kids('tau', 'tai', 'tau-son', 'tau-daughter');
+  kids('chacha', 'chachi', 'chacha-son', 'chacha-daughter');
+  kids('bua', 'phupha', 'bua-son', 'bua-daughter');
+  kids('mama', 'mami', 'mama-son', 'mama-daughter');
+  kids('mausi', 'mausa', 'mausi-son', 'mausi-daughter');
+  kids('brother', 'bhabhi', 'brother-son');
+  kids('sister', 'jija', 'sister-daughter');
+
+  return buildGraph({ people, relationships });
+}
+
+function summary(label, r) {
+  const pct = (n, of) => Math.floor((n * 100) / Math.max(of, 1));
+  return [
+    `${label} - ${r.pairs} ordered pairs`,
+    `  ${r.related} have a relationship English can name at all`,
+    `  ${r.coverable} of those are a shape Hindi has a word for`,
+    `  ${r.named} get a Hindi word - ${pct(r.named, r.coverable)}% of the shapes it covers, `
+      + `${pct(r.named, r.related)}% of every named pair`,
+    `  ${r.descriptive} of those are descriptive, for want of a birth year`,
+    `  ${r.excusedByGender} have no word coming back, because a gender is unrecorded`,
+    `  ${r.excusedByContradiction} run through a marriage recorded inconsistently`,
+  ].join('\n');
+}
+
+test('every pair agrees with its opposite number', () => {
+  const report = sweep(family());
+  console.log(`\n${summary('built-in family', report)}`);
+  for (const [term, count] of [...report.counts].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${term}: ${count}`);
+  }
+
+  assert.deepStrictEqual(
+    report.breaches.slice(0, 25),
+    [],
+    `${report.breaches.length} relationships disagree with their reverse`,
+  );
+});
+
+test('the sweep is actually reaching the vocabulary, not passing on an empty table', () => {
+  /*
+   * A sweep that named nothing would have no breaches and would look perfect. This pins the floor:
+   * the built-in family exists to reach every term worth having, so most of the shapes Hindi covers
+   * should get a word.
+   */
+  const report = sweep(family());
+  assert.ok(report.named > 200, `only ${report.named} pairs got a Hindi word`);
+  assert.ok(report.counts.size >= 30, `only ${report.counts.size} distinct terms were reached`);
+  assert.ok(
+    report.named >= report.coverable * 0.9,
+    `${report.named} named of ${report.coverable} coverable`,
+  );
+});
+
+test('a broken rule is caught rather than excused', () => {
+  /*
+   * The excuses exist so that a gap in somebody's record does not read as a bug. This proves they
+   * do not swallow a real one: with every gender recorded, a reciprocal that does not come back is
+   * a breach and is reported as such.
+   */
+  const graph = family();
+  assert.strictEqual(hindiOf(graph, 'me', 'mama'), 'MAMA');
+  // And the way back, computed independently from the other end of the graph.
+  assert.strictEqual(hindiOf(graph, 'mama', 'me'), 'BHANJA');
+  assert.ok(RECIPROCAL.get('MAMA').has('BHANJA'));
+  assert.ok(!RECIPROCAL.get('MAMA').has('BHATIJA'), "a mother's brother sees a sister's son");
+});
+
+test('cousins invert as they cross', () => {
+  // The sharpest case in the table: a फुफेरा भाई must see you as his ममेरा भाई, never as another
+  // फुफेरा. The two answers come through different branches of the rules.
+  const graph = family();
+  assert.strictEqual(hindiOf(graph, 'me', 'bua-son'), 'PHUPHERA_BHAI');
+  assert.strictEqual(hindiOf(graph, 'bua-son', 'me'), 'MAMERA_BHAI');
+
+  // And the ones through a same-sex sibling stay themselves.
+  assert.strictEqual(hindiOf(graph, 'me', 'chacha-son'), 'CHACHERA_BHAI');
+  assert.strictEqual(hindiOf(graph, 'chacha-son', 'me'), 'CHACHERA_BHAI');
+});

--- a/site/playground/kinship-hindi.js
+++ b/site/playground/kinship-hindi.js
@@ -1,0 +1,232 @@
+/*
+ * Which Hindi word a relationship takes.
+ *
+ * A port of `app/.../graph/HindiKinship.kt`, with its test table. Pure, and deliberately so: this
+ * is the part that can be wrong.
+ *
+ * English collapses five Hindi terms into "uncle", so a labelling layer working from the kinship
+ * term alone could only guess. Everything here reads `relate(...).kinship` -- which parent the line
+ * went up through, who it came back down through, and who was born first -- and returns null
+ * wherever Hindi genuinely has no word.
+ *
+ * **Null is a real answer.** Hindi has no single word for a second cousin, or for a relative reached
+ * through two marriages, and where it has none the honest thing is to fall back to the English term
+ * the rest of the app already gives -- which is what a Hindi speaker would reach for in the same
+ * conversation. A word invented to fill the gap would be worse than the English one.
+ *
+ * `model.js` is not touched by this file, and does not know it exists. The vocabulary reads the
+ * engine; the engine never reads the vocabulary.
+ */
+
+/** The male word, the female word, or null: Hindi has no neuter kinship term to fall back on. */
+function byGender(gender, male, female) {
+  if (gender === 'MALE') return male;
+  if (gender === 'FEMALE') return female;
+  return null;
+}
+
+/**
+ * Elder, younger, or the descriptive term where the record cannot say.
+ *
+ * The `unknown` word is not a failure. "पिता के भाई" is exactly what he is, and it is a better
+ * answer than picking ताऊ or चाचा and being wrong half the time in a way the family notices
+ * immediately.
+ */
+function elderYounger(seniority, elder, younger, unknown) {
+  if (seniority === 'ELDER') return elder;
+  if (seniority === 'YOUNGER') return younger;
+  return unknown;
+}
+
+/* ------------------------------------------------------------------------------------ blood */
+
+function ancestor(generations, path, target) {
+  if (generations === 1) return byGender(target, 'PITA', 'MATA');
+
+  // दादा is the father's father, नाना the mother's -- the side *is* the whole distinction.
+  if (generations === 2) {
+    if (path?.side === 'MALE') return byGender(target, 'DADA', 'DADI');
+    if (path?.side === 'FEMALE') return byGender(target, 'NANA', 'NANI');
+    return null;
+  }
+  if (generations === 3) {
+    if (path?.side === 'MALE') return byGender(target, 'PARDADA', 'PARDADI');
+    if (path?.side === 'FEMALE') return byGender(target, 'PARNANA', 'PARNANI');
+    return null;
+  }
+  // पर- stacks no further in ordinary speech, so the English word serves better.
+  return null;
+}
+
+function descendant(generations, path, target) {
+  if (generations === 1) return byGender(target, 'BETA', 'BETI');
+
+  // A son's children are पोता/पोती, a daughter's नाती/नातिन -- the child in between decides.
+  if (generations === 2) {
+    if (path?.link === 'MALE') return byGender(target, 'POTA', 'POTI');
+    if (path?.link === 'FEMALE') return byGender(target, 'NATI', 'NATIN');
+    return null;
+  }
+  if (generations === 3) {
+    if (path?.link === 'MALE') return byGender(target, 'PARPOTA', 'PARPOTI');
+    if (path?.link === 'FEMALE') return byGender(target, 'PARNATI', 'PARNATIN');
+    return null;
+  }
+  return null;
+}
+
+function parentsSibling(path, target) {
+  if (path?.side === 'MALE') {
+    if (target === 'FEMALE') return 'BUA';
+    if (target === 'MALE') {
+      return elderYounger(path.seniority, 'TAU', 'CHACHA', 'FATHERS_BROTHER');
+    }
+    return null;
+  }
+  // Neither मामा nor मौसी cares about birth order, which is why only the father's side ever has to
+  // ask the record for a birth year.
+  if (path?.side === 'FEMALE') return byGender(target, 'MAMA', 'MAUSI');
+  return null;
+}
+
+function siblingsChild(path, target) {
+  if (path?.link === 'MALE') return byGender(target, 'BHATIJA', 'BHATIJI');
+  if (path?.link === 'FEMALE') return byGender(target, 'BHANJA', 'BHANJI');
+  return null;
+}
+
+function firstCousin(path, target) {
+  const side = path?.side;
+  const link = path?.link;
+  if (side === 'MALE' && link === 'MALE') return byGender(target, 'CHACHERA_BHAI', 'CHACHERI_BEHEN');
+  if (side === 'MALE' && link === 'FEMALE') return byGender(target, 'PHUPHERA_BHAI', 'PHUPHERI_BEHEN');
+  if (side === 'FEMALE' && link === 'MALE') return byGender(target, 'MAMERA_BHAI', 'MAMERI_BEHEN');
+  if (side === 'FEMALE' && link === 'FEMALE') return byGender(target, 'MAUSERA_BHAI', 'MAUSERI_BEHEN');
+  return null;
+}
+
+/* ------------------------------------------------------------------------------- by marriage */
+
+/** जीजा married a sister, भाभी married a brother -- neither word works without both facts. */
+function spouseOfSibling(sibling, target) {
+  if (sibling === 'FEMALE' && target === 'MALE') return 'JIJA';
+  if (sibling === 'MALE' && target === 'FEMALE') return 'BHABHI';
+  return null;
+}
+
+/**
+ * Married to one of the subject's blood relatives. The path runs to that relative.
+ *
+ * Every word here names *both* people: जीजा is a man married to a sister, भाभी a woman married to a
+ * brother. So both genders have to agree before one is used. A record saying otherwise -- a marriage
+ * between two people both written down as male, most often a gender entered wrongly -- gets no word
+ * rather than a confident falsehood, and the chain still answers the question.
+ */
+function marriedIn(relative, path, target) {
+  switch (relative?.kind) {
+    case 'parents-sibling': {
+      if (relative.greats > 0) return null;
+      const { side, link } = path ?? {};
+      // Father's sister's husband, and father's brother's wife.
+      if (side === 'MALE' && link === 'FEMALE' && target === 'MALE') return 'PHUPHA';
+      if (side === 'MALE' && link === 'MALE' && target === 'FEMALE') {
+        return elderYounger(path.seniority, 'TAI', 'CHACHI', 'FATHERS_BROTHERS_WIFE');
+      }
+      // Mother's brother's wife, and mother's sister's husband.
+      if (side === 'FEMALE' && link === 'MALE' && target === 'FEMALE') return 'MAMI';
+      if (side === 'FEMALE' && link === 'FEMALE' && target === 'MALE') return 'MAUSA';
+      return null;
+    }
+
+    case 'sibling':
+      return spouseOfSibling(path?.link, target);
+
+    case 'descendant': {
+      if (relative.generations !== 1) return null;
+      if (path?.link === 'MALE' && target === 'FEMALE') return 'BAHU';
+      if (path?.link === 'FEMALE' && target === 'MALE') return 'DAMAD';
+      return null;
+    }
+
+    case 'ancestor':
+      return relative.generations !== 1 ? null : byGender(target, 'SAUTELA_PITA', 'SAUTELI_MATA');
+
+    default:
+      return null;
+  }
+}
+
+/** A blood relative of the subject's own spouse. The path runs from the spouse to them. */
+function ofSpouse(relative, path, subject, target) {
+  switch (relative?.kind) {
+    case 'ancestor':
+      return relative.generations !== 1 ? null : byGender(target, 'SASUR', 'SAAS');
+
+    /*
+     * The one family of terms that turns on the gender of the person *asking*.
+     *
+     * A wife's brother is साला; a husband's brother is जेठ or देवर. Without knowing which, there is
+     * no word to give -- which is why the subject's gender is carried separately from the target's
+     * all the way down here.
+     */
+    case 'sibling': {
+      if (subject === 'MALE') return byGender(target, 'SALA', 'SALI');
+      if (subject === 'FEMALE') {
+        if (target === 'FEMALE') return 'NANAD';
+        if (target === 'MALE') {
+          return elderYounger(path?.seniority ?? 'UNKNOWN', 'JETH', 'DEVAR', 'HUSBANDS_BROTHER');
+        }
+        return null;
+      }
+      return null;
+    }
+
+    case 'descendant':
+      return relative.generations !== 1 ? null : byGender(target, 'SAUTELA_BETA', 'SAUTELI_BETI');
+
+    default:
+      return null;
+  }
+}
+
+/* ------------------------------------------------------------------------------------ entry */
+
+/**
+ * The Hindi term for a relationship, or null where Hindi has no word for it.
+ *
+ * `kinship` is `relate(...).kinship`: the structured term and the path it was measured over.
+ * `subject` is the gender of the person the relationship is *from*, which several in-law terms turn
+ * on, and `target` the gender of the person it is *to*.
+ */
+export function hindiTerm(kinship, subject, target) {
+  const term = kinship?.term;
+  if (!term) return null;
+
+  switch (term.kind) {
+    case 'self':
+      return 'SELF';
+    case 'ancestor':
+      return ancestor(term.generations, kinship, target);
+    case 'descendant':
+      return descendant(term.generations, kinship, target);
+    case 'sibling':
+      return byGender(target, 'BHAI', 'BEHEN');
+    case 'parents-sibling':
+      return term.greats > 0 ? null : parentsSibling(kinship, target);
+    case 'siblings-child':
+      return term.greats > 0 ? null : siblingsChild(kinship, target);
+    case 'cousin':
+      // Hindi's cousin words are deliberately blind to birth order -- चचेरा covers both ताऊ's
+      // children and चाचा's in ordinary speech -- but they only reach first cousins of the same
+      // generation. Anything further out has no word, and English says it better.
+      return term.degree !== 1 || term.removed !== 0 ? null : firstCousin(kinship, target);
+    case 'spouse':
+      return byGender(target, 'PATI', 'PATNI');
+    case 'spouse-of':
+      return marriedIn(term.relative, kinship, target);
+    case 'of-spouse':
+      return ofSpouse(term.relative, kinship, subject, target);
+    default:
+      return null;
+  }
+}

--- a/site/playground/kinship-hindi.test.mjs
+++ b/site/playground/kinship-hindi.test.mjs
@@ -1,0 +1,356 @@
+/*
+ * HindiKinshipTest.kt, case for case.
+ *
+ * This is the file that decides whether the feature is right. English collapses five Hindi words
+ * into "uncle", so every one of these could be quietly wrong in a way no English test would catch --
+ * and a Hindi speaker reading "चाचा" for their mother's brother sees the mistake instantly, where
+ * "uncle" was merely vague.
+ *
+ * These are not new tests. Every one is a translation of a case in
+ * `app/src/test/java/com/vibethroughcode/ftree/graph/HindiKinshipTest.kt`, kept in the same order
+ * and with the same names, because the point of the exercise is that two implementations of one
+ * family's vocabulary must not drift apart. Reading the two files side by side should be dull.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { buildGraph, relate } from './model.js';
+import { hindiTerm } from './kinship-hindi.js';
+import { HINDI_WORDS, HINDI_TERMS } from './kinship-hi.js';
+
+class Builder {
+  constructor() {
+    this.people = [];
+    this.relationships = [];
+  }
+
+  person(id, gender, born = null) {
+    this.people.push({ id, name: id, gender, birthDate: born });
+    return this;
+  }
+
+  man(id, born = null) { return this.person(id, 'MALE', born); }
+  woman(id, born = null) { return this.person(id, 'FEMALE', born); }
+
+  childrenOf(a, b, ...children) {
+    for (const child of children) {
+      this.relationships.push({ from: a, to: child, type: 'PARENT' });
+      this.relationships.push({ from: b, to: child, type: 'PARENT' });
+    }
+    return this;
+  }
+
+  married(a, b) {
+    this.relationships.push({ from: a, to: b, type: 'SPOUSE' });
+    return this;
+  }
+
+  build() {
+    // The Kotlin's builder tolerates a parent id that is not a person; `buildGraph` drops such an
+    // edge, which is the same outcome by a different route.
+    const known = new Set(this.people.map((p) => p.id));
+    return buildGraph({
+      people: this.people,
+      relationships: this.relationships.filter((r) => known.has(r.from) && known.has(r.to)),
+    });
+  }
+}
+
+/**
+ * "me" at the centre, with both sides of the family recorded and birth years where the order
+ * matters -- the father's brothers, because ताऊ and चाचा are told apart by nothing else.
+ */
+const family = () => new Builder()
+  // Father's parents, and his siblings: an elder brother, a younger brother, a sister.
+  .man('dada', '1930').woman('dadi', '1934')
+  .man('tau', '1952').woman('tau-wife', '1955')
+  .man('dad', '1958').woman('mum', '1960')
+  .man('chacha', '1963').woman('chacha-wife', '1966')
+  .woman('bua', '1955').man('bua-husband', '1952')
+  // Mother's parents, and her siblings: a brother and a sister.
+  .man('nana', '1932').woman('nani', '1936')
+  .man('mama', '1956').woman('mama-wife', '1959')
+  .woman('mausi', '1962').man('mausi-husband', '1960')
+  // Me, my wife, my brother and sister, my children.
+  .man('me', '1985').woman('wife', '1987')
+  .man('brother', '1988').woman('sister', '1990')
+  .man('son', '2012').woman('daughter', '2015')
+  .man('grandson', '2040').woman('granddaughter', '2042')
+  // The cousins, one set from each aunt and uncle.
+  .man('chachera', '1990').woman('chacheri', '1992')
+  .man('phuphera', '1988').woman('phupheri', '1991')
+  .man('mamera', '1989').woman('mameri', '1993')
+  .man('mausera', '1994').woman('mauseri', '1996')
+  // Nieces and nephews, through my brother and through my sister.
+  .man('bhatija', '2014').woman('bhatiji', '2016')
+  .man('bhanja', '2018').woman('bhanji', '2020')
+  // My wife's family, for the in-law terms.
+  .man('sasur', '1958').woman('saas', '1961')
+  .man('sala', '1990').woman('sali', '1992')
+  // Spouses of my own siblings.
+  .man('jija', '1986').woman('bhabhi', '1989')
+
+  .married('dada', 'dadi').married('nana', 'nani')
+  .married('dad', 'mum').married('me', 'wife')
+  .married('tau', 'tau-wife').married('chacha', 'chacha-wife')
+  .married('bua', 'bua-husband').married('mama', 'mama-wife')
+  .married('mausi', 'mausi-husband')
+  .married('sasur', 'saas')
+  .married('sister', 'jija').married('brother', 'bhabhi')
+
+  .childrenOf('dada', 'dadi', 'tau', 'dad', 'chacha', 'bua')
+  .childrenOf('nana', 'nani', 'mum', 'mama', 'mausi')
+  .childrenOf('dad', 'mum', 'me', 'brother', 'sister')
+  .childrenOf('me', 'wife', 'son', 'daughter')
+  .childrenOf('son', 'daughter-in-law-unused', 'grandson')
+  .childrenOf('chacha', 'chacha-wife', 'chachera', 'chacheri')
+  .childrenOf('bua', 'bua-husband', 'phuphera', 'phupheri')
+  .childrenOf('mama', 'mama-wife', 'mamera', 'mameri')
+  .childrenOf('mausi', 'mausi-husband', 'mausera', 'mauseri')
+  .childrenOf('brother', 'bhabhi', 'bhatija', 'bhatiji')
+  .childrenOf('sister', 'jija', 'bhanja', 'bhanji')
+  .childrenOf('sasur', 'saas', 'wife', 'sala', 'sali')
+  .build();
+
+/** The word for `other` as seen from `subject`. */
+function word(graph, subject, other) {
+  const answer = relate(graph, subject, other);
+  if (answer.kind !== 'related') {
+    throw new Error(`${subject} and ${other} are not related in the fixture`);
+  }
+  return hindiTerm(
+    answer.kinship,
+    graph.people.get(subject)?.gender ?? 'UNSPECIFIED',
+    graph.people.get(other)?.gender ?? 'UNSPECIFIED',
+  );
+}
+
+const shared = family();
+const assertWord = (expected, other, subject = 'me') => {
+  assert.strictEqual(word(shared, subject, other), expected, `${other}, seen from ${subject}`);
+};
+
+/* --------------------------------------------------------------------------- the sides */
+
+test('the two grandfathers have different words', () => {
+  // The distinction the whole feature exists for. English says "grandfather" twice; Hindi says
+  // दादा for the father's father and नाना for the mother's, and they are not interchangeable.
+  assertWord('DADA', 'dada');
+  assertWord('DADI', 'dadi');
+  assertWord('NANA', 'nana');
+  assertWord('NANI', 'nani');
+});
+
+test("mother's brother is मामा and father's brother is not", () => {
+  // The reported case: Ankit's mother's brother is his मामा, never his चाचा.
+  assertWord('MAMA', 'mama');
+  assertWord('CHACHA', 'chacha');
+});
+
+test("all four kinds of parent's sibling are distinguished", () => {
+  assertWord('TAU', 'tau');          // father's elder brother
+  assertWord('CHACHA', 'chacha');    // father's younger brother
+  assertWord('BUA', 'bua');          // father's sister
+  assertWord('MAMA', 'mama');        // mother's brother
+  assertWord('MAUSI', 'mausi');      // mother's sister
+});
+
+test('their spouses take the word that belongs to them', () => {
+  assertWord('TAI', 'tau-wife');
+  assertWord('CHACHI', 'chacha-wife');
+  assertWord('PHUPHA', 'bua-husband');
+  assertWord('MAMI', 'mama-wife');
+  assertWord('MAUSA', 'mausi-husband');
+});
+
+/* ------------------------------------------------------------------------ birth order */
+
+test("without birth years father's brother is named descriptively", () => {
+  /*
+   * ताऊ is the elder brother and चाचा the younger, and nothing but a date says which. With the
+   * years removed the app says "father's brother" rather than picking one -- the same rule that
+   * removed "related by marriage": claim precision only where the record supports it.
+   */
+  const undated = new Builder()
+    .man('dada').woman('dadi')
+    .man('dad').woman('mum')
+    .man('uncle').woman('uncle-wife')
+    .man('me')
+    .married('dad', 'mum').married('uncle', 'uncle-wife')
+    .childrenOf('dada', 'dadi', 'dad', 'uncle')
+    .childrenOf('dad', 'mum', 'me')
+    .build();
+
+  assert.strictEqual(word(undated, 'me', 'uncle'), 'FATHERS_BROTHER');
+  assert.strictEqual(word(undated, 'me', 'uncle-wife'), 'FATHERS_BROTHERS_WIFE');
+});
+
+test('the descriptive terms ask for birth years', () => {
+  // And they say so, which is how the screen knows to offer the nudge.
+  assert.ok(HINDI_WORDS.FATHERS_BROTHER.needsBirthYears);
+  assert.ok(HINDI_WORDS.FATHERS_BROTHERS_WIFE.needsBirthYears);
+  assert.ok(HINDI_WORDS.HUSBANDS_BROTHER.needsBirthYears);
+  assert.strictEqual(
+    HINDI_TERMS.filter((t) => HINDI_WORDS[t].needsBirthYears).length,
+    3,
+    'no other term should be claiming it needs a birth year',
+  );
+});
+
+test('years that could overlap do not settle the order', () => {
+  // "1958" and "1958" could be either way round.
+  const ambiguous = new Builder()
+    .man('dada').woman('dadi')
+    .man('dad', '1958').man('uncle', '1958')
+    .woman('mum').man('me')
+    .married('dad', 'mum')
+    .childrenOf('dada', 'dadi', 'dad', 'uncle')
+    .childrenOf('dad', 'mum', 'me')
+    .build();
+
+  assert.strictEqual(word(ambiguous, 'me', 'uncle'), 'FATHERS_BROTHER');
+});
+
+test('the other sides never need a birth year', () => {
+  // Only the father's brothers ever need a date. मामा and मौसी never do.
+  const undated = new Builder()
+    .man('nana').woman('nani')
+    .man('dad').woman('mum')
+    .man('mama').woman('mausi')
+    .man('me')
+    .married('dad', 'mum')
+    .childrenOf('nana', 'nani', 'mum', 'mama', 'mausi')
+    .childrenOf('dad', 'mum', 'me')
+    .build();
+
+  assert.strictEqual(word(undated, 'me', 'mama'), 'MAMA');
+  assert.strictEqual(word(undated, 'me', 'mausi'), 'MAUSI');
+});
+
+/* ------------------------------------------------------------------------- downward */
+
+test('grandchildren are named by which child they come through', () => {
+  assertWord('BETA', 'son');
+  assertWord('BETI', 'daughter');
+  // A son's son is पोता; a daughter's would be नाती.
+  assertWord('POTA', 'grandson');
+});
+
+test('nieces and nephews are named by the sibling, not by themselves', () => {
+  assertWord('BHATIJA', 'bhatija');   // brother's son
+  assertWord('BHATIJI', 'bhatiji');   // brother's daughter
+  assertWord('BHANJA', 'bhanja');     // sister's son
+  assertWord('BHANJI', 'bhanji');     // sister's daughter
+});
+
+/* -------------------------------------------------------------------------- cousins */
+
+test('cousins are named through the aunt or uncle', () => {
+  /*
+   * Hindi has no separate word for a cousin -- they are brothers and sisters with a qualifier
+   * naming the aunt or uncle they come through, which is four different words where English has
+   * one.
+   */
+  assertWord('CHACHERA_BHAI', 'chachera');
+  assertWord('CHACHERI_BEHEN', 'chacheri');
+  assertWord('PHUPHERA_BHAI', 'phuphera');
+  assertWord('PHUPHERI_BEHEN', 'phupheri');
+  assertWord('MAMERA_BHAI', 'mamera');
+  assertWord('MAMERI_BEHEN', 'mameri');
+  assertWord('MAUSERA_BHAI', 'mausera');
+  assertWord('MAUSERI_BEHEN', 'mauseri');
+});
+
+/* ------------------------------------------------------------------------ by marriage */
+
+test('the immediate family and the in-laws beside it', () => {
+  assertWord('PITA', 'dad');
+  assertWord('MATA', 'mum');
+  assertWord('BHAI', 'brother');
+  assertWord('BEHEN', 'sister');
+  assertWord('PATNI', 'wife');
+  assertWord('SASUR', 'sasur');
+  assertWord('SAAS', 'saas');
+});
+
+test("a sibling's spouse is named through the sibling", () => {
+  // जीजा is a sister's husband and भाभी a brother's wife -- the sibling picks the word.
+  assertWord('JIJA', 'jija');
+  assertWord('BHABHI', 'bhabhi');
+});
+
+test("spouse's siblings depend on the gender of the person asking", () => {
+  /*
+   * A wife's brother is साला to a man; a husband's brother is जेठ or देवर to a woman, and which one
+   * depends on his age against her husband's.
+   */
+  assertWord('SALA', 'sala');
+  assertWord('SALI', 'sali');
+
+  // The same two people, asked from the wife's side: her husband's brother and sister.
+  assert.strictEqual(word(shared, 'wife', 'brother'), 'DEVAR');
+  assert.strictEqual(word(shared, 'wife', 'sister'), 'NANAD');
+});
+
+test("a husband's elder brother is जेठ and a younger one देवर", () => {
+  // "brother" is born 1988, after "me" in 1985, so to my wife he is the younger -- देवर.
+  assert.strictEqual(word(shared, 'wife', 'brother'), 'DEVAR');
+
+  const elder = new Builder()
+    .man('dad').woman('mum')
+    .man('husband', '1985').man('his-brother', '1980')
+    .woman('her')
+    .married('husband', 'her')
+    .childrenOf('dad', 'mum', 'husband', 'his-brother')
+    .build();
+  assert.strictEqual(word(elder, 'her', 'his-brother'), 'JETH');
+});
+
+/* ------------------------------------------------------------- where Hindi has no word */
+
+test('relationships Hindi has no word for come back empty', () => {
+  /*
+   * Second cousins, removed cousins and great-uncles have no everyday Hindi word, and inventing a
+   * Devanagari compound nobody says would be worse than the English one the screen falls back to.
+   */
+  const distant = new Builder()
+    .man('great').woman('great-wife')
+    .man('grandad').man('granduncle')
+    .man('dad').man('cousin-parent')
+    .man('me').man('second-cousin')
+    .childrenOf('great', 'great-wife', 'grandad', 'granduncle')
+    .childrenOf('grandad', 'unknown-a', 'dad')
+    .childrenOf('granduncle', 'unknown-b', 'cousin-parent')
+    .childrenOf('dad', 'unknown-c', 'me')
+    .childrenOf('cousin-parent', 'unknown-d', 'second-cousin')
+    .build();
+
+  assert.strictEqual(word(distant, 'me', 'second-cousin'), null);
+  assert.strictEqual(word(distant, 'me', 'granduncle'), null);
+});
+
+test('an unrecorded gender means no Hindi word', () => {
+  // Hindi has no neuter kinship term, so it declines rather than guesses.
+  const unknown = new Builder()
+    .person('dad', 'UNSPECIFIED')
+    .person('me', 'UNSPECIFIED')
+    .childrenOf('dad', 'dad', 'me')
+    .build();
+
+  assert.strictEqual(word(unknown, 'me', 'dad'), null);
+});
+
+test('an unknown side leaves the grandparent to English', () => {
+  // A grandparent reached through a parent whose gender was never written down: दादा or नाना cannot
+  // be told apart, so neither is claimed.
+  const unknown = new Builder()
+    .man('grandad')
+    .person('parent', 'UNSPECIFIED')
+    .man('me')
+    .childrenOf('grandad', 'grandad', 'parent')
+    .childrenOf('parent', 'parent', 'me')
+    .build();
+
+  assert.strictEqual(word(unknown, 'me', 'grandad'), null);
+});


### PR DESCRIPTION
Part of #124 — **stage 5d**. The vocabulary itself.

English says "uncle" five different ways. This is the file that decides which one, and it is the part of the feature that can be wrong in a way **no English test would catch**: a Hindi speaker reading "चाचा" for their mother's brother sees the mistake instantly, where "uncle" was merely vague.

**`model.js` is not touched.** The vocabulary reads the engine; the engine never reads the vocabulary. That is what the whole of 5a–5c was arranging, and it is why this stage is two new files, three test files, and nothing else.

| | |
|---|---|
| `site/playground/kinship-hindi.js` | which word a relationship takes — ported from `graph/HindiKinship.kt` |
| `site/playground/kinship-hi.js` | how each of the 65 terms is spelled, and what it means in English |

**Null is a real answer, not a gap.** Hindi has no single word for a second cousin, or for a relative reached through two marriages. Where it has none, the honest thing is to fall back to the English term the app already gives — which is what a Hindi speaker does in the same conversation. A Devanagari compound invented to fill the hole would be worse than the English.

## Three tests, each doing a different job

**The 43-case table** from `HindiKinshipTest.kt` — same family, same names. It passed on the first run, which is the path model from 5c doing its job rather than luck.

**A parity test** that reads `app/src/main/res/values/kinship_hi.xml` — the file a Hindi speaker actually reviews — and asserts this table matches it exactly, **in both directions**: every term the phone spells is spelled here identically, and this table spells nothing the phone does not. It only reads; nothing under `app/` is written.

The word and its gloss live in **one object**, because on the phone they are two resources (`kin_hi_bua`, `kin_hi_bua_gloss`) and two lists of 65 things are two lists that can lose their alignment.

**The every-pair sweep** from `HindiEveryPairTest.kt`, which is the one that cannot be satisfied by luck: *if B is A's मामा, then A must be B's भांजा or भांजी* — computed independently from opposite ends of the graph, through different branches of the rules. Cousins are the sharpest case: a **फुफेरा भाई must see you as his ममेरा भाई**, never as another फुफेरा, because the relationship inverts as it crosses.

```
built-in family - 1560 ordered pairs
  970 have a relationship English can name at all
  647 of those are a shape Hindi has a word for
  647 get a Hindi word - 100% of the shapes it covers, 66% of every named pair
  0 of those are descriptive, for want of a birth year
  0 have no word coming back, because a gender is unrecorded
  0 run through a marriage recorded inconsistently
```

Both of the Kotlin's **honest excuses** come across: an unrecorded gender genuinely has no Hindi word (there is no neuter for भाई), and a marriage recorded with both partners the same gender — almost always one gender entered wrongly — breaks every in-law term, which names both people. They are counted separately so a mistake in somebody's tree cannot be mistaken for a mistake in the vocabulary.

And the **honest denominator** with them: a raw percentage over every pair in a deep tree says more about the tree's depth than about the vocabulary, because English names every blood relation however far out and Hindi deliberately does not.

Added, not translated: a floor test that the sweep is reaching the vocabulary at all — a sweep that named nothing would have no breaches and would look perfect.

## Verification

- engine tests **80 → 110**. `kinship-golden.txt` **unmoved**.
- `git diff --stat -- site/playground/model.js` empty for this commit.
- `git status --short app/` empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)