### PR TITLE
feat(desktop): the person panel saves when asked, as the phone does (#147, #148)

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -944,24 +944,101 @@ async function runEditSmoke(win, check) {
   check('a new tree starts with somebody to name', seen.panelOpen && seen.nameField,
     seen.counts);
 
-  // Typing a name and leaving the field: one edit, one undo step.
+  /*
+   * The panel commits when asked, not when a field loses focus (#148).
+   *
+   * Typing goes into a draft; Add or Save keeps it. So these steps type the way a person does --
+   * `input` events -- and then press the button, and the assertions are about what the panel says
+   * at each point: that a new person is offered Add and Discard rather than Save and Delete, that
+   * leaving with a typed name asks first, and that nothing reaches the tree until Add.
+   */
+  const type = (id, value) => page((field, text) => {
+    const input = document.getElementById(field);
+    input.focus();
+    input.value = text;
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }, id, value);
+  const buttons = () => page(() => ({
+    save: document.getElementById('panel-save')?.textContent ?? null,
+    saveEnabled: document.getElementById('panel-save')?.disabled === false,
+    remove: document.getElementById('panel-remove')?.textContent ?? null,
+    status: document.getElementById('panel-status')?.textContent ?? '',
+    title: document.getElementById('panel-title')?.textContent ?? '',
+  }));
+
+  let panel = await buttons();
+  check('a person being added is offered Add, not Save', panel.save === 'Add' && panel.saveEnabled,
+    `${panel.title}: ${panel.save}`);
+  check('and Discard, not Delete, while there is nothing to lose', panel.remove === 'Discard',
+    String(panel.remove));
+
+  // A name, a date typed with spaces the way #90 asked for, and a note. The import step later needs
+  // two records that agree on enough to be a candidate and disagree on something that cannot rule
+  // the pairing out.
+  await type('f-name', 'Shyam Lal');
+  await type('f-birth', '1938');
+  await type('f-notes', 'Grandfather. Born in Ballia.');
+  await settle(150);
+
+  panel = await buttons();
+  seen = await page(() => ({ counts: document.getElementById('counts')?.textContent ?? '' }));
+  check('typing is not a commit: the tree still holds nobody named', panel.status === 'Unsaved'
+    && /1 person/.test(seen.counts), `${panel.status} — ${seen.counts}`);
+
+  // Leaving with the name typed asks first, in Android's words, and Escape is the safe answer.
+  await page(() => document.getElementById('panel-close').click());
+  await settle(200);
+  seen = await page(() => ({
+    open: document.getElementById('ask')?.open === true,
+    title: document.getElementById('ask-title')?.textContent ?? '',
+  }));
+  check('closing a panel with unsaved edits asks first', seen.open && seen.title === 'Discard changes?',
+    seen.title);
+  await page(() => document.querySelector('#ask-actions button').click());   // Keep editing
+  await settle(200);
+  seen = await page(() => ({
+    open: document.getElementById('panel')?.hidden === false,
+    name: document.getElementById('f-name')?.value ?? '',
+  }));
+  check('keeping on editing keeps every letter', seen.open && seen.name === 'Shyam Lal', seen.name);
+
+  // #90: a space is the dash, typed in, and a date that cannot be understood stops the Add.
+  await type('f-death', '19x');
+  await page(() => document.getElementById('panel-save').click());
+  await settle(200);
+  seen = await page(() => ({
+    error: document.getElementById('f-death-error')?.textContent ?? '',
+    counts: document.getElementById('counts')?.textContent ?? '',
+  }));
+  check('a date that cannot be understood is refused, in words that say how to fix it',
+    /1938-04-17/.test(seen.error), seen.error);
+  await type('f-death', '');
+  await page((id) => {
+    const input = document.getElementById(id);
+    input.value = '1938 04';
+    input.setSelectionRange(7, 7);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }, 'f-birth');
+  seen = await page(() => document.getElementById('f-birth').value);
+  check('a space typed in a date becomes the dash', seen === '1938-04', seen);
+  await type('f-birth', '1938');
+  // Clearing the death date leaves "no longer living" ticked, as the phone does; untick it so the
+  // record is the living grandfather the rest of this test was written against.
   await page(() => {
-    const input = document.getElementById('f-name');
-    input.value = 'Shyam Lal';
-    input.dispatchEvent(new Event('change', { bubbles: true }));
+    const box = document.getElementById('f-deceased');
+    if (box.checked) box.click();
   });
+
+  await page(() => document.getElementById('panel-save').click());
   await settle();
 
-  // A date and a note as well as a name. The import step later needs two records that agree on
-  // enough to be a candidate and disagree on something that cannot rule the pairing out.
-  await page(() => {
-    for (const [id, value] of [['f-birth', '1938'], ['f-notes', 'Grandfather. Born in Ballia.']]) {
-      const input = document.getElementById(id);
-      input.value = value;
-      input.dispatchEvent(new Event('change', { bubbles: true }));
-    }
-  });
-  await settle();
+  panel = await buttons();
+  seen = await page(() => ({ counts: document.getElementById('counts')?.textContent ?? '' }));
+  check('Add keeps the person, and the panel says so', /1 person/.test(seen.counts)
+    && panel.status === 'Added' && panel.title === 'Edit person', `${panel.title} — ${panel.status}`);
+  check('after which it offers Save and Delete, as for anybody already in the tree',
+    panel.save === 'Save' && !panel.saveEnabled && panel.remove === 'Delete this person',
+    `${panel.save} (${panel.saveEnabled ? 'enabled' : 'disabled'}) / ${panel.remove}`);
 
   // Add a child, by name, as a new person.
   await page(() => {
@@ -1036,6 +1113,45 @@ async function runEditSmoke(win, check) {
   }));
   check('the saved file reopens with both people and the connection',
     /2 people/.test(seen.counts) && /1 connection/.test(seen.counts), seen.counts);
+
+  /*
+   * Deleting somebody with a connection asks, and offers to keep their place.
+   *
+   * Android's dialog: "Keep as unknown" beside "Delete completely", because the person you know
+   * least about is often the one joining two branches. Cancelled here, so the import that follows
+   * still merges into the two-person tree it was written for.
+   */
+  // Through the people list, named explicitly: the search box behaves differently in each view (it
+  // filters the list in place there), and the first half of this harness leaves the list up.
+  await page(() => document.querySelector('[data-view="index"]').click());
+  await settle(200);
+  await page(() => [...document.querySelectorAll('#index-list .index-row')]
+    .find((row) => row.textContent.includes('Ravi'))?.click());
+  await settle(300);
+  await page(() => document.getElementById('panel-remove').click());
+  await settle(250);
+  seen = await page(() => ({
+    // Read only while open: the dialog keeps the last question's words after it closes, and a
+    // check that read those would pass on a dialog that never appeared.
+    open: document.getElementById('ask')?.open === true,
+    title: document.getElementById('ask')?.open ? document.getElementById('ask-title').textContent : '',
+    options: [...document.querySelectorAll('.ask-option-label')].map((o) => o.textContent),
+  }));
+  check('deleting somebody with a connection asks first', seen.open && /^Delete Ravi/.test(seen.title),
+    seen.title);
+  check('and offers to keep their place in the family',
+    seen.options.join(' / ') === 'Keep as unknown / Delete completely', seen.options.join(' / '));
+  await page(() => [...document.querySelectorAll('#ask-actions button')]
+    .find((b) => b.textContent === 'Cancel')?.click());
+  await settle(200);
+  seen = await page(() => ({
+    open: document.getElementById('ask')?.open === true,
+    counts: document.getElementById('counts')?.textContent ?? '',
+  }));
+  check('and Cancel changes nothing', !seen.open && /2 people/.test(seen.counts)
+    && /1 connection/.test(seen.counts), seen.counts);
+  await page(() => document.getElementById('panel-close').click());
+  await settle(200);
 }
 
 /*

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -12,9 +12,10 @@
  * relationship rules, and the only thing that can put a change back. A field that wrote to a person
  * directly would edit somebody's family with no rule check, no undo and no unsaved mark.
  *
- * **One edit is one undo step.** Form fields commit on `change`, not on `input`, so typing a name
- * is one step rather than one per keystroke -- which would make undo useless exactly when it
- * matters.
+ * **One edit is one undo step, and it happens when somebody says so.** The person panel holds its
+ * edits as a draft and commits them on Save, as the phone does (#148): one Save is one step, the
+ * panel shows whether there is anything unsaved, and leaving with edits asks first. It used to
+ * commit on every field's `change`, which meant nothing on screen ever said an edit was taken.
  *
  * **A refusal is an explanation.** The rules say no for reasons a person can understand, so the
  * interface says the reason and not "invalid".
@@ -36,6 +37,10 @@ import { MatchTier } from './matching.js';
 import { renderBands } from './bands.js';
 import { sentenceFor, unrelatedWording, paintSentence, nameNode, hindiFor } from './relation.js';
 import { decode, encode, asImageUrl, freeName, squareCrop } from './photo.js';
+import {
+  DateProblem, draftFrom, withChange, dateProblems, isDirty, fieldsFrom, isBlankPerson,
+  normaliseDateTyping,
+} from './person-draft.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
 
@@ -54,6 +59,22 @@ const state = {
   selected: null,
   /** Which kind of relative the "add" form is currently offering. */
   adding: null,
+  /**
+   * The person panel's edits, not yet kept: `{ id, values, showProblems }`.
+   *
+   * Keyed by id and held here rather than read back out of the inputs, because the panel is redrawn
+   * whenever anything else changes the tree -- a photograph, a relative added -- and a redraw that
+   * rebuilt the form from the tree would throw away a name somebody was halfway through typing.
+   */
+  draft: null,
+  /**
+   * Somebody "Add a person" created, not yet confirmed with Add.
+   *
+   * The card exists from the first click so the chart can show where it will go, but until Add is
+   * pressed it is a question rather than a person: backing out takes it away again, and finishing
+   * it is one step in the history rather than an addition followed by an edit.
+   */
+  fresh: null,
   /** 'chart', 'compact' or 'index'. */
   view: 'chart',
   /**
@@ -84,20 +105,49 @@ function setState(value) {
 }
 
 let toastTimer = null;
-function toast(message, tone = 'good') {
+let toastLinger = 0;
+
+/**
+ * Says something once, where the eye already is.
+ *
+ * `action` puts one button in it -- in practice always Undo. The toolbar's undo button is gone
+ * (#150) and a toast that says "Undo with Ctrl+Z" is advertising a shortcut to somebody who has
+ * just been surprised; the button is the thing itself, and the shortcut still works. A toast with
+ * a button stays a little longer, and holds still while the pointer or focus is on it, so it
+ * cannot vanish from under a click.
+ */
+function toast(message, tone = 'good', { action = null } = {}) {
   const box = $('toast');
-  box.textContent = message;
+  $('toast-text').textContent = message;
+  const button = $('toast-action');
+  button.hidden = !action;
+  button.textContent = action?.label ?? '';
+  button.onclick = action ? () => { box.hidden = true; action.run(); } : null;
   box.dataset.tone = tone;
   box.hidden = false;
-  clearTimeout(toastTimer);
   // A refusal is longer and worth reading twice; a confirmation is not.
-  const linger = { bad: 9000, warn: 9000 }[tone] ?? 2600;
-  toastTimer = setTimeout(() => { box.hidden = true; }, linger);
+  toastLinger = { bad: 9000, warn: 9000 }[tone] ?? (action ? 6500 : 2600);
+  holdToast(false);
+}
+
+function holdToast(holding) {
+  clearTimeout(toastTimer);
+  if (!holding) toastTimer = setTimeout(() => { $('toast').hidden = true; }, toastLinger);
+}
+
+/** The Undo button a toast offers after something that can be taken back. */
+const UNDO = { label: 'Undo', run: () => undo() };
+
+/** Whether the person panel holds edits the tree does not. */
+function draftIsDirty() {
+  const draft = state.draft;
+  const person = draft && state.tree?.person(draft.id);
+  return Boolean(person && isDirty(draft.values, person));
 }
 
 /** Keeps the window, the menu and the dot in step with whether there is work not on disk. */
 function reflectDirty() {
-  const dirty = Boolean(state.tree?.isDirty);
+  const dirty = Boolean(state.tree?.isDirty) || draftIsDirty();
   $('unsaved').hidden = !dirty;
   $('save').dataset.dirty = String(dirty);
   $('undo').disabled = !state.tree?.canUndo;
@@ -315,7 +365,7 @@ function setPhoto(id, bytes) {
     return;
   }
   rebuild();
-  toast(bytes ? 'Photograph added. Undo with Ctrl+Z.' : 'Photograph removed. Undo with Ctrl+Z.');
+  toast(bytes ? 'Photograph added.' : 'Photograph removed.', 'good', { action: UNDO });
 }
 
 /** The framing step: pick a file, choose what the circle shows, then store it. */
@@ -632,10 +682,11 @@ function forgetRelate() {
   }
 }
 
-function openRelate(seed = state.selected) {
+async function openRelate(seed = state.selected) {
   // One question at a time. Both panels are positioned in the same corner, and two open at once
-  // would be two things claiming to be what the window is about.
-  if (state.selected) select(null);
+  // would be two things claiming to be what the window is about. Closing the person panel can be
+  // refused -- it asks first if it holds unsaved edits -- and then the question waits.
+  if (state.selected && !(await select(null))) return;
 
   $('relate').hidden = false;
 
@@ -1044,26 +1095,141 @@ const REFUSALS = {
   DUPLICATE_ID: 'Somebody with that id is already here.',
 };
 
+/** Android's own words for each date problem, so the two shells say the same thing. */
+const DATE_PROBLEMS = {
+  [DateProblem.MALFORMED]: 'Use a year like 1938, or 1938-04-17',
+  [DateProblem.DEATH_BEFORE_BIRTH]: 'This is earlier than the birth date',
+};
+
+/** Which draft field each input edits. */
+const FIELD_KEYS = {
+  'f-name': 'name',
+  'f-gender': 'gender',
+  'f-birth': 'birthDate',
+  'f-death': 'deathDate',
+  'f-deceased': 'deceased',
+  'f-notes': 'notes',
+};
+
+/**
+ * Somebody "Add a person" made and nobody has finished adding: still blank, joined to nobody.
+ *
+ * Checked against the tree rather than remembered, because the moment they gain a relative or a
+ * photograph they are a person with something recorded, and "Discard" would understate what the
+ * button then does.
+ */
+function isFresh(person) {
+  if (!person || state.fresh !== person.id || !isBlankPerson(person)) return false;
+  return !state.tree.relationships.some((r) => r.from === person.id || r.to === person.id);
+}
+
 function renderPanel() {
   const panel = $('panel');
   const id = state.selected;
-  if (!id) {
-    panel.hidden = true;
-    return;
-  }
-  const person = state.tree.person(id);
+  const person = id ? state.tree.person(id) : null;
   if (!person) {
     panel.hidden = true;
+    state.draft = null;
     return;
   }
   panel.hidden = false;
 
+  /*
+   * The draft survives a redraw, unless there is nothing in it.
+   *
+   * A draft nobody has touched is refreshed from the tree every time, so an undo that changes this
+   * person shows in the form at once. One with edits in it is kept, because it holds something the
+   * tree does not and a redraw is not the reader asking to lose it.
+   */
+  const draft = state.draft;
+  if (draft?.id !== id || !isDirty(draft.values, draft.base)) {
+    state.draft = { id, base: person, values: draftFrom(person), showProblems: false,
+      touched: new Set() };
+  }
+
+  $('panel-title').textContent = isFresh(person) ? 'Add a person' : 'Edit person';
   const body = $('panel-body');
   body.replaceChildren();
-  body.append(personForm(person), relativesSection(person), dangerRow(person));
+  body.append(personForm(person), relativesSection(person));
+  paintPanelState();
 }
 
-function field({ label, id, value = '', type = 'text', wide = false, hint = null }) {
+/** The word the panel shows for a moment after its edits were kept. */
+let panelFlash = null;
+let panelFlashTimer = null;
+
+function flashPanel(word) {
+  panelFlash = word;
+  clearTimeout(panelFlashTimer);
+  panelFlashTimer = setTimeout(() => { panelFlash = null; paintPanelState(); }, 2400);
+}
+
+/**
+ * Brings the panel's buttons, status and date problems up to date with its draft.
+ *
+ * Called on every keystroke, so it touches only those -- redrawing the form would take the caret
+ * out of the field being typed in.
+ */
+function paintPanelState() {
+  const draft = state.draft;
+  const person = draft && state.tree?.person(draft.id);
+  if (!person) return;
+
+  const fresh = isFresh(person);
+  const dirty = isDirty(draft.values, person);
+
+  // "Add" and "Discard" only while this is still an addition; for anybody already in the tree the
+  // destructive button says what it does, which is remove them and every one of their connections.
+  const save = $('panel-save');
+  save.textContent = fresh ? 'Add' : 'Save';
+  save.disabled = !fresh && !dirty;
+  $('panel-remove').textContent = fresh ? 'Discard' : 'Delete this person';
+
+  const status = $('panel-status');
+  status.textContent = dirty ? 'Unsaved' : (panelFlash ?? '');
+  status.dataset.tone = dirty ? 'dirty' : 'done';
+
+  /*
+   * A problem is shown once the field has been left, or once Save has been pressed -- not while
+   * the first digit of a year is being typed. It clears the moment it is fixed.
+   */
+  const problems = dateProblems(draft.values);
+  for (const [key, inputId] of [['birthDate', 'f-birth'], ['deathDate', 'f-death']]) {
+    const input = $(inputId);
+    if (!input) continue;
+    const shown = draft.showProblems || draft.touched.has(key) ? problems[key] : null;
+    input.setAttribute('aria-invalid', String(Boolean(shown)));
+    input.closest('.field').dataset.problem = String(Boolean(shown));
+    paintProblem($(`${inputId}-error`), shown ? DATE_PROBLEMS[shown] : '');
+  }
+
+  reflectDirty();
+}
+
+/**
+ * A problem's words, with any example date kept on one line.
+ *
+ * The date fields are half the panel wide, and "1938-04-17" broken at a hyphen reads as two
+ * fragments rather than one example of the shape to type -- exactly the thing the message is for.
+ */
+function paintProblem(box, message) {
+  box.replaceChildren();
+  let last = 0;
+  for (const match of message.matchAll(/\d{4}(?:-\d{2}){0,2}/g)) {
+    box.append(message.slice(last, match.index));
+    const date = document.createElement('span');
+    date.className = 'nowrap';
+    date.textContent = match[0];
+    box.append(date);
+    last = match.index + match[0].length;
+  }
+  box.append(message.slice(last));
+}
+
+function field({
+  label, id, value = '', type = 'text', wide = false, hint = null, placeholder = null,
+  validated = false, describedBy = null,
+}) {
   const wrap = document.createElement('div');
   wrap.className = wide ? 'field wide' : 'field';
   const lab = document.createElement('label');
@@ -1072,9 +1238,13 @@ function field({ label, id, value = '', type = 'text', wide = false, hint = null
   const input = type === 'textarea'
     ? document.createElement('textarea')
     : document.createElement('input');
-  if (type !== 'textarea') input.type = 'text';
+  if (type !== 'textarea') {
+    input.type = 'text';
+    input.autocomplete = 'off';
+  }
   input.id = id;
   input.value = value ?? '';
+  if (placeholder) input.placeholder = placeholder;
   wrap.append(lab, input);
   if (hint) {
     const note = document.createElement('p');
@@ -1082,10 +1252,21 @@ function field({ label, id, value = '', type = 'text', wide = false, hint = null
     note.textContent = hint;
     wrap.append(note);
   }
+  const described = [];
+  if (validated) {
+    const error = document.createElement('p');
+    error.className = 'field-error';
+    error.id = `${id}-error`;
+    wrap.append(error);
+    described.push(error.id);
+  }
+  if (describedBy) described.push(describedBy);
+  if (described.length) input.setAttribute('aria-describedby', described.join(' '));
   return wrap;
 }
 
 function personForm(person) {
+  const values = state.draft.values;
   const form = document.createElement('div');
   form.className = 'form-grid';
 
@@ -1095,12 +1276,15 @@ function personForm(person) {
   photo.classList.add('field', 'wide');
   form.append(photo);
 
+  // Android's own placeholder: a blank name is not a mistake here, it is how an unknown person is
+  // recorded, and the field should say so before anybody wonders.
   form.append(field({
-    label: 'Name', id: 'f-name', value: person.name ?? '', wide: true,
+    label: 'Name', id: 'f-name', value: values.name, wide: true,
+    placeholder: 'Leave blank if you don’t know it',
   }));
 
   const gender = document.createElement('div');
-  gender.className = 'field';
+  gender.className = 'field wide';
   const gl = document.createElement('label');
   gl.textContent = 'Gender';
   gl.htmlFor = 'f-gender';
@@ -1110,47 +1294,97 @@ function personForm(person) {
     const option = document.createElement('option');
     option.value = value;
     option.textContent = text;
-    if ((person.gender ?? '') === value) option.selected = true;
+    if (values.gender === value) option.selected = true;
     select.append(option);
   }
   gender.append(gl, select);
   form.append(gender);
 
+  /*
+   * The two dates side by side, with one hint under both (#147).
+   *
+   * The placeholders are real dates rather than a format string: `1948` shows that a year alone is
+   * a whole answer, and `2019-03-14` shows the fullest shape and the separator. One hint under the
+   * pair says the same thing to both, rather than printing it twice or leaving one field bare.
+   */
   form.append(field({
-    label: 'Born', id: 'f-birth', value: person.birthDate ?? '', hint: 'A year alone is fine',
+    label: 'Born', id: 'f-birth', value: values.birthDate, placeholder: '1948',
+    validated: true, describedBy: 'f-dates-hint',
   }));
-  form.append(field({ label: 'Died', id: 'f-death', value: person.deathDate ?? '' }));
+  form.append(field({
+    label: 'Passed away', id: 'f-death', value: values.deathDate, placeholder: '2019-03-14',
+    validated: true, describedBy: 'f-dates-hint',
+  }));
+  const hint = document.createElement('p');
+  hint.className = 'field-hint dates-hint';
+  hint.id = 'f-dates-hint';
+  hint.textContent = 'A year alone is fine. Spaces become dashes.';
+  form.append(hint);
+  for (const id of ['f-birth', 'f-death']) {
+    const input = form.querySelector(`#${id}`);
+    input.spellcheck = false;
+  }
 
   const check = document.createElement('label');
   check.className = 'check';
   const box = document.createElement('input');
   box.type = 'checkbox';
   box.id = 'f-deceased';
-  box.checked = Boolean(person.deceased);
+  box.checked = values.deceased;
   check.append(box, document.createTextNode('No longer living'));
   form.append(check);
 
   form.append(field({
-    label: 'Notes', id: 'f-notes', value: person.notes ?? '', type: 'textarea', wide: true,
+    label: 'Notes', id: 'f-notes', value: values.notes, type: 'textarea', wide: true,
+    placeholder: 'Anything worth remembering',
   }));
 
   /*
-   * Committed on `change`, never on `input`.
+   * Every keystroke goes into the draft, and nothing into the tree until Save.
    *
-   * `input` fires per keystroke, which would put eleven undo steps behind a name like
-   * "Shyam Sundar" and make undo useless at the moment somebody actually needs it.
+   * So a name typed letter by letter is still one step in the history -- the reason this used to
+   * wait for `change` -- and the panel can say at once that there is something unsaved.
    */
-  form.addEventListener('change', () => {
-    const result = state.tree.updatePerson(person.id, {
-      name: $('f-name').value,
-      gender: $('f-gender').value || null,
-      birthDate: $('f-birth').value,
-      deathDate: $('f-death').value,
-      deceased: $('f-deceased').checked,
-      notes: $('f-notes').value,
-    });
-    if (!result.ok) { toast(REFUSALS[result.reason] ?? 'That change was not made.', 'bad'); return; }
-    rebuild();
+  const onEdit = (event) => {
+    const key = FIELD_KEYS[event.target.id];
+    if (!key || !state.draft) return;
+
+    let value = event.target.type === 'checkbox' ? event.target.checked : event.target.value;
+    if (key === 'birthDate' || key === 'deathDate') {
+      const typed = normaliseDateTyping(value, event.target.selectionStart ?? value.length);
+      if (typed.value !== value) {
+        event.target.value = typed.value;
+        event.target.setSelectionRange(typed.caret, typed.caret);
+      }
+      value = typed.value;
+    }
+
+    state.draft.values = withChange(state.draft.values, key, value);
+    // A death date ticks "no longer living", and unticking it clears the date: show both at once.
+    $('f-deceased').checked = state.draft.values.deceased;
+    if ($('f-death').value !== state.draft.values.deathDate) {
+      $('f-death').value = state.draft.values.deathDate;
+    }
+    paintPanelState();
+  };
+  form.addEventListener('input', onEdit);
+  form.addEventListener('change', onEdit);
+
+  form.addEventListener('focusout', (event) => {
+    const key = FIELD_KEYS[event.target.id];
+    if (key !== 'birthDate' && key !== 'deathDate') return;
+    state.draft?.touched.add(key);
+    paintPanelState();
+  });
+
+  // Enter keeps the edit, as a form does; in the notes, where Enter is a new line, Ctrl+Enter does.
+  form.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter') return;
+    const line = event.target.tagName === 'INPUT' && event.target.type === 'text';
+    if (line || event.ctrlKey || event.metaKey) {
+      event.preventDefault();
+      commitDraft();
+    }
   });
 
   return form;
@@ -1299,18 +1533,6 @@ function addRelativeForm(person) {
   return box;
 }
 
-function dangerRow(person) {
-  const row = document.createElement('div');
-  row.className = 'danger-row';
-  const button = document.createElement('button');
-  button.type = 'button';
-  button.className = 'btn-danger';
-  button.textContent = 'Delete this person';
-  button.addEventListener('click', () => removePerson(person.id));
-  row.append(button);
-  return row;
-}
-
 function escapeHtml(text) {
   return String(text).replace(/[&<>"']/g, (c) => (
     { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
@@ -1318,7 +1540,142 @@ function escapeHtml(text) {
 
 /* ------------------------------------------------------------------ editing */
 
+/**
+ * Asks one short question in a dialog and resolves with the answer, or null for the safe one.
+ *
+ * `options` are the choices that need a sentence each to be understood -- "Keep as unknown" does
+ * not explain itself -- and are drawn as a list; `actions` are the ordinary buttons along the foot.
+ * Escape, and closing any other way, always answers null: whatever the question, the answer that
+ * changes nothing is the one a stray keypress gets.
+ */
+function ask({ title, body, options = [], actions = [], focus = null }) {
+  const dialog = $('ask');
+  $('ask-title').textContent = title;
+  $('ask-body').textContent = body;
+
+  const optionsBox = $('ask-options');
+  optionsBox.replaceChildren();
+  optionsBox.hidden = options.length === 0;
+  const actionsBox = $('ask-actions');
+  actionsBox.replaceChildren();
+
+  return new Promise((resolve) => {
+    const finish = (value) => {
+      dialog.onclose = null;
+      if (dialog.open) dialog.close();
+      resolve(value);
+    };
+
+    for (const option of options) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'ask-option';
+      if (option.tone) button.dataset.tone = option.tone;
+      const label = document.createElement('span');
+      label.className = 'ask-option-label';
+      label.textContent = option.label;
+      const detail = document.createElement('span');
+      detail.className = 'ask-option-detail';
+      detail.textContent = option.detail;
+      button.append(label, detail);
+      button.addEventListener('click', () => finish(option.value));
+      optionsBox.append(button);
+    }
+
+    for (const action of actions) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = `btn ${action.tone ?? 'quiet'}`;
+      button.textContent = action.label;
+      button.addEventListener('click', () => finish(action.value ?? null));
+      actionsBox.append(button);
+    }
+
+    dialog.onclose = () => resolve(null);
+    dialog.showModal();
+    (focus == null ? $('ask-head') : actionsBox.children[focus]).focus();
+  });
+}
+
+/** Whether a question is on screen, which the keyboard shortcuts must not reach past. */
+const dialogOpen = () => Boolean(document.querySelector('dialog[open]'));
+
+/**
+ * Lets go of the person in the panel, asking first if that would lose edits.
+ *
+ * Resolves false when the reader chose to keep editing, and every caller then leaves things as
+ * they were. The wording is Android's (`edit_discard_*`), so the two shells ask the same question
+ * in the same words.
+ *
+ * A fresh addition is taken away again on the way out: backing out of "Add a person" is backing
+ * out, and leaving a blank card on the chart would be the app deciding somebody unknown exists.
+ */
+async function releasePanel() {
+  if (draftIsDirty()) {
+    const answer = await ask({
+      title: 'Discard changes?',
+      body: 'Your edits to this person won’t be kept.',
+      actions: [
+        { label: 'Keep editing', value: null },
+        { label: 'Discard', value: 'discard', tone: 'danger' },
+      ],
+      focus: 0,
+    });
+    if (answer !== 'discard') {
+      $('f-name')?.focus();
+      return false;
+    }
+  }
+  letGoOfPanel();
+  return true;
+}
+
+/** Drops the draft, and a fresh addition with it. The part of letting go that needs no question. */
+function letGoOfPanel() {
+  const person = state.draft && state.tree?.person(state.draft.id);
+  state.draft = null;
+  if (person && isFresh(person)) {
+    withdrawFresh(person.id);
+    state.selected = null;
+    rebuild();
+  }
+  state.fresh = null;
+}
+
+/** Takes an unfinished addition back out of the tree, without a trace in the history if possible. */
+function withdrawFresh(id) {
+  if (state.tree.canWithdraw(id)) state.tree.withdraw(id);
+  else state.tree.removePerson(id);
+  state.fresh = null;
+}
+
+/**
+ * Opens somebody in the panel, or closes it with null -- after asking, if it holds unsaved edits.
+ *
+ * Resolves whether the selection actually changed. When the reader keeps editing, the chart is put
+ * back on the person the panel still holds, so the two never disagree about who is open.
+ */
 function select(id) {
+  // Immediately, when there is nothing to ask: a click on a card should open it in the same frame,
+  // not a turn of the event loop later.
+  if (id === state.selected || !draftIsDirty()) {
+    if (id !== state.selected) letGoOfPanel();
+    selectNow(id);
+    return Promise.resolve(true);
+  }
+  return releasePanel().then((released) => {
+    if (!released) {
+      chart.selected = state.selected;
+      chart.invalidate();
+      return false;
+    }
+    selectNow(id);
+    return true;
+  });
+}
+
+/** The selection itself, for callers that have already dealt with the panel. */
+function selectNow(id) {
   state.selected = id;
   state.adding = null;
   chart.selected = id;
@@ -1328,10 +1685,123 @@ function select(id) {
   if (state.view === 'index') renderPeople();
 }
 
-function addPerson() {
+/**
+ * Keeps the panel's edits.
+ *
+ * Refused, with the problem shown under the field and the caret put in it, while a date cannot be
+ * understood. Finishing a fresh addition replaces the blank one in the history, so undo takes back
+ * "Add Shyam Lal" in one step rather than a name and then a person.
+ *
+ * @returns {boolean} whether there is now nothing unsaved in the panel
+ */
+function commitDraft() {
+  const draft = state.draft;
+  const person = draft && state.tree?.person(draft.id);
+  if (!person) return true;
+
+  const fresh = isFresh(person);
+  if (!fresh && !isDirty(draft.values, person)) return true;
+
+  const problems = dateProblems(draft.values);
+  const wrong = problems.birthDate ? 'f-birth' : problems.deathDate ? 'f-death' : null;
+  if (wrong) {
+    draft.showProblems = true;
+    paintPanelState();
+    $(wrong)?.focus();
+    return false;
+  }
+
+  const fields = fieldsFrom(draft.values);
+  let result;
+  if (fresh && state.tree.canWithdraw(person.id)) {
+    state.tree.withdraw(person.id);
+    result = state.tree.addPerson({ id: person.id, ...fields });
+  } else {
+    result = state.tree.updatePerson(person.id, fields);
+  }
+  if (!result.ok) {
+    toast(REFUSALS[result.reason] ?? 'That change was not made.', 'bad');
+    return false;
+  }
+
+  state.fresh = null;
+  state.draft = null;
+  flashPanel(fresh ? 'Added' : 'Saved');
+  rebuild();
+  return true;
+}
+
+/** The panel's destructive button, which is Discard for an addition and Delete for anybody else. */
+async function removeFromPanel() {
+  const person = state.tree.person(state.selected);
+  if (!person) return;
+  if (isFresh(person)) {
+    state.draft = null;
+    withdrawFresh(person.id);
+    state.selected = null;
+    rebuild();
+    return;
+  }
+  await deletePerson(person.id);
+}
+
+/**
+ * Deletes somebody, asking first when that would take connections with them.
+ *
+ * Android's dialog, ported: somebody joined to others is offered "Keep as unknown" beside "Delete
+ * completely", because a grandparent you know little about is still the join between two branches,
+ * and deleting them outright splits the family in two. Somebody joined to nobody is removed at once
+ * -- there is no shape to lose -- with Undo in the toast.
+ */
+async function deletePerson(id) {
+  const person = state.tree.person(id);
+  if (!person) return;
+  const edges = state.tree.relationships.filter((r) => r.from === id || r.to === id);
+
+  if (edges.length) {
+    const others = new Set(edges.map((r) => (r.from === id ? r.to : r.from))).size;
+    const who = person.name ? displayName(person) : 'This person';
+    const choice = await ask({
+      title: person.name ? `Delete ${displayName(person)}?` : 'Delete this person?',
+      body: `${who} is connected to ${count(others, 'other person', 'other people')}. `
+        + 'Choose what happens to those connections.',
+      options: [
+        {
+          value: 'unknown',
+          label: 'Keep as unknown',
+          detail: 'Clears their details but keeps their place in the tree, so the family still joins up.',
+        },
+        {
+          value: 'delete',
+          label: 'Delete completely',
+          detail: `Removes them and their ${count(edges.length, 'connection', 'connections')}.`,
+          tone: 'danger',
+        },
+      ],
+      actions: [{ label: 'Cancel', value: null }],
+    });
+    if (choice === 'unknown') { keepAsUnknown(id); return; }
+    if (choice !== 'delete') return;
+  }
+  removePerson(id);
+}
+
+function keepAsUnknown(id) {
+  const result = state.tree.clearDetails(id);
+  if (!result.ok) { toast(REFUSALS[result.reason] ?? 'Nothing was changed.', 'bad'); return; }
+  state.draft = null;
+  state.selected = null;
+  rebuild();
+  toast('Kept as an unknown person.', 'good', { action: UNDO });
+}
+
+async function addPerson() {
+  if (!(await releasePanel())) return;
   const result = state.tree.addPerson({ name: '' });
   if (!result.ok) { toast(REFUSALS[result.reason] ?? 'Could not add anybody.', 'bad'); return; }
   state.selected = result.id;
+  state.fresh = result.id;
+  state.draft = null;
   state.adding = null;
   rebuild({ refit: state.tree.people.length <= 1 });
   $('f-name')?.focus();
@@ -1398,15 +1868,29 @@ function removePerson(id) {
   const name = displayName(person ?? {});
   const result = state.tree.removePerson(id);
   if (!result.ok) { toast(REFUSALS[result.reason] ?? 'Nobody was deleted.', 'bad'); return; }
+  state.draft = null;
   state.selected = null;
   rebuild();
   toast(result.removedEdges
-    ? `Deleted ${name} and ${count(result.removedEdges, 'connection', 'connections')}. `
-      + 'Undo with Ctrl+Z.'
-    : `Deleted ${name}. Undo with Ctrl+Z.`);
+    ? `Deleted ${name} and ${count(result.removedEdges, 'connection', 'connections')}.`
+    : `Deleted ${name}.`, 'good', { action: UNDO });
+}
+
+/**
+ * Whether the caret is in a text field, where Ctrl+Z means the text.
+ *
+ * The menu owns the accelerator, so without this Ctrl+Z inside the name field would take back the
+ * last change to the *tree* -- a relative added a minute ago -- rather than the last few letters.
+ * With edits now held in the panel until Save, the letters are what somebody typing means.
+ */
+function typingInField() {
+  const el = document.activeElement;
+  return Boolean(el) && (el.tagName === 'TEXTAREA'
+    || (el.tagName === 'INPUT' && /^(text|search)$/.test(el.type)));
 }
 
 function undo() {
+  if (typingInField()) { document.execCommand('undo'); return; }
   const result = state.tree?.undo();
   if (!result?.ok) return;
   rebuild();
@@ -1414,6 +1898,7 @@ function undo() {
 }
 
 function redo() {
+  if (typingInField()) { document.execCommand('redo'); return; }
   const result = state.tree?.redo();
   if (!result?.ok) return;
   rebuild();
@@ -1422,8 +1907,11 @@ function redo() {
 
 /* ------------------------------------------------------------------ files */
 
-function startNewTree() {
+async function startNewTree() {
+  if (state.tree && !(await releasePanel())) return;
   state.tree = new Tree({}, { ownTreeId: state.ownTreeId });
+  state.draft = null;
+  state.fresh = null;
   state.photos = new Map();
   state.path = null;
   state.name = 'Untitled tree';
@@ -1457,6 +1945,8 @@ async function openBytes(bytes, name, filePath) {
 
     state.tree = new Tree(doc, { ownTreeId: state.ownTreeId });
     state.tree.markSaved();
+    state.draft = null;
+    state.fresh = null;
     state.photos = photos;
     state.path = filePath ?? null;
     state.name = name;
@@ -1690,8 +2180,9 @@ function commitImport(plan, decisions, importedPhotos, fileName) {
       + 'added without contradicting your tree.'
     : '';
 
-  toast(`${said.join(', ')}.${extra}${refused}\nUndo puts this back.`,
-    result.conflicts.length || result.relationshipsRefused.length ? 'warn' : 'good');
+  toast(`${said.join(', ')}.${extra}${refused}`,
+    result.conflicts.length || result.relationshipsRefused.length ? 'warn' : 'good',
+    { action: UNDO });
 }
 
 /**
@@ -1709,6 +2200,10 @@ function photosStillUsed() {
 
 async function save({ as = false } = {}) {
   if (!state.tree || state.saving) return;
+  // Saving the file saves the person being edited too; a Ctrl+S that wrote everything except the
+  // name on screen would be the one save somebody could not believe. A date that cannot be kept
+  // stops the whole save, with the problem shown where it is.
+  if (!commitDraft()) return;
   state.saving = true;
   try {
     let made;
@@ -1754,6 +2249,15 @@ function wireChrome() {
   $('undo').addEventListener('click', undo);
   $('redo').addEventListener('click', redo);
   $('panel-close').addEventListener('click', () => select(null));
+  $('panel-save').addEventListener('click', () => commitDraft());
+  $('panel-remove').addEventListener('click', () => removeFromPanel());
+
+  // A toast with a button in it holds still while somebody is reaching for the button.
+  const box = $('toast');
+  box.addEventListener('mouseenter', () => holdToast(true));
+  box.addEventListener('mouseleave', () => holdToast(false));
+  box.addEventListener('focusin', () => holdToast(true));
+  box.addEventListener('focusout', () => holdToast(false));
 
   for (const button of document.querySelectorAll('[data-view]')) {
     button.addEventListener('click', () => setView(button.dataset.view));
@@ -1804,11 +2308,10 @@ function wireChrome() {
       button.type = 'button';
       button.innerHTML = `<span>${escapeHtml(displayName(person))}</span>`
         + `<small>${escapeHtml(lifespan(person) || '')}</small>`;
-      button.addEventListener('click', () => {
-        select(person.id);
-        chart.centreOn(person.id);
+      button.addEventListener('click', async () => {
         search.value = '';
         results.hidden = true;
+        if (await select(person.id)) chart.centreOn(person.id);
       });
       li.append(button);
       results.append(li);
@@ -1820,7 +2323,11 @@ function wireChrome() {
 function wireShell() {
   if (!shell) return;
 
-  shell.onOpenTree((tree) => openBytes(tree.bytes, tree.name, tree.path));
+  shell.onOpenTree(async (tree) => {
+    // Opening another file closes the panel as surely as clicking away does, so it asks the same.
+    if (state.tree && !(await releasePanel())) return;
+    openBytes(tree.bytes, tree.name, tree.path);
+  });
 
   shell.onMenuCommand((command) => {
     if (command === 'file:new') { startNewTree(); return; }
@@ -1840,17 +2347,26 @@ function wireShell() {
     if (command === 'search') { $('search').focus(); return; }
     if (command === 'theme') { $('theme-btn').click(); return; }
     if (command === 'close') {
-      state.tree = null;
-      state.selected = null;
-      forgetRelate();
-      setState('empty');
-      shell.setDirty(false);
+      releasePanel().then((released) => { if (released) closeTree(); });
     }
   });
 }
 
+function closeTree() {
+  state.tree = null;
+  state.selected = null;
+  state.draft = null;
+  state.fresh = null;
+  forgetRelate();
+  setState('empty');
+  shell.setDirty(false);
+}
+
 function wireKeys() {
   document.addEventListener('keydown', (event) => {
+    // A dialog owns the keyboard while it is open. Escape there means "the safe answer" to the
+    // dialog, and must not also close the panel behind it -- which would ask a second question.
+    if (dialogOpen()) return;
     const typing = /^(INPUT|TEXTAREA|SELECT)$/.test(event.target.tagName);
     if (event.key === 'Escape') {
       if (state.adding) { state.adding = null; renderPanel(); return; }

--- a/desktop/renderer/document.js
+++ b/desktop/renderer/document.js
@@ -244,6 +244,51 @@ export class Tree {
   }
 
   /**
+   * Whether the newest step is exactly the addition of this person, and nothing else since.
+   *
+   * The person panel creates somebody the moment "Add a person" is pressed, so the card is on the
+   * chart while their name is being typed. Backing out of that, or finishing it, should read as one
+   * act in the history rather than an addition plus an edit plus a removal.
+   */
+  canWithdraw(id) {
+    const top = this.past.at(-1);
+    const person = this.state.people.at(-1);
+    if (!top || person?.id !== id) return false;
+    if (top.state.people.some((p) => p.id === id)) return false;
+    return JSON.stringify([[...top.state.people, person], top.state.relationships]) === this.signature();
+  }
+
+  /**
+   * Takes back the addition of a person nobody finished adding, leaving no trace in the history.
+   *
+   * Only when `canWithdraw` says the newest step is that addition; otherwise it is refused, because
+   * rewinding past somebody else's edit to reach it would lose that edit.
+   */
+  withdraw(id) {
+    if (!this.canWithdraw(id)) return { ok: false, reason: 'NOT_THE_LATEST' };
+    this.state = this.past.pop().state;
+    return { ok: true };
+  }
+
+  /**
+   * Strips a person back to somebody unknown, leaving every relationship where it was.
+   *
+   * Android's "Keep as unknown" (`PersonDao.clearDetails`): deleting somebody you know little about
+   * should not tear a hole in the shape of the family, so their place stays and joins it up.
+   */
+  clearDetails(id) {
+    const at = this.state.people.findIndex((p) => p.id === id);
+    if (at < 0) return { ok: false, reason: 'NO_SUCH_PERSON' };
+    const current = this.state.people[at];
+    return this.edit(`Keep ${current.name ?? 'someone'} as unknown`, () => {
+      const next = { id };
+      if (current.origins) next.origins = current.origins;
+      this.state.people[at] = next;
+      return { ok: true };
+    });
+  }
+
+  /**
    * Removes a person and every relationship that touched them.
    *
    * Leaving the edges behind would put ends in the file that point at nobody. `model.js` drops

--- a/desktop/renderer/document.test.js
+++ b/desktop/renderer/document.test.js
@@ -258,3 +258,66 @@ test('exportedAt is stamped at save time', () => {
   const when = new Date('2026-01-02T03:04:05Z');
   assert.strictEqual(tree.toExchange(when).exportedAt, '2026-01-02T03:04:05.000Z');
 });
+
+/* ---------------------------------------------------------------- an addition nobody finished */
+
+test('withdrawing an unfinished addition leaves no trace in the history', () => {
+  const { tree } = family();
+  const before = tree.signature();
+  const steps = tree.undoLabel;
+  const { id } = tree.addPerson({ name: '' });
+
+  assert.ok(tree.canWithdraw(id));
+  assert.deepStrictEqual(tree.withdraw(id), { ok: true });
+  assert.strictEqual(tree.signature(), before, 'the tree is as it was');
+  assert.strictEqual(tree.undoLabel, steps, 'and the history is as it was');
+  assert.ok(!tree.canRedo, 'a blank person is not something to redo');
+});
+
+test('an addition can only be withdrawn while it is the newest step', () => {
+  const { tree, father } = family();
+  const { id } = tree.addPerson({ name: '' });
+  tree.addRelationship({ from: father, to: id, type: PARENT });
+
+  assert.ok(!tree.canWithdraw(id), 'something has happened since');
+  assert.strictEqual(tree.withdraw(id).reason, 'NOT_THE_LATEST');
+  assert.ok(tree.person(id), 'and the person is still there');
+});
+
+test('only the person the newest step added can be withdrawn', () => {
+  const { tree, child } = family();
+  tree.addPerson({ name: '' });
+  assert.ok(!tree.canWithdraw(child));
+  assert.ok(!new Tree().canWithdraw('nobody'), 'nothing to withdraw in an empty history');
+});
+
+test('finishing an addition as one step: withdraw, then add with the same id', () => {
+  const tree = new Tree();
+  const { id } = tree.addPerson({ name: '' });
+  tree.withdraw(id);
+  tree.addPerson({ id, name: 'Ravi' });
+
+  assert.strictEqual(tree.undoLabel, 'Add Ravi');
+  tree.undo();
+  assert.strictEqual(tree.people.length, 0, 'one undo takes the whole addition back');
+});
+
+/* ---------------------------------------------------------------- keep as unknown */
+
+test('keeping someone as unknown clears every detail and keeps every connection', () => {
+  const { tree, father } = family();
+  tree.updatePerson(father, { birthDate: '1938', deceased: true, notes: 'x', photo: 'photos/a.jpg' });
+  const edges = tree.relationships.length;
+
+  assert.deepStrictEqual(tree.clearDetails(father), { ok: true });
+  assert.deepStrictEqual(tree.person(father), { id: father });
+  assert.strictEqual(tree.relationships.length, edges, 'the family still joins up through them');
+  assert.strictEqual(tree.undoLabel, 'Keep Shyam as unknown');
+
+  tree.undo();
+  assert.strictEqual(tree.person(father).name, 'Shyam', 'and undo gives them back');
+});
+
+test('keeping nobody as unknown is refused', () => {
+  assert.strictEqual(new Tree().clearDetails('nobody').reason, 'NO_SUCH_PERSON');
+});

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -115,8 +115,42 @@
  * who does not know the day should not be made to invent one.
  */
 .editor .field-hint {
-  font-size: 11px;
-  opacity: 0.55;
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--ink-faint);
+}
+
+/* One hint under both dates, rather than the same line twice or one field left bare (#147). */
+.editor .dates-hint {
+  grid-column: 1 / -1;
+  margin-top: calc(var(--field-gap) * -0.5);
+}
+
+/*
+ * A placeholder is an example, not a value.
+ *
+ * `1948` in the Born field must not be mistaken for somebody's birth year, so it is set in the
+ * faint ink the rest of the form uses for things that are not the record itself.
+ */
+.editor .field input::placeholder,
+.editor .field textarea::placeholder {
+  color: var(--ink-faint);
+  opacity: .8;
+}
+
+/* What is wrong with a date, under that date, in words that say how to put it right. */
+.editor .field-error {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.4;
+  color: var(--danger);
+}
+
+.editor .field-error:empty { display: none; }
+
+.editor .field[data-problem='true'] input {
+  border-color: var(--danger);
 }
 
 .editor .check {
@@ -266,6 +300,14 @@
   max-height: 168px;
 }
 
+/* The years beside a name in a list of matches, set apart as the viewer's own results set them. */
+.editor .search-results button small {
+  margin-left: 8px;
+  font-family: var(--mono);
+  font-size: calc(11px * var(--ui));
+  color: var(--ink-faint);
+}
+
 /* ------------------------------------------------------------------ saying no */
 
 /*
@@ -285,25 +327,172 @@
   line-height: 1.45;
 }
 
-.editor .danger-row {
-  margin-top: 26px;
-  padding-top: 14px;
-  border-top: 1px solid var(--rule);
+/* ------------------------------------------------------------------ the panel's frame */
+
+/*
+ * A head, a body that scrolls, and a foot that does not.
+ *
+ * The playground's panel scrolls as one block, which suits a reader. An editor's panel ends in the
+ * buttons that keep or discard what was typed, and a Save that has scrolled below a long family list
+ * is a Save nobody presses -- so here only the middle moves.
+ */
+.editor .edit-panel {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
 }
 
+.editor .panel-head {
+  display: flex;
+  align-items: center;
+  flex: none;
+  min-height: calc(56px * var(--ui));
+  padding: calc(14px * var(--ui)) calc(56px * var(--ui)) calc(12px * var(--ui)) calc(20px * var(--ui));
+  border-bottom: 1px solid var(--rule);
+}
+
+.editor .panel-title {
+  margin: 0;
+  font-family: var(--serif);
+  font-size: calc(18px * var(--ui));
+  font-weight: 600;
+  letter-spacing: -.01em;
+}
+
+.editor .edit-panel .panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 0 calc(20px * var(--ui)) calc(22px * var(--ui));
+  scrollbar-width: thin;
+  scrollbar-color: var(--rule-strong) transparent;
+}
+
+.editor .panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: none;
+  padding: calc(11px * var(--ui)) calc(14px * var(--ui)) calc(11px * var(--ui)) calc(20px * var(--ui));
+  border-top: 1px solid var(--rule);
+  background: var(--bone-dim);
+}
+
+/*
+ * Whether there is anything unsaved, said beside the button that would save it.
+ *
+ * Brass rather than the colour of a refusal: an unsaved edit is something to notice, not something
+ * wrong. After a save it says so for a moment in the quiet colour, then says nothing.
+ */
+.editor .panel-status {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  text-align: right;
+  font-family: var(--mono);
+  font-size: calc(11.5px * var(--ui));
+  color: var(--ink-faint);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.editor .panel-status[data-tone='dirty'] { color: var(--brass); }
+
+.editor .panel-actions .btn {
+  font-size: calc(12.5px * var(--ui));
+  padding: calc(8px * var(--ui)) calc(18px * var(--ui));
+}
+
+.editor .btn:disabled,
+.editor .btn:disabled:hover {
+  opacity: .42;
+  cursor: default;
+}
+
+.editor .btn.primary:disabled:hover { background: var(--forest); border-color: var(--forest); }
+
 .editor .btn-danger {
-  font: inherit;
-  font-size: 12.5px;
+  font-family: var(--mono);
+  font-size: calc(12.5px * var(--ui));
   color: var(--danger);
   background: none;
   border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-  border-radius: 8px;
-  padding: 6px 11px;
+  border-radius: 999px;
+  padding: calc(8px * var(--ui)) calc(14px * var(--ui));
   cursor: pointer;
+  white-space: nowrap;
+  transition: background .12s, border-color .12s;
 }
 
 .editor .btn-danger:hover {
   background: color-mix(in srgb, var(--danger) 12%, transparent);
+  border-color: var(--danger);
+}
+
+.editor .panel-actions button:focus-visible,
+.editor .ask button:focus-visible,
+.editor .toast-action:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* ------------------------------------------------------------------ a question before an act */
+
+.editor .review.ask[open] { width: min(470px, calc(100vw - 48px)); }
+
+/* No rule under the question: the options, or the buttons, are the rest of the same sentence. */
+.editor .ask .review-head { border-bottom: 0; padding-bottom: 6px; }
+.editor .ask .review-foot { justify-content: flex-end; margin-top: 16px; }
+
+.editor .ask-options {
+  display: grid;
+  gap: 8px;
+  padding: 12px 26px 0;
+}
+
+/*
+ * A choice that needs its sentence to be understood.
+ *
+ * "Keep as unknown" does not explain itself, and the difference between it and "Delete completely"
+ * is the whole reason the dialog exists -- so each is a block with its consequence written under it,
+ * not a button with a tooltip.
+ */
+.editor .ask-option {
+  display: grid;
+  gap: 3px;
+  width: 100%;
+  text-align: left;
+  font-family: var(--serif);
+  color: var(--ink);
+  background: var(--raised);
+  border: 1px solid var(--rule-strong);
+  border-radius: 11px;
+  padding: 12px 15px 13px;
+  cursor: pointer;
+  transition: border-color .12s, background .12s;
+}
+
+.editor .ask-option:hover { background: var(--bone-dim); border-color: var(--forest); }
+.editor .ask-option-label { font-size: 15px; font-weight: 600; }
+.editor .ask-option-detail { font-size: 13px; line-height: 1.45; color: var(--ink-soft); }
+
+.editor .ask-option[data-tone='danger'] .ask-option-label { color: var(--danger); }
+.editor .ask-option[data-tone='danger']:hover { border-color: var(--danger); }
+
+/* The one filled destructive button: the answer to "Discard changes?" that loses something. */
+.editor .btn.danger {
+  background: var(--danger);
+  border-color: var(--danger);
+  color: var(--on-danger);
+}
+
+.editor .btn.danger:hover {
+  background: color-mix(in srgb, var(--danger) 86%, var(--ink));
+  border-color: color-mix(in srgb, var(--danger) 86%, var(--ink));
+  color: var(--on-danger);
 }
 
 /* ------------------------------------------------------------------ toast */
@@ -321,7 +510,35 @@
   color: var(--paper);
   font-size: 13px;
   box-shadow: 0 6px 26px rgba(0, 0, 0, 0.22);
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
+
+/*
+ * The one thing a toast can offer to do, which is put back what it just announced.
+ *
+ * Set in the inverse of the forest -- pale green on the ink toast by day, deep green on the pale one
+ * by night -- so it reads as the app's own action colour on a surface that has swapped its ground.
+ */
+.editor .toast-action {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .02em;
+  color: var(--inverse-accent);
+  background: none;
+  border: 0;
+  border-radius: 6px;
+  padding: 4px 8px;
+  margin: -4px -8px -4px 0;
+  cursor: pointer;
+}
+
+.editor .toast-action:hover { background: color-mix(in srgb, var(--inverse-accent) 16%, transparent); }
+.editor .toast[data-tone='bad'] .toast-action { color: var(--on-danger); text-decoration: underline; }
+.editor .toast[data-tone='warn'] .toast-action { color: var(--forest); }
 
 .editor .toast[data-tone='bad'] {
   background: var(--danger);
@@ -1182,3 +1399,5 @@
   line-height: 1.5;
   color: var(--ink-faint);
 }
+
+.editor .nowrap { white-space: nowrap; }

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -203,9 +203,22 @@
     </aside>
 
     <!-- ------------------------------------------------------------ one person, editable -->
-    <aside class="panel edit-panel" id="panel" hidden aria-label="Edit this person">
-      <button type="button" class="panel-close" id="panel-close" aria-label="Close">&times;</button>
+    <!--
+      Three parts, and only the middle one scrolls. The heading says whether this is somebody being
+      added or somebody being edited, and the actions stay in reach however long the family list
+      below the form grows -- a Save button that has scrolled out of sight is one nobody presses.
+    -->
+    <aside class="panel edit-panel" id="panel" hidden aria-labelledby="panel-title">
+      <div class="panel-head">
+        <h2 class="panel-title" id="panel-title">Edit person</h2>
+        <button type="button" class="panel-close" id="panel-close" aria-label="Close">&times;</button>
+      </div>
       <div class="panel-body" id="panel-body"></div>
+      <div class="panel-actions" id="panel-actions">
+        <button type="button" class="btn-danger" id="panel-remove">Delete this person</button>
+        <p class="panel-status" id="panel-status" aria-live="polite"></p>
+        <button type="button" class="btn primary" id="panel-save">Save</button>
+      </div>
     </aside>
 
     <div class="busy" id="busy" hidden><span></span> Reading the file&hellip;</div>
@@ -355,8 +368,29 @@
     </div>
   </dialog>
 
+  <!-- ------------------------------------------------------------ a question before an act -->
+  <!--
+    One dialog for the app's two short questions -- "Discard changes?" and "Delete this person?" --
+    filled in by `ask()` in app.js. It borrows the review dialog's box so every question this app
+    asks looks like the same app asking, and it is native for the same reason: the focus trap and
+    Escape come with it, and Escape here always means the safe answer.
+  -->
+  <dialog class="review ask" id="ask" aria-labelledby="ask-title" aria-describedby="ask-body">
+    <div class="review-head" id="ask-head" tabindex="-1">
+      <h2 class="review-title" id="ask-title"></h2>
+      <p class="review-lead" id="ask-body"></p>
+    </div>
+    <div class="ask-options" id="ask-options"></div>
+    <div class="review-foot">
+      <div class="review-actions" id="ask-actions"></div>
+    </div>
+  </dialog>
+
   <!-- Said once, where the eye already is, and gone again. Never a dialog for a saved file. -->
-  <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
+  <div class="toast" id="toast" role="status" aria-live="polite" hidden>
+    <span class="toast-text" id="toast-text"></span>
+    <button type="button" class="toast-action" id="toast-action" hidden></button>
+  </div>
 </div>
 
 <script type="module" src="app.js"></script>

--- a/desktop/renderer/person-draft.js
+++ b/desktop/renderer/person-draft.js
@@ -1,0 +1,145 @@
+/*
+ * The person panel's edits, before they are kept.
+ *
+ * Until 0.6 the panel committed on every field's `change` event: nothing on screen said an edit had
+ * been taken, closing the panel did not commit, and a field still focused when it closed relied on
+ * the browser firing `change` on blur (#148). The phone never worked that way. Its edit screen holds
+ * the form in memory with a dirty flag, validates the dates, and writes on an explicit Save, with a
+ * discard dialog on the way out -- so this is that, ported, and pure so it can be tested without a
+ * page.
+ *
+ * The rules are `PersonEditViewModel.kt`'s, and the ones that are easy to get subtly wrong are
+ * spelled out where they live: which date problems block a save, and how a death date and "no
+ * longer living" pull on each other.
+ */
+
+import { parsePartialDate } from '../../site/playground/dates.js';
+
+/** Why a date somebody typed cannot be kept. The Kotlin's `DateProblem`, by name. */
+export const DateProblem = Object.freeze({
+  MALFORMED: 'MALFORMED',
+  DEATH_BEFORE_BIRTH: 'DEATH_BEFORE_BIRTH',
+});
+
+/** The fields the panel edits. A photograph is not one: it is framed and kept by its own dialog. */
+export const DRAFT_FIELDS = ['name', 'gender', 'birthDate', 'deathDate', 'deceased', 'notes'];
+
+/** What the form shows for a person, as strings and a boolean -- never null. */
+export function draftFrom(person) {
+  return {
+    name: person?.name ?? '',
+    gender: person?.gender ?? '',
+    birthDate: person?.birthDate ?? '',
+    deathDate: person?.deathDate ?? '',
+    deceased: Boolean(person?.deceased),
+    notes: person?.notes ?? '',
+  };
+}
+
+/**
+ * One field changed, with the two rules that tie a death to its date.
+ *
+ * Both from the Kotlin, and both about keeping the record consistent rather than about convenience:
+ * recording a death date says the person has died, so the switch follows the fact; and clearing
+ * "no longer living" would leave a death date stranded, so the date goes with it.
+ */
+export function withChange(draft, key, value) {
+  const next = { ...draft, [key]: value };
+  if (key === 'deathDate' && String(value).trim()) next.deceased = true;
+  if (key === 'deceased' && !value) next.deathDate = '';
+  return next;
+}
+
+/**
+ * What is wrong with the two dates, field by field.
+ *
+ * Only a date that cannot be understood, or an *impossible* order, is a problem. Overlapping partial
+ * dates are left alone -- "born 1938, died 1938" is a real thing to record -- so the comparison is
+ * the latest the death could be against the earliest the birth could be. A blank date is not a
+ * problem at all: most of a family tree is people whose dates nobody knows.
+ */
+export function dateProblems(draft) {
+  const birthText = String(draft.birthDate ?? '').trim();
+  const deathText = String(draft.deathDate ?? '').trim();
+  const birth = parsePartialDate(birthText);
+  const death = parsePartialDate(deathText);
+
+  const problems = {
+    birthDate: birthText && !birth ? DateProblem.MALFORMED : null,
+    deathDate: deathText && !death ? DateProblem.MALFORMED : null,
+  };
+  if (!problems.deathDate && birth && death && death.latest() < birth.earliest()) {
+    problems.deathDate = DateProblem.DEATH_BEFORE_BIRTH;
+  }
+  return problems;
+}
+
+/** A completely blank form is valid: it records a person whose details nobody knows yet. */
+export function canSave(draft) {
+  const problems = dateProblems(draft);
+  return !problems.birthDate && !problems.deathDate;
+}
+
+/** Text compared as it will be kept: `Tree.updatePerson` trims, so a trailing space is no edit. */
+const kept = (value) => (typeof value === 'string' ? value.trim() : value);
+
+/** Whether the form says something the tree does not. */
+export function isDirty(draft, person) {
+  const saved = draftFrom(person);
+  return DRAFT_FIELDS.some((key) => kept(draft[key]) !== kept(saved[key]));
+}
+
+/**
+ * The fields to hand `Tree.updatePerson`.
+ *
+ * Every field is named, including the empty ones, because naming a field with an empty value is how
+ * `updatePerson` is told to clear it -- a field left out would be left as it was.
+ */
+export function fieldsFrom(draft) {
+  return {
+    name: draft.name,
+    gender: draft.gender || null,
+    birthDate: draft.birthDate,
+    deathDate: draft.deathDate,
+    deceased: draft.deceased,
+    notes: draft.notes,
+  };
+}
+
+/** Nothing recorded about this person at all -- the state "Add a person" creates them in. */
+export function isBlankPerson(person) {
+  if (!person) return false;
+  return !person.name && !person.gender && !person.birthDate && !person.deathDate
+    && !person.deceased && !person.notes && !person.photo;
+}
+
+/**
+ * A date as it is typed, with any separator a person reaches for turned into the one the format uses.
+ *
+ * #90: the format is strict on purpose -- `1938`, `1938-04`, `1938-04-17`, because the precision is
+ * the statement about how much is known -- which makes the hyphen the only separator it accepts.
+ * So a space, a slash or a full stop becomes a hyphen *as it is typed*, and the parser stays exactly
+ * as strict as it was. A separator cannot lead, and cannot double up: leaning on the spacebar gives
+ * `1938-04`, never `1938--04` or `-1938`.
+ *
+ * Nothing is inserted, only replaced or dropped, so backspace goes back through a hyphen one press
+ * at a time. The caret is returned because dropping a character before it would otherwise leave it
+ * one place too far along.
+ *
+ * @param {string} value what the field holds after the keystroke
+ * @param {number} caret where the caret is in `value`
+ * @returns {{value: string, caret: number}}
+ */
+export function normaliseDateTyping(value, caret = value.length) {
+  let out = '';
+  let at = caret;
+  for (let i = 0; i < value.length; i += 1) {
+    const char = /[\s./]/.test(value[i]) ? '-' : value[i];
+    if (char === '-' && (out === '' || out.endsWith('-'))) {
+      if (i < caret) at -= 1;
+      continue;
+    }
+    out += char;
+  }
+  return { value: out, caret: Math.max(0, at) };
+}

--- a/desktop/renderer/person-draft.test.js
+++ b/desktop/renderer/person-draft.test.js
@@ -1,0 +1,159 @@
+/*
+ * The person panel's staged edits (#148) and date typing (#90's desktop half).
+ *
+ * There is no Kotlin test table to translate: `PersonEditViewModel.validate()` has none. So the
+ * cases here are written from what that function does, and the ones that encode a *decision* rather
+ * than arithmetic -- overlapping dates are allowed, a blank form is valid, a death date implies a
+ * death -- say which line of the Kotlin they come from.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import {
+  DateProblem, draftFrom, withChange, dateProblems, canSave, isDirty, fieldsFrom, isBlankPerson,
+  normaliseDateTyping,
+} from './person-draft.js';
+
+const blank = draftFrom({ id: 'p' });
+
+/* ------------------------------------------------------------------ dates */
+
+test('a blank date is not a problem -- most of a tree is people nobody has dates for', () => {
+  assert.deepStrictEqual(dateProblems(blank), { birthDate: null, deathDate: null });
+  assert.ok(canSave(blank), 'a completely blank form is valid (canSave in the Kotlin)');
+});
+
+test('the three precisions are all accepted', () => {
+  for (const date of ['1938', '1938-04', '1938-04-17']) {
+    assert.strictEqual(dateProblems({ ...blank, birthDate: date }).birthDate, null, date);
+  }
+});
+
+test('anything else is malformed, including a day that does not exist', () => {
+  for (const date of ['38', '1938-4', '17/04/1938', '1938-13', '1938-02-30', 'about 1938', '1938-']) {
+    assert.strictEqual(dateProblems({ ...blank, birthDate: date }).birthDate,
+      DateProblem.MALFORMED, date);
+  }
+});
+
+test('surrounding space is not a problem; the tree trims it anyway', () => {
+  assert.strictEqual(dateProblems({ ...blank, birthDate: ' 1938 ' }).birthDate, null);
+});
+
+test('a death before the birth is refused, and it is the death field that says so', () => {
+  const problems = dateProblems({ ...blank, birthDate: '1950', deathDate: '1949-12-31' });
+  assert.deepStrictEqual(problems, { birthDate: null, deathDate: DateProblem.DEATH_BEFORE_BIRTH });
+  assert.ok(!canSave({ ...blank, birthDate: '1950', deathDate: '1949' }));
+});
+
+test('overlapping partial dates are allowed -- "born 1938, died 1938" is real', () => {
+  // The Kotlin compares death.latest() with birth.earliest(), not the other way round.
+  for (const [birth, death] of [['1938', '1938'], ['1938-04', '1938'], ['1938', '1938-01-01'],
+    ['1938-04-17', '1938-04']]) {
+    assert.strictEqual(dateProblems({ ...blank, birthDate: birth, deathDate: death }).deathDate,
+      null, `${birth} / ${death}`);
+  }
+});
+
+test('a malformed date is reported as malformed, not also as out of order', () => {
+  const problems = dateProblems({ ...blank, birthDate: '1950', deathDate: '19x' });
+  assert.strictEqual(problems.deathDate, DateProblem.MALFORMED);
+});
+
+/* ------------------------------------------------------------------ a death and its date */
+
+test('typing a death date says the person has died', () => {
+  // onDeathDateChange: `deceased = it.deceased || value.isNotBlank()`
+  assert.strictEqual(withChange(blank, 'deathDate', '2001').deceased, true);
+  assert.strictEqual(withChange(blank, 'deathDate', '  ').deceased, false);
+});
+
+test('clearing "no longer living" takes the death date with it', () => {
+  // onDeceasedChange: `deathDate = if (value) it.deathDate else ""`
+  const died = { ...blank, deceased: true, deathDate: '2001' };
+  assert.deepStrictEqual(withChange(died, 'deceased', false), { ...died, deceased: false, deathDate: '' });
+  assert.strictEqual(withChange(blank, 'deceased', true).deathDate, '', 'ticking it invents nothing');
+});
+
+test('clearing a death date leaves the person dead -- plenty of deaths have no date', () => {
+  const died = { ...blank, deceased: true, deathDate: '2001' };
+  assert.strictEqual(withChange(died, 'deathDate', '').deceased, true);
+});
+
+/* ------------------------------------------------------------------ dirty */
+
+test('a form straight from a person is not dirty', () => {
+  const person = { id: 'p', name: 'Shyam Lal', birthDate: '1938', deceased: true, notes: 'x' };
+  assert.ok(!isDirty(draftFrom(person), person));
+});
+
+test('any field that differs makes it dirty', () => {
+  const person = { id: 'p', name: 'Shyam Lal' };
+  for (const [key, value] of [['name', 'Shyam'], ['gender', 'MALE'], ['birthDate', '1938'],
+    ['deathDate', '2001'], ['deceased', true], ['notes', 'x']]) {
+    assert.ok(isDirty({ ...draftFrom(person), [key]: value }, person), key);
+  }
+});
+
+test('a trailing space is not an edit, because it is not kept', () => {
+  const person = { id: 'p', name: 'Shyam Lal' };
+  assert.ok(!isDirty({ ...draftFrom(person), name: 'Shyam Lal  ' }, person));
+});
+
+test('the fields handed to the tree name every field, so clearing one clears it', () => {
+  const fields = fieldsFrom({ ...blank, name: 'Ravi' });
+  assert.deepStrictEqual(Object.keys(fields).sort(),
+    ['birthDate', 'deathDate', 'deceased', 'gender', 'name', 'notes']);
+  assert.strictEqual(fields.gender, null, 'no gender is null, not the empty string');
+});
+
+test('blank means nothing recorded at all, a photograph included', () => {
+  assert.ok(isBlankPerson({ id: 'p' }));
+  assert.ok(isBlankPerson({ id: 'p', name: '' }));
+  assert.ok(!isBlankPerson({ id: 'p', notes: 'x' }));
+  assert.ok(!isBlankPerson({ id: 'p', photo: 'photos/a.jpg' }));
+  assert.ok(!isBlankPerson({ id: 'p', deceased: true }));
+  assert.ok(!isBlankPerson(null));
+});
+
+/* ------------------------------------------------------------------ typing a date (#90) */
+
+const typed = (value, caret) => normaliseDateTyping(value, caret);
+
+test('a space, a slash or a full stop becomes a hyphen', () => {
+  assert.strictEqual(typed('1938 04 17').value, '1938-04-17');
+  assert.strictEqual(typed('1938/04/17').value, '1938-04-17');
+  assert.strictEqual(typed('1938.04.17').value, '1938-04-17');
+});
+
+test('a separator can neither lead nor double up', () => {
+  assert.strictEqual(typed(' 1938').value, '1938');
+  assert.strictEqual(typed('-1938').value, '1938');
+  assert.strictEqual(typed('1938  04').value, '1938-04');
+  assert.strictEqual(typed('1938- 04').value, '1938-04');
+});
+
+test('a trailing separator survives, because the next digits are on their way', () => {
+  assert.strictEqual(typed('1938 ').value, '1938-');
+});
+
+test('anything that is not a separator is left for the validator to judge', () => {
+  // Normalising is about the separator only. Loosening what counts as a date is not its job.
+  assert.strictEqual(typed('abt 1938').value, 'abt-1938');
+  assert.strictEqual(typed('17 04 1938').value, '17-04-1938');
+});
+
+test('the caret stays where it was, allowing for anything dropped before it', () => {
+  assert.deepStrictEqual(typed('1938 ', 5), { value: '1938-', caret: 5 });
+  assert.deepStrictEqual(typed('1938--', 6), { value: '1938-', caret: 5 });
+  // A space typed in front of the year is dropped, and the caret with it.
+  assert.deepStrictEqual(typed(' 1938', 1), { value: '1938', caret: 0 });
+  // Editing in the middle: a doubled separator after the caret moves nothing before it.
+  assert.deepStrictEqual(typed('19-38--04', 2), { value: '19-38-04', caret: 2 });
+});
+
+test('a value that needs nothing done comes back unchanged', () => {
+  assert.deepStrictEqual(typed('1938-04-17', 4), { value: '1938-04-17', caret: 4 });
+  assert.deepStrictEqual(typed('', 0), { value: '', caret: 0 });
+});

--- a/desktop/renderer/theme-tokens.test.js
+++ b/desktop/renderer/theme-tokens.test.js
@@ -4,7 +4,7 @@
  * #145: four tokens -- --paper, --danger, --accent and --sunk -- were used seventeen times and
  * defined nowhere. Each use carried an inline fallback, and every fallback was a daytime colour, so
  * the page looked right by day purely by accident and drew near-white text on a near-white toast by
- * night (about 1.09:1). Nothing was looking, which is the part worth fixing.
+ * night (1.19:1). Nothing was looking, which is the part worth fixing.
  *
  * So this reads the two stylesheets the desktop loads and asserts the whole class rather than the
  * four instances: nothing used is undefined, nothing hides behind a fallback, every colour the day
@@ -118,8 +118,10 @@ const PAIRS = [
   ['--paper', '--ink', 'the ordinary toast'],
   ['--on-danger', '--danger', 'a refusal toast'],
   ['--ink', '--brass-surface', 'a warning toast'],
-  ['--danger', '--raised', '"Delete this person" on the panel'],
+  ['--danger', '--raised', 'a date problem, under its field'],
   ['--ink', '--raised', 'the panel itself'],
+  ['--inverse-accent', '--ink', 'the Undo button on a toast'],
+  ['--danger', '--bone-dim', '"Delete this person", in the foot of the panel'],
 ];
 
 for (const [label, overrides] of [['day', new Map()], ['night', DARK]]) {

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -27,6 +27,40 @@ which multiply a chart's width far faster than they add to what it tells you. Cl
 the reading to that person. Where the record goes further than the reading, it says so and offers
 to go on.
 
+## Editing a person
+
+The person panel keeps its edits as a draft and writes them to the tree on **Save**, which is how
+the phone's edit screen has always worked ([#148](https://github.com/thisisankit27/f-tree/issues/148)).
+It used to commit each field as it lost focus. That meant nothing on screen said an edit had been
+taken, and closing the panel with a field still focused depended on the browser firing `change`.
+
+| | |
+|---|---|
+| **Save** | keeps the draft as one step in the history; disabled while there is nothing unsaved |
+| **Add** | the same button for somebody "Add a person" has just created, still blank |
+| **Discard** | backs out of that addition. The blank card goes, with no trace in the history (`Tree.withdraw`) |
+| **Delete this person** | for anybody already in the tree. Asks first when they have connections |
+| leaving with edits | *Discard changes? / Your edits to this person won't be kept.*, in Android's words |
+
+"Discard" is offered only while the person is a fresh, blank addition. On anybody else the button
+removes them and every one of their connections, and "Discard" would read as "discard my edits",
+which is not what happens.
+
+**Deleting somebody with connections** offers Android's two choices: *Keep as unknown*, which clears
+their details but keeps their place so the family still joins up (`Tree.clearDetails`), and *Delete
+completely*. Somebody joined to nobody is deleted straight away. Either way the toast carries an
+**Undo** button.
+
+**Dates are checked before they are kept**, by Android's rules (`renderer/person-draft.js`): a date
+must be `1938`, `1938-04` or `1938-04-17`, and a death may not end before the birth begins.
+Overlapping partial dates are fine, since "born 1938, died 1938" is real. A space, slash or full stop
+typed in a date becomes the dash as it is typed
+([#90](https://github.com/thisisankit27/f-tree/issues/90)), so the parser stays exactly as strict as
+it was. A death date ticks *No longer living*, and unticking it clears the date.
+
+Ctrl+Z inside a text field undoes the typing, not the last change to the tree. The menu owns the
+accelerator, so without that exception it would take back a relative added a minute ago.
+
 ## Photographs
 
 A face in the person panel, and **click it to see the photograph whole** — every other surface shows

--- a/site/playground/playground.css
+++ b/site/playground/playground.css
@@ -60,6 +60,8 @@
   --accent: var(--forest);
   --paper: var(--bone);
   --sunk: rgba(26, 28, 26, .045);
+  /* The action colour on an ink surface -- the toast -- where the forest would vanish. */
+  --inverse-accent: var(--sage);
 
   /* One multiplier for every size in the chrome, so "big screen" is a single number. */
   --ui: 1;
@@ -106,6 +108,7 @@
   --danger: #ffb4a8;
   --on-danger: #561410;
   --sunk: rgba(224, 228, 221, .06);
+  --inverse-accent: #2a5138;
   --forest-hover: #b6dbc3;
   --on-forest: #06371c;
   --on-sage: #abe4bc;


### PR DESCRIPTION
The second PR of #152. It is **stacked on #159** (the base is that branch), so the diff shows only this work. Once #159 is merged, retarget this to `main`.

The second PR of #152. #159 is merged and this now targets `main`.

**#148: the panel commits when asked, not when a field blurs.**

| state | primary | destructive | leaving with edits |
|---|---|---|---|
| just created by "Add a person", still blank | **Add** | **Discard** (removes the blank card, no trace in history) | asks |
| anybody already in the tree | **Save** (disabled when clean) | **Delete this person** | asks |

- The draft survives redraws (adding a photo, adding a relative). A draft with no edits refreshes from the tree, so an undo shows in the form at once.
- The footer says `Unsaved`, then `Saved` or `Added` for a moment. The panel now has a fixed head ("Add a person" / "Edit person") and a fixed footer. Only the form and family list scroll, so Save never scrolls out of reach.
- **Every way of leaving asks** when there are edits: another card, ×, Escape, the relation finder, opening a file, New tree, Close tree. It uses Android's wording, *Discard changes? / Your edits to this person won't be kept. / Keep editing / Discard*, with Keep editing focused and Escape = keep.
- **Delete confirmation (your decision):** someone with connections gets Android's dialog, *Keep as unknown* or *Delete completely*, or Cancel. Someone joined to nobody is deleted at once. Every toast announcing an undoable act now carries an **Undo** button instead of "Undo with Ctrl+Z".
- Enter in a single-line field saves; Ctrl+Enter saves from Notes. Ctrl+S saves the draft together with the file.
- Ctrl+Z *inside a text field* undoes typing, not the last tree change. The menu owns the accelerator, so before this it would have undone a relative added a minute ago.

**#147: dates.**
- Born and **Passed away** (Android's label) now actually sit side by side. Gender was taking Born's partner slot and stranding Died on its own row.
- Placeholders are real dates, `1948` and `2019-03-14`. One hint sits under both: *A year alone is fine. Spaces become dashes.* I chose a single shared hint over printing the same line twice.
- **Validation ported from Android** (`PersonEditViewModel.validate`):
  - A malformed date or a death before birth is shown under its field, in Android's words, once the field is left or Save is pressed.
  - Save is refused, and the caret goes to the problem.
  - Before this the desktop accepted *any* text as a date, including ones the phone cannot parse.
- **#90, desktop half:** space, `/` and `.` become `-` as they are typed. There is no leading or doubled dash, the caret is preserved, and the parser is as strict as ever. #90 stays open for Android, which I haven't touched.

Also fixed: add-relative results ran the name into the years ("Gopal Sharma1940–2008").

## Code
- `renderer/person-draft.js` (pure) + 21 tests: the validation, the death/deceased coupling, dirty checking, and the date-typing normaliser with caret handling.
- `Tree.withdraw` / `canWithdraw` (finish or back out of an addition as one history step) and `Tree.clearDetails` (Keep as unknown) + 6 tests.
- One `ask()` dialog helper on the existing `.review` dialog shell, so every question looks like the same app asking.
- `--inverse-accent` is the toast's Undo colour. The contrast guard now also covers the Undo button and date errors: all pairs ≥ 4.5:1 in both themes.

## Verified locally
- `npm test`: **320 pass**
- full smoke with every CI gate set: **110 ok, 0 failed** (12 new assertions for this PR)
- driven in Chromium with Playwright, light and dark:
  - the fresh → type → click away → *Keep editing* → Add flow
  - the delete dialog → Keep as unknown → toast **Undo** → restored
  - an untouched "Add a person" + Escape leaves the count unchanged
  - a new tree's first person closed untouched brings back the empty-tree invitation
- `git status --short app/` is empty

Part of #152. Closes #147, closes #148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
