### PR TITLE
chore(desktop): 0.5.0, and the pre-release flag keeps only its real reason

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -10,14 +10,17 @@ name: Desktop
 # the ordinary channel reads - answering with the newest *app* release. Two independent reasons a
 # phone will never be offered an .AppImage, because there are live users on the app.
 #
-# The pre-release flag now carries a second meaning as well: the desktop app stays a pre-release
-# until issue #89 is finished. It builds a tree as well as reading one now, but the parity that
-# issue asks for is not there yet, so calling any build of it a stable release would claim a
-# completeness it does not have.
+# The flag used to carry a second meaning, and no longer does. Until #89 closed it also meant "not
+# finished yet": the desktop could read a tree but not build one, and calling such a build stable
+# would have claimed a completeness it did not have. #89's parity checklist is done, so that reason
+# is spent. The flag stays for the mechanical reason above, which does not expire and must not be
+# removed on the grounds that the app is finished now - the two were never the same argument.
 #
 # Worth keeping straight, because the two senses of "beta" are not the same mechanism:
 #
-#   GitHub's pre-release flag  ->  how finished this is. Set on every desktop release.
+#   GitHub's pre-release flag  ->  which project `releases/latest` answers for. Set on every desktop
+#                                  release, permanently, so that endpoint keeps naming an *app*
+#                                  release. Says nothing about how finished the desktop app is.
 #   the tag's suffix           ->  the app's own beta channel. `desktop-v0.3.3` is stable to it;
 #                                  `desktop-v0.3.3-beta.1` is not. See update.js.
 #
@@ -221,7 +224,7 @@ jobs:
             Chromium a working sandbox helper without you touching anything; the portable
             \`.tar.gz\` and the \`.AppImage\` need one \`sudo chmod 4755\` on Ubuntu 24.04+.
 
-          Marked a pre-release on purpose, for two reasons. It keeps the Android app's update
-          channel pointing at Android releases; and the desktop app stays a pre-release until
-          [#89](https://github.com/thisisankit27/f-tree/issues/89) is done: it builds a tree as
-          well as reading one now, but it is not yet the equal of the phone app."
+          Marked a pre-release on purpose, and that is **not** a statement about how finished this
+          is. It is what keeps the Android app's update channel answering with Android releases, so
+          nobody's phone is ever offered a desktop installer. See the note at the top of
+          \`.github/workflows/desktop.yml\`."

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "f-tree-desktop",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "f-tree-desktop",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "electron": "^33.2.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "f-tree-desktop",
   "productName": "f-tree",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A local-first family tree, on your own machine",
   "author": {
     "name": "thisisankit27",


### PR DESCRIPTION
The last of #89. The parity checklist is done, so the pre-release flag's second meaning is spent.

### The flag meant two things; now it means one

| | |
|---|---|
| **Mechanical** | Publishing as a pre-release keeps `releases/latest` — the endpoint the Android app's *ordinary* update channel reads — answering with the newest **app** release. A phone is never offered an `.AppImage`. |
| **A judgement** | The desktop stayed a pre-release until it was the equal of the phone app. |

The judgement no longer applies. The mechanism does, permanently.

The comment now says that explicitly, **including that the flag must not be removed on the grounds
that the app is finished now** — because the two were never the same argument. Somebody will
eventually read "the desktop app is done" and reach for this flag; the note is there for them.

The tag prefix stays exactly as it was: `AppVersion.parse` cannot match `desktop-v0.5.0`, so a
desktop release is invisible to both Android channels. Two independent guards, because there are
live users on the app.

The published release notes carried the same claim and now carry the honest version: *marked a
pre-release on purpose, and that is not a statement about how finished this is.*

### 0.5.0, not 1.0.0

Compact view, the relation finder, settings, photographs and Hindi kinship make this a feature
release. Parity with the phone app is a real milestone — but GitHub will still label the download a
**Pre-release**, and a `1.0.0` under that badge invites exactly the confusion the new note on the
download page exists to prevent.

### One piece of drift fixed on the way

`package-lock.json` said **0.1.0**. It has never been bumped alongside `package.json`, and nothing
noticed because nothing reads it for the app version. Corrected to match rather than left to drift
further; the two dependencies that legitimately sit at 0.1.0 were left alone.

### Checks

- 276 desktop tests, 110 engine tests, 99 smoke assertions.
- `git status --short app/` empty. Nothing under `app/` has changed in any of the fifteen PRs.
- Workflow parses; the tag-prefix paragraphs are untouched.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)
