### PR TITLE
test(ci): run the other 52 smoke assertions, and fail when a gate is added without one

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -87,6 +87,14 @@ jobs:
           # unit-tested, but the thing that must not regress is that it *asks* -- a strong match
           # merges unless it is refused, and a merge is the one act here nobody can undo by hand.
           FTREE_SMOKE_IMPORT: ${{ runner.temp }}/fixtures/a-cousins-tree.ftree
+          # The four feature sections. These ran nowhere for four phases of work -- 52 of the
+          # harness's 95 assertions -- because the gates were added to the harness and not to here,
+          # which is a thing no file-level guard can see. `smoke-gates.test.js` now fails when the
+          # two disagree, so this list cannot fall behind the harness again.
+          FTREE_SMOKE_COMPACT: '1'
+          FTREE_SMOKE_RELATE: '1'
+          FTREE_SMOKE_SETTINGS: '1'
+          FTREE_SMOKE_PHOTO: '1'
         run: xvfb-run -a npx electron . --no-sandbox
 
   package:
@@ -140,6 +148,19 @@ jobs:
           FTREE_SMOKE: ${{ runner.temp }}/fixtures/sample-family.ftree
           FTREE_SMOKE_SAVE_TO: ${{ runner.temp }}/built-in-the-package.ftree
           FTREE_SMOKE_IMPORT: ${{ runner.temp }}/fixtures/a-cousins-tree.ftree
+          # The updater against the packaged app, not only the checkout. The rule below has no
+          # exceptions on purpose -- and asking for this one turned out to be right rather than
+          # pedantic: the regression it guards reported itself as ERR_BLOCKED_BY_CLIENT, and the
+          # page-level refusal it reaches through is set up from a file that packaging moves.
+          FTREE_SMOKE_NETWORK: '1'
+          # Set here too, and this is the copy that matters most: this is the only run that reads the
+          # *staged* page rather than the checkout, and a page staged wrong is what shipped in 0.4.0.
+          # A feature whose assertions only run against the checkout is a feature that can be missing
+          # from the package and still report green.
+          FTREE_SMOKE_COMPACT: '1'
+          FTREE_SMOKE_RELATE: '1'
+          FTREE_SMOKE_SETTINGS: '1'
+          FTREE_SMOKE_PHOTO: '1'
         run: |
           python3 ../tools/make_sample_tree.py "$RUNNER_TEMP/fixtures"
           xvfb-run -a ./dist/linux-unpacked/f-tree-desktop --no-sandbox

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -58,6 +58,13 @@ jobs:
       # The layout is checked in both orientations here as well as in the site workflow. Both
       # shells draw rows today, but the engine keeps columns and so does this check: an
       # orientation nobody currently ships is exactly the one that rots unnoticed.
+      # Pillow, because `make_sample_tree.py` now refuses to run without it. It used to carry on and
+      # write a fixture with no photographs in it, which no runner has ever had the library to draw --
+      # so every check that reads the sample tree has, until now, been reading a tree with none. A
+      # photograph is the hardest thing in the format to round-trip and the one CI never saw.
+      - name: Pillow, for the photographs in the sample tree
+        run: python3 -m pip install --break-system-packages pillow || python3 -m pip install pillow
+
       - name: Check the layout, rows and columns
         run: |
           python3 tools/make_sample_tree.py "$RUNNER_TEMP/fixtures"
@@ -141,6 +148,14 @@ jobs:
       # uploaded, reading the asar and the staged page that users will actually get. Building a
       # tree and saving it is part of it: a package can start and still be missing the half of
       # itself that only a real edit touches.
+      # Pillow, because `make_sample_tree.py` now refuses to run without it. It used to carry on and
+      # write a fixture with no photographs in it, which no runner has ever had the library to draw --
+      # so every check that reads the sample tree has, until now, been reading a tree with none. A
+      # photograph is the hardest thing in the format to round-trip and the one CI never saw.
+      - name: Pillow, for the photographs in the sample tree
+        if: matrix.os == 'ubuntu-latest'
+        run: python3 -m pip install --break-system-packages pillow || python3 -m pip install pillow
+
       - name: Start the packaged app and build a tree in it
         if: matrix.os == 'ubuntu-latest'
         working-directory: desktop

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,6 +54,13 @@ jobs:
       - name: The engine's rules, ported out of the Kotlin
         run: node --test "site/playground/*.test.mjs"
 
+      # Pillow, because `make_sample_tree.py` now refuses to run without it. It used to carry on and
+      # write a fixture with no photographs in it, which no runner has ever had the library to draw --
+      # so every check that reads the sample tree has, until now, been reading a tree with none. A
+      # photograph is the hardest thing in the format to round-trip and the one CI never saw.
+      - name: Pillow, for the photographs in the sample tree
+        run: python3 -m pip install --break-system-packages pillow || python3 -m pip install pillow
+
       - name: Check the viewer parses and lays out a real archive
         run: |
           set -euo pipefail

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -2040,17 +2040,54 @@ async function runSmoke(win, file) {
 
   await runMenuSmoke(win, check);
 
+  /*
+   * Back to the sample family before each feature section.
+   *
+   * `runEditSmoke` clicks "start a new tree", so every section after it was reading a two-person
+   * tree built from nothing rather than the 23-person fixture whose contents its assertions
+   * describe. It went unseen because each section was only ever run on its own, with its own gate,
+   * while it was being written -- and CI set none of those four gates (#140), so until now no run
+   * had ever contained both halves at once.
+   *
+   * Turning the gates on made two assertions fail immediately, and both were right to:
+   *
+   *   "the sample family has somebody connected to nobody"  -- a tree of two related people has not
+   *   "nobody else's photograph is dropped with it"         -- nor has it four to prune around
+   *
+   * So each section reopens the fixture it was written against instead of inheriting whatever the
+   * section before it left on screen. Sections that share state by accident are the reason a suite
+   * passes in one order and fails in another.
+   */
+  const reopenSample = async () => {
+    await openInto(win, file);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  };
+
   if (process.env.FTREE_SMOKE_SAVE_TO) await runEditSmoke(win, check);
 
-  if (process.env.FTREE_SMOKE_COMPACT) await runCompactSmoke(win, check);
-
-  if (process.env.FTREE_SMOKE_RELATE) await runRelateSmoke(win, check);
-
-  if (process.env.FTREE_SMOKE_SETTINGS) await runSettingsSmoke(win, check);
-
-  if (process.env.FTREE_SMOKE_PHOTO) await runPhotoSmoke(win, check);
-
+  // Import stays directly after the edit: merging a relative's file into *the tree just built* is
+  // the case it was written for, and it is the one section that wants what the edit left behind.
   if (process.env.FTREE_SMOKE_IMPORT) await runImportSmoke(win, check);
+
+  if (process.env.FTREE_SMOKE_COMPACT) {
+    await reopenSample();
+    await runCompactSmoke(win, check);
+  }
+
+  if (process.env.FTREE_SMOKE_RELATE) {
+    await reopenSample();
+    await runRelateSmoke(win, check);
+  }
+
+  if (process.env.FTREE_SMOKE_SETTINGS) {
+    await reopenSample();
+    await runSettingsSmoke(win, check);
+  }
+
+  if (process.env.FTREE_SMOKE_PHOTO) {
+    await reopenSample();
+    await runPhotoSmoke(win, check);
+  }
 
   if (process.env.FTREE_SMOKE_SHOT) {
     const image = await win.webContents.capturePage();

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
     "smoke": "electron . --no-sandbox",
     "pack:linux": "electron-builder --linux",
     "pack:win": "electron-builder --win nsis",
-    "test": "node --test update.test.js atomic.test.js identity.test.js settings.test.js suite.test.js \"renderer/*.test.js\" \"../site/playground/*.test.mjs\"",
+    "test": "node --test update.test.js atomic.test.js identity.test.js settings.test.js smoke-gates.test.js suite.test.js \"renderer/*.test.js\" \"../site/playground/*.test.mjs\"",
     "test:package": "node --test package.test.js"
   },
   "devDependencies": {

--- a/desktop/smoke-gates.test.js
+++ b/desktop/smoke-gates.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/*
+ * Every gate the smoke harness knows must be one the workflow sets.
+ *
+ * This is #117 a second time, and the reason it needed a second guard is worth keeping.
+ *
+ * #118 added `suite.test.js`, which proves every `*.test.js` file is claimed by an npm script. It
+ * reasons about *files*. The smoke harness is one file, claimed by one command, and its sections are
+ * gated on environment variables set in a workflow -- so there is no unclaimed file for that guard to
+ * find, and 52 of 95 assertions ran nowhere for four phases of work without anything going red.
+ *
+ * The rule here is deliberately about the harness rather than a list: a gate added to `main.js` and
+ * not to `desktop.yml` fails, so the next feature cannot repeat this quietly. Nobody has to remember.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const MAIN = fs.readFileSync(path.join(__dirname, 'main.js'), 'utf8');
+const WORKFLOW = fs.readFileSync(
+  path.join(__dirname, '..', '.github', 'workflows', 'desktop.yml'),
+  'utf8',
+);
+
+/*
+ * `FTREE_SMOKE` itself is the file to open, not a gate, and every step that runs the harness sets it
+ * by definition or the harness refuses to start.
+ *
+ * `FTREE_SMOKE_SHOT*` are excluded by name and not by accident: they write a PNG for a person to look
+ * at and assert nothing. Requiring CI to set them would mean uploading screenshots no test reads.
+ */
+const NOT_A_GATE = (name) => name === 'FTREE_SMOKE' || name.startsWith('FTREE_SMOKE_SHOT');
+
+function gatesInHarness() {
+  const found = new Set();
+  for (const [, name] of MAIN.matchAll(/process\.env\.(FTREE_SMOKE[A-Z_]*)/g)) {
+    if (!NOT_A_GATE(name)) found.add(name);
+  }
+  return [...found].sort();
+}
+
+/*
+ * Each `- name:` block is one step. A step that mentions any gate is a step that runs the harness,
+ * and there is more than one: the `smoke` job runs it from the checkout, and `package` runs it again
+ * against the built binary. The second is the only check that reads the *staged* page, which is where
+ * 0.4.0's two packaging mistakes lived, so a gate set in one and not the other is half a check.
+ */
+function stepsThatRunTheHarness() {
+  return WORKFLOW.split(/^ {6}- name: /m)
+    .slice(1)
+    .map((block) => ({ name: block.split('\n')[0].trim(), text: block }))
+    .filter((step) => /FTREE_SMOKE/.test(step.text));
+}
+
+test('the workflow sets every gate the harness reads', () => {
+  const gates = gatesInHarness();
+
+  // If this is ever empty the test has stopped testing anything -- a rename in main.js would do it.
+  assert.ok(gates.length >= 4, `found only ${gates.length} gates in main.js; the pattern has rotted`);
+
+  const steps = stepsThatRunTheHarness();
+  assert.ok(steps.length >= 2, `expected the harness to run in at least two steps, found ${steps.length}`);
+
+  for (const step of steps) {
+    const missing = gates.filter((gate) => !step.text.includes(gate));
+    assert.deepStrictEqual(
+      missing,
+      [],
+      `"${step.name}" runs the smoke harness but never sets ${missing.join(', ')} — `
+        + 'those assertions will not run in CI',
+    );
+  }
+});
+
+test('the gates it excludes are excluded for a stated reason, not by omission', () => {
+  // Screenshot writers assert nothing; the base variable is the file to open. Both are named above.
+  assert.ok(NOT_A_GATE('FTREE_SMOKE'));
+  assert.ok(NOT_A_GATE('FTREE_SMOKE_SHOT'));
+  assert.ok(NOT_A_GATE('FTREE_SMOKE_SHOT_RELATE'));
+  assert.ok(!NOT_A_GATE('FTREE_SMOKE_RELATE'), 'a feature gate must never read as a screenshot');
+  assert.ok(!NOT_A_GATE('FTREE_SMOKE_COMPACT'));
+});

--- a/docs/site.md
+++ b/docs/site.md
@@ -68,9 +68,16 @@ Everything happens in the tab. The file is never uploaded, there is no analytics
 the only thing stored is four display preferences in `localStorage`.
 
 ```bash
+python3 -m pip install pillow                     # needed: the sample tree has photographs in it
 python3 tools/make_sample_tree.py /tmp/fixtures   # .ftree files, including odd ones
 node tools/check_layout.mjs /tmp/fixtures         # layout invariants, run in CI
 ```
+
+The generator **refuses to run** without Pillow rather than writing a photo-less archive, which is
+what it used to do. No CI runner had the library, so every fixture CI built was missing the four
+photographs the sample family is supposed to have — and a photograph is the hardest thing in the
+format to round-trip. A tool that quietly emits different test data depending on what is installed
+is worse than one that will not start.
 
 To preview it locally:
 

--- a/tools/make_sample_tree.py
+++ b/tools/make_sample_tree.py
@@ -22,6 +22,26 @@ try:
 except ImportError:
     Image = None
 
+# Pillow is not optional, and it used to be treated as though it were.
+#
+# `jpeg()` returned None without it and `with_photo` quietly skipped the person, so the script still
+# exited 0 and still wrote a valid archive -- just one with no photographs in it. No CI runner has
+# ever had Pillow installed, so every fixture CI has ever built has been photo-less, and everything
+# downstream has been checking a tree that does not contain the one thing hardest to round-trip:
+# the binary payload. `check_writer.mjs` compares a written archive against what Android's reader
+# would see and never once saw a photo entry.
+#
+# A tool that silently emits different test data depending on what happens to be installed is worse
+# than one that will not run. So it will not run.
+def require_pillow():
+    if Image is None:
+        sys.exit(
+            "make_sample_tree.py needs Pillow to draw the photographs in the sample tree.\n"
+            "Without it this script would write a valid archive with no photographs in it, and\n"
+            "every check downstream would pass while never once reading a photo entry.\n\n"
+            "    python3 -m pip install pillow\n"
+        )
+
 
 def pid(seed):
     return str(uuid.uuid5(uuid.NAMESPACE_URL, f"f-tree/{seed}"))
@@ -74,8 +94,6 @@ class Tree:
 
 
 def jpeg(colour, label):
-    if Image is None:
-        return None
     img = Image.new("RGB", (200, 200), colour)
     draw = ImageDraw.Draw(img)
     draw.ellipse((40, 30, 160, 150), fill=(255, 255, 255, 60))
@@ -129,8 +147,6 @@ def sample():
     photos = {}
 
     def with_photo(key, colour, label):
-        if Image is None:
-            return None
         name = f"{pid(key)[:8]}.jpg"
         photos[name] = jpeg(colour, label)
         return name
@@ -300,6 +316,8 @@ def cousins():
 
 
 if __name__ == "__main__":
+    require_pillow()
+
     out = Path(sys.argv[1] if len(sys.argv) > 1 else ".")
     out.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
The smoke harness gates each feature section on an environment variable. **CI set four of them and
not the other four.** On the same fixture, same binary:

```
CI's four gates      43 assertions
all eight            95 assertions
```

**52 assertions ran nowhere** — every one covering compact view, the relation finder, settings and
photos. Four phases of this work shipped with in-app coverage that had only ever run on my laptop.

### Why the existing guard couldn't see it

#118 added `suite.test.js` after #117, and it does its job: every `*.test.js` must be claimed by an
npm script. But it reasons about **files**. The harness is one file, claimed by one command, whose
sections are gated by **environment variables in a workflow**. No unclaimed file, so nothing red.

`smoke-gates.test.js` closes that: every `process.env.FTREE_SMOKE_*` the harness reads must be set
by every workflow step that runs it. `FTREE_SMOKE_SHOT*` is excluded by name and for a stated
reason — those write a PNG for a person to look at and assert nothing.

Both steps, not one. The `package` job's run is the only check that reads the **staged** page rather
than the checkout, and a page staged wrong is what shipped in 0.4.0.

### Turning the gates on failed immediately, twice

Both were right to. `runEditSmoke` clicks *"start a new tree"*, so every section after it had been
reading a **two-person tree built from nothing** rather than the 23-person fixture its assertions
describe:

```
FAIL  the sample family has somebody connected to nobody  none found — this case went unchecked
FAIL  and nobody else's photograph is dropped with it     0 still in use
```

A tree of two related people has nobody connected to nobody, and has no four photographs to prune
around. Invisible until now because each section was only ever run alone, with its own gate, while
it was being written — and CI set none of those gates, so no single run had ever held both halves.

Each section now reopens the fixture it was written against instead of inheriting what the last one
left on screen. Import stays directly after the edit: merging into *the tree just built* is the case
it was written for.

### The gain is not only the count

That first failure is a fallback branch which was reporting *"this case went unchecked"* **and
passing anyway**. It now runs for real:

```
ok  two people the file does not connect are told exactly that
    Nothing in this file connects Aarav Kumar to Ishwar Dutt. They may still be related —
    the record simply does not say how.
ok  and are not shown a chain that does not exist  0 steps
```

And the new guard asked for something I had not intended, correctly: **the packaged run never
checked the network refusal.** Set rather than carved out — the rule is better with no exceptions to
remember, and that regression reported itself as `ERR_BLOCKED_BY_CLIENT` from a file packaging moves.

### Checks

- **43 → 99** smoke assertions in CI. **274 → 276** tests.
- Verified the guard fails by leaving a gate out; verified the full run green with all eight set.
- `kinship-golden.txt` unmoved; `git status --short app/` empty.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)
