### PR TITLE
fix(desktop): file Preferences under Settings, not under Updates

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -515,10 +515,16 @@ function buildMenu(win) {
       ],
     },
     {
-      label: 'Updates',
+      // Named for what it holds, which is not only updates. `Preferences…` opens a dialog whose own
+      // sections are Reading and Updates -- so while this menu was called Updates, one of the two
+      // was inside the other both ways round, and `Family words: English / हिन्दी` was filed under a
+      // heading no reader would open to look for it. See #138.
+      //
+      // The two checkboxes stay in the menu rather than only in the dialog. They are the two things
+      // this app must never turn on quietly, and a checkbox you can see without opening anything is
+      // the plainest way to say they are off.
+      label: 'Settings',
       submenu: [
-        { label: 'Check for updates now…', click: () => checkForUpdates(win) },
-        { type: 'separator' },
         {
           label: 'Preferences…',
           accelerator: 'CmdOrCtrl+,',
@@ -549,6 +555,8 @@ function buildMenu(win) {
           label: 'Both are off until you switch them on',
           enabled: false,
         },
+        { type: 'separator' },
+        { label: 'Check for updates now…', click: () => checkForUpdates(win) },
       ],
     },
     {
@@ -1826,6 +1834,53 @@ async function runImportSmoke(win, check) {
   check('the whole import can be undone', after.undo, 'undo is available');
 }
 
+/*
+ * The menu, read back from the app that built it.
+ *
+ * Nothing tested the menu before this. It is assembled inline in `createWindow`, so there is no
+ * template a unit test can import -- `settings.test.js` covers the values behind the checkboxes and
+ * this harness only proved that *a* menu was attached. That is how `Preferences…` came to sit under
+ * a top-level menu called Updates while the dialog it opens has an Updates section of its own (#138):
+ * a naming mistake no check could have caught, because no check was looking.
+ *
+ * So this reads `Menu.getApplicationMenu()` -- the real one, in the real app, after the real build --
+ * and asserts the two things a reader depends on: that the settings live under a name that describes
+ * them, and that the accelerator which opens them is the one every desktop app uses.
+ *
+ * Deliberately not behind an env flag. Every other smoke section is opt-in and CI sets four of them;
+ * this one costs nothing and guards a thing that only breaks when somebody edits the menu, which is
+ * exactly when nobody is running the optional half.
+ */
+async function runMenuSmoke(win, check) {
+  const menu = Menu.getApplicationMenu();
+  const tops = (menu ? menu.items : []).map((item) => item.label);
+
+  check('the app has a menu at all', tops.length > 0, tops.join(' / '));
+
+  // Not `Updates`: it holds Family words and Photographs, which have nothing to do with updating.
+  check('the settings live under a menu named for what it holds', tops.includes('Settings'), 'Settings');
+  check('and not under one named for a section of its own dialog', !tops.includes('Updates'));
+
+  const settings = (menu ? menu.items : []).find((item) => item.label === 'Settings');
+  const labels = settings ? settings.submenu.items.map((item) => item.label) : [];
+
+  // The dialog first. It is the whole of the settings; the two checkboxes are a shortcut to two of
+  // them, and a reader looking for anything else needs to be shown the door that leads there.
+  check('Preferences… is the first thing in it', labels[0] === 'Preferences…', labels[0] || '(empty)');
+
+  const prefs = settings && settings.submenu.items[0];
+  check(
+    'and opens on the accelerator every other desktop app uses for it',
+    Boolean(prefs) && prefs.accelerator === 'CmdOrCtrl+,',
+    prefs ? String(prefs.accelerator) : '(none)',
+  );
+
+  // The two the app must never turn on quietly stay visible without opening anything.
+  for (const label of ['Check for updates automatically', 'Offer me beta releases']) {
+    check(`"${label}" is still a checkbox in the menu`, labels.includes(label));
+  }
+}
+
 async function runSmoke(win, file) {
   const failures = [];
   const iconExists = await fs.access(ICON_FOR_WINDOW).then(() => true, () => false);
@@ -1982,6 +2037,8 @@ async function runSmoke(win, file) {
     }
     check('the updater can reach GitHub through the page-level refusal', reachable, detail);
   }
+
+  await runMenuSmoke(win, check);
 
   if (process.env.FTREE_SMOKE_SAVE_TO) await runEditSmoke(win, check);
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -97,7 +97,7 @@ must be B's भांजा or भांजी*, computed independently from opp
 
 ## Settings
 
-`Updates > Preferences…`, on `Ctrl+,`. Family words, photographs on the chart, appearance, and the
+`Settings > Preferences…`, on `Ctrl+,`. Family words, photographs on the chart, appearance, and the
 two update settings. Every one of them is also in the native menu, and **both surfaces go through
 the same `settings:set`**, which rebuilds the menu from the result.
 
@@ -284,7 +284,7 @@ guards, because there are live users on the app.
 
 ## The updater
 
-Two switches under **Updates**, both off until the reader turns them on, and the same two the
+Two switches under **Settings**, both off until the reader turns them on, and the same two the
 Android app offers for the same reasons:
 
 | | |

--- a/site/desktop/index.html
+++ b/site/desktop/index.html
@@ -182,14 +182,14 @@
         reopen it next time. No account, no server, no telemetry. The window itself is
         <em>refused</em> the network outright — which is why its typefaces are read from disk rather
         than fetched from Google. The only request the app can make is the update check, and that
-        is off until you switch it on in <b>Updates</b>.
+        is off until you switch it on in <b>Settings</b>.
       </p>
     </details>
 
     <details class="folded">
       <summary>How do updates work?</summary>
       <p style="margin:14px 0 0;max-width:40em">
-        Two switches under <b>Updates</b>, both off when you install: <b>check automatically</b>,
+        Two switches under <b>Settings</b>, both off when you install: <b>check automatically</b>,
         which looks once at startup and stays quiet unless there is something to say, and
         <b>offer me betas</b>, which asks before it turns on. Anything downloaded is checked against
         the SHA-256 GitHub published for it before you are offered it to run; if they disagree the

--- a/site/desktop/thanks/index.html
+++ b/site/desktop/thanks/index.html
@@ -137,7 +137,7 @@
     <p style="max-width:40em">
       No account, no upload, no telemetry. The window is refused the network outright — its
       typefaces are read from disk rather than fetched from Google. The only request the app can
-      make is the update check under <b>Updates</b>, and both switches there are off until you turn
+      make is the update check under <b>Settings</b>, and both switches there are off until you turn
       them on.
     </p>
   </div>


### PR DESCRIPTION
`Preferences…` sat in a top-level menu called **Updates** — and the dialog it opens has sections
called **Reading** and **Updates**. One of the two was inside the other, both ways round.

```
Updates                              ← before
  Check for updates now…
  Preferences…              Ctrl+,      ← opens a dialog whose sections are
  Check for updates automatically           Reading  (family words, photographs, appearance)
  Offer me beta releases                    Updates  (the two switches)
```

The cost was not tidiness. **Family words — English / हिन्दी** is the setting this app just grew
five Hindi kinship words for, and a reader wanting it had to open a menu called *Updates* to find
it. Photographs on the chart was filed the same way.

```
Settings                             ← after
  Preferences…              Ctrl+,
  ────
  Check for updates automatically     ☐
  Offer me beta releases              ☐
  Both are off until you switch them on
  ────
  Check for updates now…
```

Everything in it is now either a setting or the one action those settings govern. "Updates"
survives in the only place it was ever accurate: the section heading inside the dialog.

The two checkboxes stay in the menu rather than moving into the dialog alone. They are the two
things this app must never turn on quietly, and a checkbox you can see without opening anything is
the plainest way to say they are off.

### Why a rename needed a new test

**Nothing tested the menu.** It is built inline in `createWindow`, so there is no template a unit
test can import — `settings.test.js` covers the values behind the checkboxes, and the smoke harness
only proved that *a* menu was attached. That is how this mistake shipped: no check was looking.

The harness now reads `Menu.getApplicationMenu()` back out of the running app and asserts the name,
the order, the accelerator, and that both switches are still visible without opening a dialog.

```
ok   the app has a menu at all  File / View / Settings / Help
ok   the settings live under a menu named for what it holds  Settings
ok   and not under one named for a section of its own dialog
ok   Preferences… is the first thing in it  Preferences…
ok   and opens on the accelerator every other desktop app uses for it  CmdOrCtrl+,
ok   "Check for updates automatically" is still a checkbox in the menu
ok   "Offer me beta releases" is still a checkbox in the menu
```

Not behind an env flag, unlike every other smoke section: it costs nothing, and it guards a thing
that only breaks when somebody edits the menu — which is exactly when nobody runs the optional half.

**Verified it can fail.** Reverting the label to `Updates` turns six of the seven red, including
the four that go looking inside a submenu that is no longer there.

### Checks

- 274 desktop tests, 110 engine tests, smoke passing against the real app run unconfined.
- `kinship-golden.txt` unmoved; `git status --short app/` empty.
- The name followed into all five places the docs and site used it: `docs/desktop.md` ×2, the
  download page ×2, the thanks page ×1.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
