### PR TITLE
fix: dead card areas, dark-mode toasts, and a wordmark that looked like a link (#144, #145, #146)

### DIFF
--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -26,7 +26,7 @@
  * Somebody mid-edit knows they are mid-edit; the dot is for coming back to a window after lunch.
  */
 .editor .unsaved {
-  color: var(--accent, #c56a3a);
+  color: var(--accent);
   font-size: 20px;
   line-height: 1;
   margin-left: 2px;
@@ -87,8 +87,8 @@
   font: inherit;
   font-size: 13.5px;
   color: inherit;
-  background: var(--sunk, rgba(0, 0, 0, 0.04));
-  border: 1px solid var(--rule, rgba(0, 0, 0, 0.14));
+  background: var(--sunk);
+  border: 1px solid var(--rule);
   border-radius: 8px;
   padding: 7px 9px;
   width: 100%;
@@ -104,7 +104,7 @@
 .editor .field input:focus-visible,
 .editor .field select:focus-visible,
 .editor .field textarea:focus-visible {
-  outline: 2px solid var(--accent, #c56a3a);
+  outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
 
@@ -130,7 +130,7 @@
 .editor .check input {
   width: 15px;
   height: 15px;
-  accent-color: var(--accent, #c56a3a);
+  accent-color: var(--accent);
 }
 
 /* ------------------------------------------------------------------ relatives */
@@ -169,7 +169,7 @@
 }
 
 .editor .rel-list li:hover {
-  background: var(--sunk, rgba(0, 0, 0, 0.04));
+  background: var(--sunk);
 }
 
 .editor .rel-go {
@@ -219,7 +219,7 @@
 
 .editor .rel-cut:hover {
   opacity: 1;
-  color: var(--danger, #b3402f);
+  color: var(--danger);
 }
 
 .editor .rel-empty {
@@ -232,7 +232,7 @@
 
 .editor .add-rel {
   margin-top: 10px;
-  border: 1px dashed var(--rule, rgba(0, 0, 0, 0.18));
+  border: 1px dashed var(--rule);
   border-radius: 10px;
   padding: 12px;
 }
@@ -248,7 +248,7 @@
   font: inherit;
   font-size: 12.5px;
   color: inherit;
-  background: var(--sunk, rgba(0, 0, 0, 0.04));
+  background: var(--sunk);
   border: 1px solid transparent;
   border-radius: 7px;
   padding: 6px 4px;
@@ -256,7 +256,7 @@
 }
 
 .editor .kinds button[aria-pressed='true'] {
-  border-color: var(--accent, #c56a3a);
+  border-color: var(--accent);
   font-weight: 600;
 }
 
@@ -279,8 +279,8 @@
   margin: 10px 0 0;
   padding: 9px 11px;
   border-radius: 8px;
-  background: color-mix(in srgb, var(--danger, #b3402f) 12%, transparent);
-  border: 1px solid color-mix(in srgb, var(--danger, #b3402f) 34%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 34%, transparent);
   font-size: 12.5px;
   line-height: 1.45;
 }
@@ -288,22 +288,22 @@
 .editor .danger-row {
   margin-top: 26px;
   padding-top: 14px;
-  border-top: 1px solid var(--rule, rgba(0, 0, 0, 0.12));
+  border-top: 1px solid var(--rule);
 }
 
 .editor .btn-danger {
   font: inherit;
   font-size: 12.5px;
-  color: var(--danger, #b3402f);
+  color: var(--danger);
   background: none;
-  border: 1px solid color-mix(in srgb, var(--danger, #b3402f) 40%, transparent);
+  border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
   border-radius: 8px;
   padding: 6px 11px;
   cursor: pointer;
 }
 
 .editor .btn-danger:hover {
-  background: color-mix(in srgb, var(--danger, #b3402f) 12%, transparent);
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
 }
 
 /* ------------------------------------------------------------------ toast */
@@ -317,14 +317,15 @@
   max-width: min(560px, 88vw);
   padding: 10px 16px;
   border-radius: 999px;
-  background: var(--ink, #1b1f1a);
-  color: var(--paper, #f7f6f1);
+  background: var(--ink);
+  color: var(--paper);
   font-size: 13px;
   box-shadow: 0 6px 26px rgba(0, 0, 0, 0.22);
 }
 
 .editor .toast[data-tone='bad'] {
-  background: var(--danger, #b3402f);
+  background: var(--danger);
+  color: var(--on-danger);
   border-radius: 12px;
   white-space: pre-line;
   text-align: left;
@@ -384,7 +385,7 @@
 
 /* Which person the panel is currently editing, marked where the eye already is. */
 .editor .index-row[aria-current='true'] {
-  outline: 2px solid var(--accent, #c56a3a);
+  outline: 2px solid var(--accent);
   outline-offset: -2px;
   border-radius: 8px;
 }
@@ -595,7 +596,7 @@
 }
 
 .editor .pair-choice button:focus-visible {
-  outline: 2px solid var(--accent, #c56a3a);
+  outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
 

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -41,7 +41,7 @@
 <div class="viewer editor" id="viewer" data-state="empty">
 
   <header class="bar">
-    <span class="wordmark" title="f-tree">
+    <span class="wordmark">
       <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
         <rect x="3" y="3" width="18" height="18" rx="5"/>
         <circle cx="9" cy="9" r="1.9"/><circle cx="15" cy="9" r="1.9"/><circle cx="12" cy="16" r="1.9"/>

--- a/desktop/renderer/link-affordance.test.js
+++ b/desktop/renderer/link-affordance.test.js
@@ -1,0 +1,52 @@
+/*
+ * Only a link looks like a link.
+ *
+ * #146: the website's stylesheet underlined `.wordmark` on hover. On the website the wordmark is an
+ * anchor back to the landing page, so that was right. The desktop app loads the same stylesheet and
+ * uses the same class on a <span>, because an app window has nowhere to go -- and the rule, matched
+ * on the class rather than the element, underlined it anyway. Hovering the title bar promised a
+ * click that did nothing.
+ *
+ * The rule here is general rather than about the wordmark: a hover underline is only ever given to
+ * an anchor. (`.link-btn` is underlined at rest, on purpose, and is not a hover rule.)
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SHEETS = {
+  'playground.css': readFileSync(path.join(here, '..', '..', 'site', 'playground', 'playground.css'), 'utf8'),
+  'editor.css': readFileSync(path.join(here, 'editor.css'), 'utf8'),
+};
+
+/** Each rule as [selector, body], comments removed so a selector inside one is not counted. */
+function rules(css) {
+  const bare = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  return [...bare.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(([, selector, body]) => [selector.trim(), body]);
+}
+
+test('a hover underline is only ever given to an anchor', () => {
+  const offenders = [];
+  for (const [file, css] of Object.entries(SHEETS)) {
+    for (const [selectors, body] of rules(css)) {
+      if (!/text-decoration\s*:\s*underline/.test(body)) continue;
+      for (const selector of selectors.split(',').map((s) => s.trim())) {
+        if (!selector.includes(':hover')) continue;
+        // The compound that is hovered must name the element `a`, not only a class an anchor has.
+        const hovered = selector.split(/\s+|>|\+|~/).find((part) => part.includes(':hover'));
+        if (!/^a[.:#[]/.test(hovered)) offenders.push(`${file}: ${selector}`);
+      }
+    }
+  }
+  assert.deepStrictEqual(offenders, []);
+});
+
+test('the desktop wordmark is not an anchor, so nothing may underline it', () => {
+  const html = readFileSync(path.join(here, 'index.html'), 'utf8');
+  assert.match(html, /<span class="wordmark">/);
+  assert.doesNotMatch(html, /<a[^>]*class="wordmark"/);
+});

--- a/desktop/renderer/theme-tokens.test.js
+++ b/desktop/renderer/theme-tokens.test.js
@@ -1,0 +1,135 @@
+/*
+ * Every colour the desktop asks for exists, in both themes.
+ *
+ * #145: four tokens -- --paper, --danger, --accent and --sunk -- were used seventeen times and
+ * defined nowhere. Each use carried an inline fallback, and every fallback was a daytime colour, so
+ * the page looked right by day purely by accident and drew near-white text on a near-white toast by
+ * night (about 1.09:1). Nothing was looking, which is the part worth fixing.
+ *
+ * So this reads the two stylesheets the desktop loads and asserts the whole class rather than the
+ * four instances: nothing used is undefined, nothing hides behind a fallback, every colour the day
+ * theme sets the night theme sets too, and the pairs a person has to read clear 4.5:1 in both.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const PLAYGROUND = readFileSync(path.join(here, '..', '..', 'site', 'playground', 'playground.css'), 'utf8');
+const EDITOR = readFileSync(path.join(here, 'editor.css'), 'utf8');
+
+/** The declarations inside the first rule whose selector line is exactly `selector {`. */
+function block(css, selector) {
+  const start = css.indexOf(`\n${selector} {\n`);
+  assert.ok(start >= 0, `no rule for ${selector} -- has the stylesheet been restructured?`);
+  const body = css.slice(start, css.indexOf('\n}', start));
+  const tokens = new Map();
+  for (const [, name, value] of body.matchAll(/^\s*(--[a-z0-9-]+)\s*:\s*([^;]+);/gm)) {
+    tokens.set(name, value.trim());
+  }
+  return tokens;
+}
+
+const LIGHT = block(PLAYGROUND, '.viewer');
+const DARK = block(PLAYGROUND, ':root[data-theme="dark"] .viewer');
+
+/** Tokens the editor defines for itself, on its own elements. */
+const EDITOR_OWN = new Set([...EDITOR.matchAll(/^\s*(--[a-z0-9-]+)\s*:/gm)].map((m) => m[1]));
+
+/*
+ * Colours that are deliberately the same by day and by night, each with its reason. Anything not
+ * here that the day theme sets as a colour must be set again for the night.
+ */
+const SAME_IN_BOTH = new Map([
+  ['--sage', 'the pale green is the same hue in both themes; only its role changes, via --forest'],
+  ['--forest-deep', 'a scrim and the day hover; darkening what is behind a sheet is right in both'],
+]);
+
+const isColour = (value) => /#[0-9a-f]{3,8}\b|rgba?\(/i.test(value);
+
+test('every token either stylesheet uses is defined', () => {
+  const used = new Set();
+  for (const css of [PLAYGROUND, EDITOR]) {
+    for (const [, name] of css.matchAll(/var\((--[a-z0-9-]+)/g)) used.add(name);
+  }
+  const missing = [...used].filter((name) => !LIGHT.has(name) && !EDITOR_OWN.has(name));
+  assert.deepStrictEqual(missing, [], `used but never defined: ${missing.join(', ')}`);
+});
+
+test('no var() carries a fallback that could stand in for a missing token', () => {
+  // A fallback is how #145 stayed hidden: the token did not exist, and the fallback was a daytime
+  // colour that looked right half the time. Without one, a missing token shows at once.
+  for (const [file, css] of [['playground.css', PLAYGROUND], ['editor.css', EDITOR]]) {
+    const found = [...css.matchAll(/var\(--[a-z0-9-]+\s*,[^)]*\)/g)].map((m) => m[0]);
+    assert.deepStrictEqual(found, [], `${file} has fallbacks: ${found.join(' ')}`);
+  }
+});
+
+test('every colour the day theme sets, the night theme sets too', () => {
+  const unthemed = [...LIGHT]
+    // An alias follows whatever it points at, so it flips with its target.
+    .filter(([, value]) => isColour(value) && !value.startsWith('var('))
+    .map(([name]) => name)
+    .filter((name) => !DARK.has(name) && !SAME_IN_BOTH.has(name));
+  assert.deepStrictEqual(unthemed, [], `set by day and never by night: ${unthemed.join(', ')}`);
+});
+
+test('the tokens #145 found missing are defined in both themes, or alias one that is', () => {
+  for (const name of ['--paper', '--danger', '--accent', '--sunk']) {
+    assert.ok(LIGHT.has(name), `${name} is not defined for the day theme`);
+    const value = LIGHT.get(name);
+    const alias = /^var\((--[a-z0-9-]+)\)$/.exec(value)?.[1];
+    assert.ok(DARK.has(name) || (alias && DARK.has(alias)),
+      `${name} does not change for the night theme`);
+  }
+  // A darkening wash on a dark surface is invisible, so the well has to go the other way at night.
+  assert.notStrictEqual(LIGHT.get('--sunk'), DARK.get('--sunk'));
+});
+
+/* ------------------------------------------------------------------ contrast */
+
+function resolve(theme, name, seen = new Set()) {
+  const value = theme.get(name);
+  assert.ok(value, `${name} has no value`);
+  const alias = /^var\((--[a-z0-9-]+)\)$/.exec(value)?.[1];
+  if (!alias) return value;
+  assert.ok(!seen.has(alias), `${name} is an alias loop`);
+  return resolve(theme, alias, seen.add(alias));
+}
+
+function luminance(hex) {
+  const clean = hex.replace('#', '');
+  const full = clean.length === 3 ? [...clean].map((c) => c + c).join('') : clean;
+  const [r, g, b] = [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16) / 255)
+    .map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrast(a, b) {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/* The pairs a person has to read, as the stylesheets pair them: [text, ground, where]. */
+const PAIRS = [
+  ['--paper', '--ink', 'the ordinary toast'],
+  ['--on-danger', '--danger', 'a refusal toast'],
+  ['--ink', '--brass-surface', 'a warning toast'],
+  ['--danger', '--raised', '"Delete this person" on the panel'],
+  ['--ink', '--raised', 'the panel itself'],
+];
+
+for (const [label, overrides] of [['day', new Map()], ['night', DARK]]) {
+  test(`every pair a person has to read clears 4.5:1 by ${label}`, () => {
+    const theme = new Map([...LIGHT, ...overrides]);
+    const failing = [];
+    for (const [text, ground, where] of PAIRS) {
+      const ratio = contrast(resolve(theme, text), resolve(theme, ground));
+      if (ratio < 4.5) failing.push(`${where}: ${text} on ${ground} is ${ratio.toFixed(2)}:1`);
+    }
+    assert.deepStrictEqual(failing, []);
+  });
+}

--- a/site/playground/chart-hit.test.mjs
+++ b/site/playground/chart-hit.test.mjs
@@ -1,0 +1,126 @@
+/*
+ * Which card is under the pointer.
+ *
+ * chart.js went without a test from the day it was written, and this is what that cost: the spatial
+ * index filed each card in the one 400x400 bucket holding its top-left corner, while a card is
+ * 188x64 and the lookup reads only the bucket under the click. Any card straddling a bucket edge was
+ * dead in the part that spilled across it -- up to 150px of a 188px card, leaving a strip at the
+ * left that happened to be where the photograph is drawn. Reported as "only clickable near the
+ * photo" on a 150-person tree, and present in the website viewer too, because it shares the file.
+ *
+ * Everything that asks "which person is here?" goes through this one function: hover, the click
+ * that opens the person panel, and the double-click that centres. So it is tested on its own,
+ * without a canvas, in both orientations the engine can draw.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { openArchive, parseDocument } from './archive.js';
+import { buildGraph } from './model.js';
+import { layoutArchive, METRICS } from './layout.js';
+import { spatialIndex, nodeAtPoint, HIT_CELL } from './chart.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const FAMILY = path.join(here, 'sample-family.ftree');
+
+const { NODE_W, NODE_H } = METRICS;
+
+function hit(nodes, x, y) {
+  return nodeAtPoint(spatialIndex(nodes, METRICS), METRICS, x, y)?.id ?? null;
+}
+
+/** Every point a reader could reasonably click on a card: the four corners and the middle. */
+function pointsOn(node) {
+  return [
+    ['top-left', node.x, node.y],
+    ['top-right', node.x + NODE_W, node.y],
+    ['bottom-left', node.x, node.y + NODE_H],
+    ['bottom-right', node.x + NODE_W, node.y + NODE_H],
+    ['centre', node.x + NODE_W / 2, node.y + NODE_H / 2],
+  ];
+}
+
+test('the cell is the one these cases were measured against', () => {
+  // The cases below place cards across the edge of a 400-unit cell. If the cell changes they stop
+  // straddling anything and pass for the wrong reason.
+  assert.strictEqual(HIT_CELL, 400);
+});
+
+test('a card straddling a vertical bucket edge is live on both sides of it', () => {
+  // Spans x 300..488, so the edge at 400 runs through it.
+  const nodes = [{ id: 'a', x: 300, y: 20 }];
+  assert.strictEqual(hit(nodes, 320, 50), 'a', 'left of the edge');
+  assert.strictEqual(hit(nodes, 470, 50), 'a', 'right of the edge -- the part that was dead');
+});
+
+test('a card straddling a horizontal bucket edge is live above and below it', () => {
+  // Spans y 370..434.
+  const nodes = [{ id: 'a', x: 20, y: 370 }];
+  assert.strictEqual(hit(nodes, 100, 380), 'a', 'above the edge');
+  assert.strictEqual(hit(nodes, 100, 425), 'a', 'below the edge');
+});
+
+test('a card over a corner of four buckets is live in all four', () => {
+  // Spans x 300..488 and y 370..434, so it sits in four cells at once.
+  const nodes = [{ id: 'a', x: 300, y: 370 }];
+  for (const [x, y] of [[320, 380], [480, 380], [320, 430], [480, 430]]) {
+    assert.strictEqual(hit(nodes, x, y), 'a', `at ${x},${y}`);
+  }
+});
+
+test('a card across the origin is live at negative coordinates too', () => {
+  // `Math.floor` of a negative number rounds away from zero; a truncating index would lose this.
+  const nodes = [{ id: 'a', x: -100, y: -30 }];
+  assert.strictEqual(hit(nodes, -90, -20), 'a');
+  assert.strictEqual(hit(nodes, 80, 30), 'a');
+});
+
+test('the gap between two cards is still nobody', () => {
+  // The fix files a card in every bucket it touches. That must not make the bucket's whole area
+  // answer for it: between two cards is empty paper, and clicking it deselects.
+  const nodes = [{ id: 'a', x: 0, y: 0 }, { id: 'b', x: 300, y: 0 }];
+  assert.strictEqual(hit(nodes, 240, 30), null, 'between the two cards');
+  assert.strictEqual(hit(nodes, 100, 200), null, 'below them, in the same bucket');
+  assert.strictEqual(hit(nodes, 100, 30), 'a');
+  assert.strictEqual(hit(nodes, 400, 30), 'b');
+});
+
+test('a point on no card at all, in a bucket nobody is in, is nobody', () => {
+  assert.strictEqual(hit([{ id: 'a', x: 0, y: 0 }], 5000, 5000), null);
+});
+
+/** `openArchive` wants an ArrayBuffer; `readFile` gives a Buffer over a shared one. */
+async function familyGraph() {
+  const buffer = await readFile(FAMILY);
+  const bytes = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
+  const archive = await openArchive(bytes);
+  return buildGraph(parseDocument(await archive.readText('tree.json')));
+}
+
+for (const orientation of ['rows', 'columns']) {
+  test(`every card in the sample family answers at its corners and centre (${orientation})`, async () => {
+    const graph = await familyGraph();
+    const layout = layoutArchive(graph, { orientation });
+    const index = spatialIndex(layout.nodes, layout.metrics);
+
+    // A fixture where nothing straddles a bucket edge would pass on the old code too, and prove
+    // nothing. Measured on this one: rows 38%, columns 54% of cards cross an edge.
+    const straddling = layout.nodes.filter((n) => (
+      Math.floor(n.x / HIT_CELL) !== Math.floor((n.x + NODE_W) / HIT_CELL)
+      || Math.floor(n.y / HIT_CELL) !== Math.floor((n.y + NODE_H) / HIT_CELL)));
+    assert.ok(straddling.length > 0, 'the fixture must contain cards that cross a bucket edge');
+
+    const missed = [];
+    for (const node of layout.nodes) {
+      for (const [where, x, y] of pointsOn(node)) {
+        const found = nodeAtPoint(index, layout.metrics, x, y)?.id ?? null;
+        if (found !== node.id) missed.push(`${node.id} ${where} -> ${found}`);
+      }
+    }
+    assert.deepStrictEqual(missed, [], `${missed.length} points missed their own card`);
+  });
+}

--- a/site/playground/chart.js
+++ b/site/playground/chart.js
@@ -71,6 +71,45 @@ function roundRect(ctx, x, y, w, h, r) {
   ctx.closePath();
 }
 
+/** The side of one bucket in the hit-test grid, in layout units. */
+export const HIT_CELL = 400;
+
+/**
+ * A coarse grid over the cards, so hit testing costs one bucket rather than a scan of every card.
+ *
+ * Each card is filed in **every** bucket its box overlaps, not only the one holding its top-left
+ * corner. A card is 188x64 and a bucket 400 square, so roughly half of all cards cross a bucket
+ * edge; filed by corner alone, the part of such a card past the edge answered nobody -- up to 150px
+ * of 188, leaving a live strip on the left that happened to be where the photograph is drawn (#144).
+ * The correction sits here, beside the arithmetic that was wrong, and keeps the lookup one bucket.
+ */
+export function spatialIndex(nodes, { NODE_W, NODE_H }, cell = HIT_CELL) {
+  const grid = new Map();
+  for (const node of nodes) {
+    const x0 = Math.floor(node.x / cell);
+    const x1 = Math.floor((node.x + NODE_W) / cell);
+    const y0 = Math.floor(node.y / cell);
+    const y1 = Math.floor((node.y + NODE_H) / cell);
+    for (let cx = x0; cx <= x1; cx += 1) {
+      for (let cy = y0; cy <= y1; cy += 1) {
+        const key = `${cx},${cy}`;
+        if (!grid.has(key)) grid.set(key, []);
+        grid.get(key).push(node);
+      }
+    }
+  }
+  return { grid, cell };
+}
+
+/** The card under a point in layout units, or null for empty paper. */
+export function nodeAtPoint(index, { NODE_W, NODE_H }, x, y) {
+  const key = `${Math.floor(x / index.cell)},${Math.floor(y / index.cell)}`;
+  for (const node of index.grid.get(key) ?? []) {
+    if (x >= node.x && x <= node.x + NODE_W && y >= node.y && y <= node.y + NODE_H) return node;
+  }
+  return null;
+}
+
 export class Chart {
   constructor(canvas, options = {}) {
     this.canvas = canvas;
@@ -130,34 +169,16 @@ export class Chart {
   }
 
   /**
-   * A coarse grid over the nodes.
-   *
    * Hit testing runs on every pointer move; scanning a few thousand nodes each time is wasteful
-   * when a bucket lookup answers the same question in constant time.
+   * when a bucket lookup answers the same question in constant time. See `spatialIndex`.
    */
   buildIndex() {
-    const cell = 400;
-    const grid = new Map();
-    for (const node of this.layout.nodes) {
-      const cx = Math.floor(node.x / cell);
-      const cy = Math.floor(node.y / cell);
-      const key = `${cx},${cy}`;
-      if (!grid.has(key)) grid.set(key, []);
-      grid.get(key).push(node);
-    }
-    this.grid = grid;
-    this.cell = cell;
+    this.index = spatialIndex(this.layout.nodes, this.layout.metrics);
   }
 
   nodeAt(worldX, worldY) {
     if (!this.layout) return null;
-    const { NODE_W, NODE_H } = this.layout.metrics;
-    const key = `${Math.floor(worldX / this.cell)},${Math.floor(worldY / this.cell)}`;
-    for (const node of this.grid.get(key) ?? []) {
-      if (worldX >= node.x && worldX <= node.x + NODE_W
-        && worldY >= node.y && worldY <= node.y + NODE_H) return node;
-    }
-    return null;
+    return nodeAtPoint(this.index, this.layout.metrics, worldX, worldY);
   }
 
   /* ---------------------------------------------------------------- view */

--- a/site/playground/playground.css
+++ b/site/playground/playground.css
@@ -43,6 +43,23 @@
   /* Matches chart.js's `departed`: the ground for somebody no longer living. */
   --departed: #eae8de;
   --shadow: 0 10px 34px rgba(20, 30, 22, .13);
+  /*
+   * Four roles the desktop's editor asked for from its first day and nobody defined (#145). They
+   * ran on inline fallbacks that were light-mode colours, so dark mode drew near-white text on a
+   * near-white toast. Defined here, in both themes, and the fallbacks are gone: a missing token
+   * should fail loudly, not quietly paint a daytime colour at night.
+   *
+   * danger / on-danger  -- Android's own `error` / `onError`, from Color.kt
+   * accent              -- focus and "this one", which is the forest's job everywhere else here
+   * paper               -- text laid on an ink surface, i.e. the ground colour
+   * sunk                -- a well for inputs: darker than the panel by day, lighter by night,
+   *                        because a darkening wash on a dark surface is invisible
+   */
+  --danger: #8f3b30;
+  --on-danger: #fff;
+  --accent: var(--forest);
+  --paper: var(--bone);
+  --sunk: rgba(26, 28, 26, .045);
 
   /* One multiplier for every size in the chrome, so "big screen" is a single number. */
   --ui: 1;
@@ -86,6 +103,9 @@
   --rule-strong: #465146;
   --departed: #11160f;
   --shadow: 0 10px 34px rgba(0, 0, 0, .45);
+  --danger: #ffb4a8;
+  --on-danger: #561410;
+  --sunk: rgba(224, 228, 221, .06);
   --forest-hover: #b6dbc3;
   --on-forest: #06371c;
   --on-sage: #abe4bc;

--- a/site/playground/playground.css
+++ b/site/playground/playground.css
@@ -154,7 +154,9 @@
 .wordmark rect { fill: var(--forest); }
 .wordmark circle { fill: var(--bone); }
 .wordmark path { stroke: var(--bone); stroke-width: 1.5; fill: none; }
-.wordmark:hover b { text-decoration: underline; text-underline-offset: 3px; }
+/* Scoped to the element, not the class: the desktop app uses the same class on a <span> that goes
+   nowhere, and a link affordance on something that is not a link is a promise it cannot keep (#146). */
+a.wordmark:hover b { text-decoration: underline; text-underline-offset: 3px; }
 
 .bar-tag {
   font-family: var(--mono);


### PR DESCRIPTION
The first PR of #152: three bugs in shipped 0.5.0 behaviour, as three commits. Two of them also fix the website viewer, which shares the files.

## #144: a card answers a click anywhere on it

`buildIndex` filed each 188×64 card in the one 400×400 bucket holding its **top-left corner**, and `nodeAt` reads only the bucket under the pointer. About half of all cards cross a bucket edge, and the part past the edge answered nobody: up to 150px of 188. What survived was a strip on the left, which is where the photo is drawn, hence the report that cards were "only clickable near the photo". Hover, click-to-edit and double-click-to-centre all go through this one lookup.

Each card is now filed in **every** bucket its box overlaps. The lookup stays one bucket, and the fix sits beside the arithmetic that was wrong. The index is pulled out as `spatialIndex` / `nodeAtPoint`, so it can be tested without a canvas.

**`chart.js`'s first test**, `site/playground/chart-hit.test.mjs`, covers:
- vertical, horizontal and corner straddles
- negative coordinates
- the gap between two cards staying empty
- every card of the sample family at its four corners and centre, in **both** orientations

Against the old index it fails with 31 (rows) and 41 (columns) dead points.

## #145: dark-mode toasts were white on white

`--paper`, `--danger`, `--accent` and `--sunk` were used 17 times and defined nowhere. They ran on inline fallbacks that were all daytime colours, so the dark-mode toast measured **1.19:1**.

| token | day | night | why |
|---|---|---|---|
| `--danger` / `--on-danger` | `#8f3b30` / `#fff` | `#ffb4a8` / `#561410` | Android's own `error` / `onError` from `Color.kt` |
| `--accent` | alias of `--forest` | follows it | focus and "this one" already use forest everywhere else |
| `--paper` | alias of `--bone` | follows it | text on an ink surface |
| `--sunk` | darkening wash | **lightening** wash | a darkening wash on a dark input is invisible |

The fallbacks are removed, so a missing token now fails loudly. `desktop/renderer/theme-tokens.test.js` covers the whole class, not just these four:
- every `var()` used is defined
- no `var()` has a fallback
- every colour set for day is set for night too (two stated exceptions)
- the toast, refusal, warning and delete-button pairs clear 4.5:1 in both themes; they now measure **7.4:1 or better**

Five of its six cases fail against the old CSS.

## #146: the wordmark stops underlining

The viewer's `.wordmark:hover b` underline was written for an anchor, but it matched on the class, so it also hit the desktop's `<span>`. It is now scoped to `a.wordmark` in the shared file, as the issue prefers. The viewer keeps its underline, which I checked in a browser: desktop `none`, website `underline`. `link-affordance.test.js` generalises the rule: a hover underline goes only to a selector naming the element `a`.

## Verified locally
- `npm test`: 293 pass
- the full smoke harness with every CI gate set: **98 ok, 0 failed**
- the dark toasts in a real browser: ordinary toast `#10150f` on `#e0e4dd`; refusal toast `#561410` on `#ffb4a8`
- `git status --short app/` is empty

Part of #152. Closes #144, closes #145, closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)