### PR TITLE
feat(desktop): say it in Hindi, under the English rather than instead of it

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -131,6 +131,18 @@ async function changeSetting(key, value, win) {
   if (JSON.stringify(before) === JSON.stringify(settings)) return settings;
   await writeSettings();
   if (win && !win.isDestroyed()) buildMenu(win);
+
+  /*
+   * And the page, which is the third surface over these values.
+   *
+   * The menu rebuild above stops a native checkbox going stale. This stops the *page* going stale
+   * the same way: change "Offer me beta releases" from the native menu, then open Preferences, and
+   * without this the dialog paints from a copy fetched at launch and shows the opposite of the
+   * truth. Every window is told, because a value that is one per app should not be one per window.
+   */
+  for (const open of BrowserWindow.getAllWindows()) {
+    if (!open.isDestroyed()) open.webContents.send('settings:changed', { ...settings });
+  }
   return settings;
 }
 
@@ -1663,6 +1675,69 @@ async function runRelateSmoke(win, check) {
     await page(() => document.getElementById('theme-btn').click());
     await settle(200);
   }
+
+  /*
+   * The same answer in Hindi, from the same panel.
+   *
+   * English says "uncle"; Hindi says which uncle. So what is asserted is not that a word appeared
+   * but that the *English wording did not change* -- the Hindi is a second thing said, not a
+   * translation of the first -- and that the word comes and goes with the setting.
+   */
+  // Back to a pair that *is* related: the checks above deliberately left the panel on the
+  // "nothing connects them" answer, which has no relationship for any language to name.
+  await pick('b', relative);
+  await page(async () => {
+    await window.ftreeDesktop.setSetting('familyWords', 'hi');
+  });
+  await settle(600);
+
+  const hindi = await page(() => {
+    const box = document.getElementById('relate-answer');
+    return {
+      english: box.querySelector('.r-term')?.textContent.trim() ?? '',
+      word: box.querySelector('.r-hindi-word')?.textContent.trim() ?? '',
+      gloss: box.querySelector('.r-hindi-gloss')?.textContent.trim() ?? '',
+      lang: box.querySelector('.r-hindi')?.lang ?? '',
+      devanagari: /[\u0900-\u097F]/.test(box.querySelector('.r-hindi-word')?.textContent ?? ''),
+    };
+  });
+
+  if (hindi.word) {
+    check('the Hindi word is written in Devanagari', hindi.devanagari, hindi.word);
+    check('it carries a gloss, so somebody without the word can still read it',
+      hindi.gloss.length > 2, hindi.gloss);
+    check('and is marked as Hindi, so a screen reader does not spell it in English',
+      hindi.lang === 'hi', hindi.lang);
+  } else {
+    // Not every pair has a Hindi word, and that is a real answer rather than a failure.
+    check('no Hindi word is offered where Hindi has none, and English still answers',
+      hindi.english.length > 0, hindi.english);
+  }
+
+  // Photographed here, with the word on screen: this is the surface worth looking at, and the
+  // English one is already captured above.
+  if (process.env.FTREE_SMOKE_SHOT_HINDI && hindi.word) {
+    const shot = process.env.FTREE_SMOKE_SHOT_HINDI;
+    await fs.writeFile(shot, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${shot}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(400);
+    const other = shot.replace(/(\.png)?$/, '-other-theme.png');
+    await fs.writeFile(other, (await win.webContents.capturePage()).toPNG());
+    console.log(`       wrote ${other}`);
+    await page(() => document.getElementById('theme-btn').click());
+    await settle(300);
+  }
+
+  await page(async () => { await window.ftreeDesktop.setSetting('familyWords', 'en'); });
+  await settle(600);
+  const back = await page(() => ({
+    english: document.getElementById('relate-answer').querySelector('.r-term')?.textContent.trim() ?? '',
+    word: document.querySelector('#relate-answer .r-hindi-word')?.textContent.trim() ?? '',
+  }));
+  check('the English wording does not change when the language does',
+    back.english === hindi.english, `"${hindi.english}" then "${back.english}"`);
+  check('and the Hindi goes away again with the setting', back.word === '', back.word);
 
   // Closing puts the whole tree back, rather than stranding somebody on a three-person chart.
   await page(() => document.getElementById('relate-close').click());

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -35,6 +35,14 @@ contextBridge.exposeInMainWorld('ftreeDesktop', {
   choosePhoto: () => ipcRenderer.invoke('photo:choose'),
 
   settings: () => ipcRenderer.invoke('settings:get'),
+
+  /**
+   * Told whenever a setting changes, whoever changed it.
+   *
+   * The native menu can change these without the page knowing, and so can another window. One
+   * value that is one per app should not become one copy per surface.
+   */
+  onSettingsChanged: (fn) => ipcRenderer.on('settings:changed', (_event, next) => fn(next)),
   setSetting: (key, value) => ipcRenderer.invoke('settings:set', { key, value }),
 
   /**

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -34,7 +34,7 @@ import { bytesForTree, SaveRefused } from './save.js';
 import { planImport, applyImport, ImportRefused } from './import.js';
 import { MatchTier } from './matching.js';
 import { renderBands } from './bands.js';
-import { sentenceFor, unrelatedWording, paintSentence, nameNode } from './relation.js';
+import { sentenceFor, unrelatedWording, paintSentence, nameNode, hindiFor } from './relation.js';
 import { decode, encode, asImageUrl, freeName, squareCrop } from './photo.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
@@ -553,6 +553,8 @@ async function setPref(key, value) {
   // Photographs change what the chart is given, so that one needs a rebuild; the rest do not.
   applyPrefs({ redraw: before?.photosOnChart !== prefs.photosOnChart });
   paintPrefs();
+  // A change of language is a change to an answer already on screen.
+  if (before?.familyWords !== prefs.familyWords && !$('relate').hidden) renderRelation();
 }
 
 function openPrefs() {
@@ -654,6 +656,41 @@ function closeRelate() {
   clearTrace();
 }
 
+/**
+ * `word (gloss)`, and where the record cannot settle a birth order, the nudge that would.
+ *
+ * The three descriptive terms are correct as they stand -- "पिता के भाई" is what he is -- so this
+ * does not apologise for them. It says which two birth years would sharpen the word, because that
+ * is a thing the reader can actually go and do, and the alternative was guessing between ताऊ and
+ * चाचा and being wrong half the time in a way the family notices immediately.
+ */
+function hindiLine(hindi) {
+  const line = document.createElement('p');
+  line.className = 'r-hindi';
+  // `lang` so a screen reader reaches for a Hindi voice rather than spelling Devanagari in English.
+  line.lang = 'hi';
+
+  const word = document.createElement('b');
+  word.className = 'r-hindi-word';
+  word.textContent = hindi.word;
+  line.append(word);
+
+  const gloss = document.createElement('span');
+  gloss.className = 'r-hindi-gloss';
+  gloss.lang = 'en';
+  gloss.textContent = ` (${hindi.gloss})`;
+  line.append(gloss);
+
+  if (hindi.needsBirthYears) {
+    const nudge = document.createElement('span');
+    nudge.className = 'r-hindi-nudge';
+    nudge.lang = 'en';
+    nudge.textContent = 'Birth years for both brothers would say whether that is ताऊ or चाचा.';
+    line.append(nudge);
+  }
+  return line;
+}
+
 /** One row of the chain: the step's label, and the person it reaches. */
 function chainRow(step) {
   const li = document.createElement('li');
@@ -733,6 +770,19 @@ function renderRelation() {
   if (parts) {
     paintSentence(note, parts);
     box.append(note);
+  }
+
+  /*
+   * The Hindi word, under the English sentence, when Family words is हिन्दी.
+   *
+   * Under rather than instead: the English wording does not change anywhere. This is a second thing
+   * said, not a translation of the first, because the two are not the same statement -- English says
+   * "uncle" and Hindi says which uncle -- and a reader who set this preference is usually the one
+   * being asked to explain the word to somebody else.
+   */
+  if (prefs?.familyWords === 'hi') {
+    const hindi = hindiFor(result, from, to);
+    if (hindi) box.append(hindiLine(hindi));
   }
 
   const chain = document.createElement('ol');
@@ -1851,6 +1901,15 @@ async function boot() {
       applyPrefs();
     } catch { /* the page already has the defaults on it */ }
   }
+
+  // Whoever changed it -- this dialog, the native menu, another window -- the page follows.
+  shell?.onSettingsChanged?.((next) => {
+    const before = prefs;
+    prefs = next;
+    applyPrefs({ redraw: before?.photosOnChart !== prefs.photosOnChart });
+    paintPrefs();
+    if (before?.familyWords !== prefs.familyWords && !$('relate').hidden) renderRelation();
+  });
 
   if (shell) {
     document.body.dataset.shell = 'desktop';

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -1141,3 +1141,43 @@
   box-shadow: 0 0 0 9999px rgba(10, 28, 18, .34);
   pointer-events: none;
 }
+
+/* ------------------------------------------------------------ the Hindi word, under the English */
+
+/*
+ * A second thing said, not a translation of the first.
+ *
+ * English says "uncle"; Hindi says *which* uncle. So this sits under the English sentence rather
+ * than replacing it, and reads as an addition -- which is also how a bilingual family says it out
+ * loud, the word and then the gloss for whoever does not have it.
+ */
+.editor .r-hindi {
+  font-family: var(--serif);
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--ink);
+  margin: 8px 0 0;
+  padding: 10px 12px;
+  background: var(--brass-surface);
+  border-radius: 4px;
+}
+
+/* Devanagari carries more above and below the line than Latin does; it wants the room. */
+.editor .r-hindi-word { font-size: 18px; font-weight: 700; line-height: 1.7; }
+
+/* Spaced with a margin rather than the space in the string: Devanagari's advance swallows it. */
+.editor .r-hindi-gloss { color: var(--ink-soft); font-size: 14px; margin-left: 5px; }
+
+/*
+ * The nudge, where a birth order cannot be settled.
+ *
+ * Not an apology. "पिता के भाई" is what he is; this says which two birth years would sharpen it,
+ * because that is a thing the reader can go and do.
+ */
+.editor .r-hindi-nudge {
+  display: block;
+  margin-top: 6px;
+  font-size: 12.5px;
+  line-height: 1.5;
+  color: var(--ink-faint);
+}

--- a/desktop/renderer/relation.js
+++ b/desktop/renderer/relation.js
@@ -11,6 +11,8 @@
  */
 
 import { displayName, spouseLabel } from '../../site/playground/model.js';
+import { hindiTerm } from '../../site/playground/kinship-hindi.js';
+import { hindiWord } from '../../site/playground/kinship-hi.js';
 
 /**
  * The sentence for an answer, as parts rather than as a string.
@@ -59,6 +61,23 @@ export function sentenceFor(result, from, to) {
    * and the chain says it better than any invented word.
    */
   return null;
+}
+
+/**
+ * The Hindi word for an answer, with its gloss, or null where Hindi has none.
+ *
+ * `word (gloss)` is how bilingual families actually speak, and it is what lets a younger relative
+ * who does not know फूफा still read the answer. The gloss is more precise than English's own kinship
+ * words on purpose: English says "uncle" five ways and the gloss says which one.
+ *
+ * Null everywhere Hindi genuinely has no word -- a second cousin, a relative through two marriages
+ * -- and the panel then says the English sentence it would have said anyway. That is the same thing
+ * a Hindi speaker does mid-conversation, and better than a Devanagari compound nobody says.
+ */
+export function hindiFor(result, from, to) {
+  const term = hindiTerm(result?.kinship, from?.gender ?? 'UNSPECIFIED', to?.gender ?? 'UNSPECIFIED');
+  const entry = hindiWord(term);
+  return entry ? { ...entry, term } : null;
 }
 
 /** What to say when the file does not connect them at all. */

--- a/desktop/renderer/relation.test.js
+++ b/desktop/renderer/relation.test.js
@@ -82,3 +82,109 @@ test('two people the file does not connect are told exactly that', () => {
   assert.match(words, /^Nothing in this file connects Ankit Kumar to Priya Sharma\./);
   assert.match(words, /may still be related — the record simply does not say how/);
 });
+
+/* ------------------------------------------------------------------ the Hindi word */
+
+import { hindiFor } from './relation.js';
+import { buildGraph, relate } from '../../site/playground/model.js';
+
+/** A man, his father's elder brother, and his mother's brother: one English word, two Hindi ones. */
+const bothUncles = () => buildGraph({
+  people: [
+    { id: 'me', name: 'Me', gender: 'MALE', birthDate: '1985' },
+    { id: 'dad', name: 'Dad', gender: 'MALE', birthDate: '1958' },
+    { id: 'mum', name: 'Mum', gender: 'FEMALE', birthDate: '1960' },
+    { id: 'tau', name: 'Tau', gender: 'MALE', birthDate: '1952' },
+    { id: 'mama', name: 'Mama', gender: 'MALE', birthDate: '1956' },
+    { id: 'dada', name: 'Dada', gender: 'MALE', birthDate: '1930' },
+    { id: 'nana', name: 'Nana', gender: 'MALE', birthDate: '1932' },
+  ],
+  relationships: [
+    { from: 'dada', to: 'dad', type: 'PARENT' },
+    { from: 'dada', to: 'tau', type: 'PARENT' },
+    { from: 'nana', to: 'mum', type: 'PARENT' },
+    { from: 'nana', to: 'mama', type: 'PARENT' },
+    { from: 'dad', to: 'me', type: 'PARENT' },
+    { from: 'mum', to: 'me', type: 'PARENT' },
+  ],
+});
+
+const hindiBetween = (graph, from, to) => hindiFor(
+  relate(graph, from, to), graph.people.get(from), graph.people.get(to),
+);
+
+test('the two uncles English cannot tell apart get different Hindi words', () => {
+  // The distinction the whole feature exists for.
+  const graph = bothUncles();
+  assert.strictEqual(relate(graph, 'me', 'tau').term, 'uncle');
+  assert.strictEqual(relate(graph, 'me', 'mama').term, 'uncle');
+
+  assert.strictEqual(hindiBetween(graph, 'me', 'tau').word, 'ताऊ');
+  assert.strictEqual(hindiBetween(graph, 'me', 'mama').word, 'मामा');
+});
+
+test('the gloss says which uncle, so the word can be read by somebody who lacks it', () => {
+  const graph = bothUncles();
+  assert.strictEqual(hindiBetween(graph, 'me', 'tau').gloss, "father's elder brother");
+  assert.strictEqual(hindiBetween(graph, 'me', 'mama').gloss, "mother's brother");
+});
+
+test('where the record cannot settle a birth order, the term says it wants years', () => {
+  // Not an apology: "पिता के भाई" is what he is. The flag is what lets the panel say which two
+  // birth years would sharpen it.
+  const undated = buildGraph({
+    people: [
+      { id: 'me', name: 'Me', gender: 'MALE' },
+      { id: 'dad', name: 'Dad', gender: 'MALE' },
+      { id: 'uncle', name: 'Uncle', gender: 'MALE' },
+      { id: 'dada', name: 'Dada', gender: 'MALE' },
+    ],
+    relationships: [
+      { from: 'dada', to: 'dad', type: 'PARENT' },
+      { from: 'dada', to: 'uncle', type: 'PARENT' },
+      { from: 'dad', to: 'me', type: 'PARENT' },
+    ],
+  });
+
+  const hindi = hindiBetween(undated, 'me', 'uncle');
+  assert.strictEqual(hindi.word, 'पिता के भाई');
+  assert.strictEqual(hindi.needsBirthYears, true);
+});
+
+test('where Hindi has no word, the panel is told nothing rather than something invented', () => {
+  /*
+   * A second cousin has no everyday Hindi word. Returning null is what makes the panel fall back to
+   * the English sentence it was already showing -- which is what a Hindi speaker does in the same
+   * conversation, and better than a Devanagari compound nobody says.
+   */
+  const distant = buildGraph({
+    people: [
+      { id: 'me', name: 'Me', gender: 'MALE' },
+      { id: 'dad', name: 'Dad', gender: 'MALE' },
+      { id: 'granddad', name: 'Granddad', gender: 'MALE' },
+      { id: 'great', name: 'Great', gender: 'MALE' },
+      { id: 'granduncle', name: 'Granduncle', gender: 'MALE' },
+      { id: 'cousin-parent', name: 'CP', gender: 'MALE' },
+      { id: 'second', name: 'Second', gender: 'MALE' },
+    ],
+    relationships: [
+      { from: 'great', to: 'granddad', type: 'PARENT' },
+      { from: 'great', to: 'granduncle', type: 'PARENT' },
+      { from: 'granddad', to: 'dad', type: 'PARENT' },
+      { from: 'granduncle', to: 'cousin-parent', type: 'PARENT' },
+      { from: 'dad', to: 'me', type: 'PARENT' },
+      { from: 'cousin-parent', to: 'second', type: 'PARENT' },
+    ],
+  });
+
+  assert.strictEqual(relate(distant, 'me', 'second').term, 'second cousin');
+  assert.strictEqual(hindiBetween(distant, 'me', 'second'), null);
+});
+
+test('two people the file does not connect get no Hindi word either', () => {
+  const graph = buildGraph({
+    people: [{ id: 'a', name: 'A', gender: 'MALE' }, { id: 'b', name: 'B', gender: 'MALE' }],
+    relationships: [],
+  });
+  assert.strictEqual(hindiBetween(graph, 'a', 'b'), null);
+});

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -63,6 +63,38 @@ stops riding along in every future write.
 Honours **Photographs on the chart**: when it is off the chart is passed *no archive at all*, rather
 than the real one and an instruction to ignore it.
 
+## Family words: English or हिन्दी
+
+Set in Preferences. When it is हिन्दी, an answer in the relation panel gains a second line under the
+English one — `word (gloss)` — and **the English wording does not change anywhere**.
+
+Under rather than instead, because the two are not the same statement. English says "uncle"; Hindi
+says *which* uncle. A reader who set this preference is usually the one being asked to explain the
+word to somebody else, and `दादी (father's mother)` is how a bilingual family actually says it.
+
+Hindi has five words where English has one, and none of them can be reached by translating the
+English. The choice reads `relate(...).kinship`: which parent the line went up through, who it came
+back down through, and — for चाचा against ताऊ — which of the two was born first. That is why the path
+model exists at all.
+
+| | |
+|---|---|
+| `site/playground/kinship-hindi.js` | which word, ported from `graph/HindiKinship.kt` |
+| `site/playground/kinship-hi.js` | how each of the 65 terms is spelled and what it means |
+
+**Null is a real answer.** Hindi has no single word for a second cousin, or a relative through two
+marriages. Where it has none the panel says the English sentence it would have said anyway — which is
+what a Hindi speaker does in the same conversation, and better than a Devanagari compound nobody says.
+
+Where the record cannot settle a birth order, the word is the descriptive one — पिता के भाई, which is
+exactly what he is — and the panel says which two birth years would sharpen it. It does not guess:
+ताऊ and चाचा are told apart by nothing but a date, and being wrong is noticed immediately.
+
+Three tests hold it: the 43-case table from `HindiKinshipTest.kt`; a parity test that reads
+`app/src/main/res/values/kinship_hi.xml` and asserts the JS table matches it exactly in both
+directions; and the every-pair sweep, which cannot be satisfied by luck — *if B is A's मामा then A
+must be B's भांजा or भांजी*, computed independently from opposite ends of the graph.
+
 ## Settings
 
 `Updates > Preferences…`, on `Ctrl+,`. Family words, photographs on the chart, appearance, and the


### PR DESCRIPTION
Last piece of phase 5, and the last item on #89's checklist.

The relation panel gains a second line when **Family words** is हिन्दी:

> Anita Kumar is Aarav Kumar's grandmother.
> दादी *(father's mother)*

**Under, not instead.** The English wording is unchanged — asserted byte-identical
either side of the switch, because the two are not the same statement. English says
"grandmother"; Hindi says *which* grandmother. दादी is the father's mother, नानी the
mother's, and they are not interchangeable. Somebody who sets this preference is
usually the one being asked to explain the word to a younger relative, so both lines
are wanted.

The gloss is what makes it readable to someone who does not have the word — and it
is more precise than English's own kinship vocabulary on purpose. English says
"uncle" five ways; the gloss says which one.

Three places it deliberately says less:

- **No birth years, no guess.** Where the record cannot settle a birth order the word
  is the descriptive one (पिता के भाई), and the panel names the two birth years that
  would sharpen it. Guessing between ताऊ and चाचा would be wrong half the time in a
  way the family notices.
- **No word, no line.** A second cousin, or a relative through two marriages: nothing
  is added and the English stands, which is what a Hindi speaker does in the same
  conversation.
- **`lang="hi"`** on the word, `lang="en"` back on the gloss, so a screen reader
  reaches for a Hindi voice instead of spelling Devanagari in English.

### A real bug the smoke test found

Writing the assertion turned up something already shipped: the page kept its own copy
of the settings, refreshed only when the page itself wrote one. So changing "Offer me
beta releases" from the **native menu** and then opening Preferences showed the
opposite of the truth — the same stale-surface bug the menu rebuild was added to fix,
in the other direction. Settings changes are now pushed to every window, whoever made
them. One value that is one per app should not become one copy per surface.

### Checks

- 269 → **274** desktop tests, **110** engine tests, **81** smoke assertions against
  the packaged binary run unconfined.
- `kinship-golden.txt` byte-identical to main — verified with `git diff --exit-code`.
- `git status --short app/` empty. Nothing under `app/` changes; there are live users.
- Both themes screenshotted with the word on screen.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)
