### PR TITLE
feat(desktop): autosave the open tree, with rotating backups (#149)

### DIFF
--- a/desktop/atomic.js
+++ b/desktop/atomic.js
@@ -20,8 +20,10 @@ const path = require('node:path');
  *    cut in the middle costs the edit, never the tree. The temp file must share the directory:
  *    a rename across filesystems is a copy, and copies are interruptible.
  *
- * 3. Whatever was there before is kept as `<name>.bak`, replaced each save. That is one step
- *    back on disk, on top of undo in the app and the phone still holding the original.
+ * 3. Nothing else is written beside the file. It used to leave the previous version there as
+ *    `<name>.bak`, which under autosave (#149) would be overwritten every second and so only ever
+ *    hold the version from a moment ago. Earlier versions are kept by `backups.js` instead, in the
+ *    app's own folder, on a schedule that makes them worth having.
  *
  * The directory itself is fsynced too, which is what actually makes the rename durable; without
  * it the file contents survive a crash and the directory entry pointing at them may not.
@@ -40,14 +42,6 @@ async function writeTreeFile(target, bytes) {
   }
 
   try {
-    /*
-     * The backup is a copy, not a rename: renaming the original away would leave the path with
-     * nothing in it for as long as the copy takes, and a reader arriving in that instant would
-     * find the tree missing. Copying leaves the original in place until the atomic rename.
-     */
-    const existing = await fs.readFile(target).catch(() => null);
-    if (existing) await fs.writeFile(`${target}.bak`, existing);
-
     await fs.rename(temporary, target);
   } catch (error) {
     await fs.rm(temporary, { force: true });

--- a/desktop/atomic.test.js
+++ b/desktop/atomic.test.js
@@ -29,32 +29,15 @@ test('a new file is written', async () => {
   assert.strictEqual(await fs.readFile(target, 'utf8'), 'hello');
 });
 
-test('no backup is made when there was nothing to back up', async () => {
-  const dir = await scratch();
-  const target = path.join(dir, 'tree.ftree');
-  await writeTreeFile(target, bytes('first'));
-  assert.ok(!fssync.existsSync(`${target}.bak`));
-});
-
-test('the previous contents are kept as .bak', async () => {
-  const dir = await scratch();
-  const target = path.join(dir, 'tree.ftree');
-  await writeTreeFile(target, bytes('first'));
-  await writeTreeFile(target, bytes('second'));
-
-  assert.strictEqual(await fs.readFile(target, 'utf8'), 'second');
-  assert.strictEqual(await fs.readFile(`${target}.bak`, 'utf8'), 'first');
-});
-
-test('the backup is one step back, not a growing pile', async () => {
+test('a second write replaces the first, and leaves nothing beside it', async () => {
+  // No `.bak` any more: earlier versions are kept by backups.js, away from the reader's folder.
   const dir = await scratch();
   const target = path.join(dir, 'tree.ftree');
   for (const text of ['one', 'two', 'three']) await writeTreeFile(target, bytes(text));
 
   assert.strictEqual(await fs.readFile(target, 'utf8'), 'three');
-  assert.strictEqual(await fs.readFile(`${target}.bak`, 'utf8'), 'two');
-  const left = await fs.readdir(dir);
-  assert.deepStrictEqual(left.sort(), ['tree.ftree', 'tree.ftree.bak']);
+  assert.deepStrictEqual(await fs.readdir(dir), ['tree.ftree']);
+  assert.ok(!fssync.existsSync(`${target}.bak`));
 });
 
 test('nothing temporary is left behind', async () => {

--- a/desktop/backups.js
+++ b/desktop/backups.js
@@ -1,0 +1,110 @@
+/*
+ * Earlier versions of a tree, kept where the reader never has to see them.
+ *
+ * Autosave (#149) writes the open file a second or two after every change. That is what makes the
+ * Save button unnecessary, and it is also what makes a mistake permanent the moment it is made: an
+ * accidental delete is on disk before anybody has noticed it. Undo covers the window the app is
+ * open; this covers the rest.
+ *
+ * The rule is Android's, from `TreeImporter.kt`'s pre-import backup -- "keep a few, not a growing
+ * pile; these exist to undo a mistake noticed soon after" -- with a policy for *when* that suits a
+ * file written continuously:
+ *
+ *   - one copy of the file as it was before the first write of each run, so opening a tree and
+ *     spoiling it always leaves the version you opened
+ *   - then at most one every ten minutes while writing continues, so an afternoon's work has a few
+ *     points to go back to rather than one per keystroke
+ *   - the newest five per tree, and nothing older
+ *
+ * They live in the app's own data folder, one folder per tree, and nothing is added beside the file
+ * the reader chose. That replaces the `<name>.bak` the atomic writer used to leave next to it, which
+ * under autosave would have been overwritten every second and so held only the version from a
+ * moment earlier.
+ */
+
+const crypto = require('node:crypto');
+const fs = require('node:fs/promises');
+const path = require('node:path');
+
+const KEEP = 5;
+const INTERVAL_MS = 10 * 60 * 1000;
+
+/** Sortable as text, and legal in a file name on every platform: no colons. */
+function stampFor(date) {
+  return `${date.toISOString().replace(/:/g, '-')}.ftree`;
+}
+
+/** The moment a stamp was taken, or NaN for a file that is not one of ours. */
+function timeOf(name) {
+  const match = /^(\d{4}-\d{2}-\d{2})T(\d{2})-(\d{2})-(\d{2})(\.\d+)?Z\.ftree$/.exec(name);
+  if (!match) return NaN;
+  return Date.parse(`${match[1]}T${match[2]}:${match[3]}:${match[4]}${match[5] ?? ''}Z`);
+}
+
+/**
+ * The folder one tree's backups live in.
+ *
+ * Named for the file so a person looking in it can tell trees apart, and suffixed with a hash of the
+ * full path so two files both called `family.ftree` in different folders never share one.
+ */
+function folderFor(root, target) {
+  const resolved = path.resolve(target);
+  const base = path.basename(resolved).replace(/\.ftree$/i, '');
+  const slug = base.normalize('NFKD').replace(/[^\w.-]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40)
+    || 'tree';
+  const hash = crypto.createHash('sha256').update(resolved).digest('hex').slice(0, 10);
+  return path.join(root, `${slug}-${hash}`);
+}
+
+/**
+ * Whether to take a backup now, and which old ones to let go.
+ *
+ * Pure, so the policy is settled by a test table rather than by waiting ten minutes.
+ *
+ * @param {{existing: string[], takenThisRun: boolean, now: Date, keep?: number, interval?: number}}
+ * @returns {{take: boolean, prune: string[]}}
+ */
+function plan({ existing, takenThisRun, now, keep = KEEP, interval = INTERVAL_MS }) {
+  const ours = existing.filter((name) => Number.isFinite(timeOf(name))).sort();
+  const newest = ours.at(-1);
+  const take = !takenThisRun || !newest || now.getTime() - timeOf(newest) >= interval;
+  const after = take ? ours.length + 1 : ours.length;
+  const excess = Math.max(0, after - keep);
+  return { take, prune: ours.slice(0, excess) };
+}
+
+/**
+ * Copies the file at `target` into its backup folder, if the policy says so.
+ *
+ * Called before every write, and deliberately unable to stop one: a backup that failed is a line in
+ * the log, while a save refused because a backup failed would lose the very edit it was protecting.
+ *
+ * @param {string} target the tree about to be overwritten
+ * @param {{root: string, now?: Date, takenThisRun: Set<string>}} options `takenThisRun` is the set of
+ *   paths already backed up since the app started; this adds to it
+ * @returns {Promise<string|null>} the backup written, or null if none was needed
+ */
+async function backUpBefore(target, { root, now = new Date(), takenThisRun }) {
+  const resolved = path.resolve(target);
+  const existing = await fs.readFile(resolved).catch(() => null);
+  if (!existing) return null;   // a new file has no earlier version to keep
+
+  const folder = folderFor(root, resolved);
+  await fs.mkdir(folder, { recursive: true });
+  const names = await fs.readdir(folder);
+  const { take, prune } = plan({ existing: names, takenThisRun: takenThisRun.has(resolved), now });
+  if (!take) return null;
+
+  const written = path.join(folder, stampFor(now));
+  await fs.writeFile(written, existing);
+  // Which tree this folder is for, in words, for whoever opens it from File > Show backups.
+  await fs.writeFile(path.join(folder, 'README.txt'),
+    `Earlier versions of ${resolved}, kept by f-tree.\n`
+    + 'Open one with File > Open tree to look at it; save it under a new name to keep it.\n');
+  takenThisRun.add(resolved);
+
+  for (const name of prune) await fs.rm(path.join(folder, name), { force: true });
+  return written;
+}
+
+module.exports = { KEEP, INTERVAL_MS, stampFor, timeOf, folderFor, plan, backUpBefore };

--- a/desktop/backups.test.js
+++ b/desktop/backups.test.js
@@ -1,0 +1,157 @@
+/*
+ * The rotating backups behind autosave (#149).
+ *
+ * The policy is the part worth pinning down, because it is the part nobody will notice is wrong
+ * until the day they need a backup: one before the first write of a run, then one per ten minutes,
+ * five kept. So it is a pure function under a table, and the file-handling around it is exercised
+ * against a real temporary directory.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const { KEEP, INTERVAL_MS, stampFor, timeOf, folderFor, plan, backUpBefore } = require('./backups');
+
+const at = (iso) => new Date(iso);
+
+/* ------------------------------------------------------------------ names */
+
+test('a stamp sorts as text in time order and has no colon in it', () => {
+  const a = stampFor(at('2026-09-11T09:05:07.001Z'));
+  const b = stampFor(at('2026-09-11T10:00:00.000Z'));
+  assert.ok(a < b);
+  assert.ok(!a.includes(':'), 'a colon is not legal in a Windows file name');
+  assert.strictEqual(timeOf(a), at('2026-09-11T09:05:07.001Z').getTime());
+});
+
+test('a file that is not a stamp is not counted as a backup', () => {
+  assert.ok(Number.isNaN(timeOf('README.txt')));
+  assert.ok(Number.isNaN(timeOf('family.ftree')));
+});
+
+test('two trees with the same name in different folders get different backup folders', () => {
+  const a = folderFor('/b', '/home/a/family.ftree');
+  const b = folderFor('/b', '/home/b/family.ftree');
+  assert.notStrictEqual(a, b);
+  assert.match(path.basename(a), /^family-[0-9a-f]{10}$/, 'named for the tree, so a person can tell');
+});
+
+test('a name with nothing usable in it still gets a folder', () => {
+  assert.match(path.basename(folderFor('/b', '/x/%%%.ftree')), /^tree-[0-9a-f]{10}$/);
+});
+
+/* ------------------------------------------------------------------ when */
+
+const stamps = (...isos) => isos.map((iso) => stampFor(at(iso)));
+
+test('the first write of a run always takes one, however recent the last', () => {
+  // Opening a tree and spoiling it must always leave the version that was opened.
+  const existing = stamps('2026-09-11T10:00:00Z');
+  const now = at('2026-09-11T10:00:05Z');
+  assert.strictEqual(plan({ existing, takenThisRun: false, now }).take, true);
+});
+
+test('after that, not again until ten minutes have passed', () => {
+  const existing = stamps('2026-09-11T10:00:00Z');
+  const soon = at('2026-09-11T10:09:59Z');
+  const later = new Date(at('2026-09-11T10:00:00Z').getTime() + INTERVAL_MS);
+  assert.strictEqual(plan({ existing, takenThisRun: true, now: soon }).take, false);
+  assert.strictEqual(plan({ existing, takenThisRun: true, now: later }).take, true);
+});
+
+test('a folder with nothing in it takes one', () => {
+  assert.strictEqual(plan({ existing: [], takenThisRun: true, now: at('2026-09-11T10:00:00Z') }).take,
+    true);
+});
+
+test('five are kept, and the oldest go first', () => {
+  const existing = stamps('2026-09-11T08:00:00Z', '2026-09-11T08:20:00Z', '2026-09-11T08:40:00Z',
+    '2026-09-11T09:00:00Z', '2026-09-11T09:20:00Z');
+  const { take, prune } = plan({ existing, takenThisRun: true, now: at('2026-09-11T10:00:00Z') });
+  assert.strictEqual(KEEP, 5);
+  assert.strictEqual(take, true);
+  assert.deepStrictEqual(prune, [existing[0]], 'one in, the oldest out');
+});
+
+test('nothing is pruned on a write that takes nothing', () => {
+  const existing = stamps('2026-09-11T08:00:00Z', '2026-09-11T08:20:00Z', '2026-09-11T08:40:00Z',
+    '2026-09-11T09:00:00Z', '2026-09-11T09:55:00Z');
+  const { take, prune } = plan({ existing, takenThisRun: true, now: at('2026-09-11T10:00:00Z') });
+  assert.strictEqual(take, false);
+  assert.deepStrictEqual(prune, []);
+});
+
+test('a README among the backups is neither counted nor pruned', () => {
+  const existing = ['README.txt', ...stamps('2026-09-11T08:00:00Z')];
+  const { prune } = plan({ existing, takenThisRun: false, now: at('2026-09-11T10:00:00Z'), keep: 1 });
+  assert.deepStrictEqual(prune, stamps('2026-09-11T08:00:00Z'));
+});
+
+/* ------------------------------------------------------------------ on a real disk */
+
+async function scratch() {
+  return fs.mkdtemp(path.join(os.tmpdir(), 'ftree-backups-'));
+}
+
+test('the version on disk is copied before it is replaced, and the folder says whose it is', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'family.ftree');
+  const root = path.join(dir, 'backups');
+  await fs.writeFile(target, 'as opened');
+
+  const written = await backUpBefore(target, { root, takenThisRun: new Set(),
+    now: at('2026-09-11T10:00:00Z') });
+
+  assert.strictEqual(await fs.readFile(written, 'utf8'), 'as opened');
+  const readme = await fs.readFile(path.join(path.dirname(written), 'README.txt'), 'utf8');
+  assert.ok(readme.includes(target), 'names the tree it holds versions of');
+  assert.deepStrictEqual((await fs.readdir(dir)).sort(), ['backups', 'family.ftree'],
+    'nothing is left beside the reader’s file');
+});
+
+test('a new file has nothing to back up', async () => {
+  const dir = await scratch();
+  const written = await backUpBefore(path.join(dir, 'new.ftree'),
+    { root: path.join(dir, 'backups'), takenThisRun: new Set() });
+  assert.strictEqual(written, null);
+});
+
+test('a run of writes a second apart makes one backup, not one each', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'family.ftree');
+  const root = path.join(dir, 'backups');
+  const takenThisRun = new Set();
+  let clock = at('2026-09-11T10:00:00Z').getTime();
+
+  for (let i = 0; i < 20; i += 1) {
+    await fs.writeFile(target, `version ${i}`);
+    await backUpBefore(target, { root, takenThisRun, now: new Date(clock) });
+    clock += 1000;
+  }
+  const kept = (await fs.readdir(folderFor(root, target))).filter((n) => n.endsWith('.ftree'));
+  assert.strictEqual(kept.length, 1);
+  assert.strictEqual(await fs.readFile(path.join(folderFor(root, target), kept[0]), 'utf8'),
+    'version 0', 'and it is the version from before the first write');
+});
+
+test('an afternoon of writing keeps five, the newest five', async () => {
+  const dir = await scratch();
+  const target = path.join(dir, 'family.ftree');
+  const root = path.join(dir, 'backups');
+  const takenThisRun = new Set();
+  let clock = at('2026-09-11T13:00:00Z').getTime();
+
+  for (let i = 0; i < 9; i += 1) {
+    await fs.writeFile(target, `version ${i}`);
+    await backUpBefore(target, { root, takenThisRun, now: new Date(clock) });
+    clock += INTERVAL_MS;
+  }
+  const folder = folderFor(root, target);
+  const kept = (await fs.readdir(folder)).filter((n) => n.endsWith('.ftree')).sort();
+  assert.strictEqual(kept.length, 5);
+  assert.strictEqual(await fs.readFile(path.join(folder, kept[0]), 'utf8'), 'version 4');
+  assert.strictEqual(await fs.readFile(path.join(folder, kept[4]), 'utf8'), 'version 8');
+});

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -18,6 +18,7 @@ const path = require('node:path');
 
 const { chooseUpdate } = require('./update');
 const { writeTreeFile } = require('./atomic');
+const { backUpBefore, folderFor } = require('./backups');
 const { installationId } = require('./identity');
 const {
   DEFAULT_SETTINGS,
@@ -101,6 +102,9 @@ if (process.env.FTREE_SMOKE) {
 const unsaved = new Map();
 
 const stateFile = () => path.join(app.getPath('userData'), 'session.json');
+
+/** The tree the session file last named, so an autosave every second does not rewrite it each time. */
+let sessionTree = null;
 const settingsFile = () => path.join(app.getPath('userData'), 'settings.json');
 
 /*
@@ -164,6 +168,7 @@ async function readSession() {
 }
 
 async function writeSession(session) {
+  sessionTree = session.lastTree ?? null;
   try {
     await fs.mkdir(path.dirname(stateFile()), { recursive: true });
     await fs.writeFile(stateFile(), JSON.stringify(session, null, 2));
@@ -181,19 +186,66 @@ async function readTree(file) {
 
 /* ------------------------------------------------------------------ saving */
 
-async function saveInto(win, target, bytes) {
+/** Where earlier versions of every tree are kept. See backups.js. */
+const backupRoot = () => path.join(app.getPath('userData'), 'backups');
+
+/** Trees already backed up since the app started, so the first write of a run always takes one. */
+const backedUpThisRun = new Set();
+
+/**
+ * Puts a tree's bytes on disk: a backup of what was there, then the atomic write.
+ *
+ * `quiet` is autosave's. A write the reader asked for gets a native error dialog when it fails; one
+ * that happens on its own a second after an edit reports back to the page instead, which says so in
+ * its own bar -- a modal dialog every few seconds while a drive is unplugged would be worse than the
+ * problem it reports.
+ */
+async function saveInto(win, target, bytes, { quiet = false } = {}) {
+  try {
+    await backUpBefore(target, { root: backupRoot(), takenThisRun: backedUpThisRun });
+  } catch (error) {
+    // Never a reason to refuse the write: that would lose the very edit the backup protects.
+    console.warn(`f-tree: could not back up ${target} — ${error.message}`);
+  }
+
   try {
     await writeTreeFile(target, bytes);
-    await writeSession({ lastTree: target });
+    if (sessionTree !== target) await writeSession({ lastTree: target });
     return { ok: true, path: target, name: path.basename(target) };
   } catch (error) {
-    await dialog.showMessageBox(win, {
-      type: 'error',
-      message: 'That tree could not be saved.',
-      detail: `${target}\n\n${error.message}\n\nThe file on disk has not been changed.`,
+    if (!quiet) {
+      await dialog.showMessageBox(win, {
+        type: 'error',
+        message: 'That tree could not be saved.',
+        detail: `${target}\n\n${error.message}\n\nThe file on disk has not been changed.`,
+        buttons: ['OK'],
+      });
+    }
+    return { ok: false, reason: error.message, code: error.code ?? null };
+  }
+}
+
+/**
+ * Opens the folder of earlier versions -- the open tree's own, if it has any yet.
+ *
+ * The folder rather than a restore screen, deliberately. A backup is a .ftree like any other: it
+ * opens with File > Open tree, and saving it under a new name keeps it. A picker that did that for
+ * the reader would be a second way to open a file, and one more thing to get wrong.
+ */
+async function showBackups() {
+  const { lastTree } = await readSession();
+  const own = lastTree ? folderFor(backupRoot(), lastTree) : null;
+  const exists = async (dir) => fs.access(dir).then(() => true, () => false);
+  const target = own && (await exists(own)) ? own : backupRoot();
+  await fs.mkdir(target, { recursive: true });
+  const problem = await shell.openPath(target);
+  if (problem) {
+    dialog.showMessageBox(window_, {
+      type: 'info',
+      message: 'Backups are kept in this folder.',
+      detail: target,
       buttons: ['OK'],
     });
-    return { ok: false, reason: error.message };
   }
 }
 
@@ -482,6 +534,9 @@ function buildMenu(win) {
           click: () => win.webContents.send('menu:command', 'file:save') },
         { label: 'Save as…', accelerator: 'CmdOrCtrl+Shift+S',
           click: () => win.webContents.send('menu:command', 'file:saveAs') },
+        // Earlier versions, kept by autosave's backups. Beside Save, because it is the answer to
+        // "autosave kept a mistake": the version before it is in here.
+        { label: 'Show backups', click: () => showBackups() },
         { type: 'separator' },
         { label: 'Undo', accelerator: 'CmdOrCtrl+Z',
           click: () => win.webContents.send('menu:command', 'edit:undo') },
@@ -630,54 +685,72 @@ function refuseTheNetwork(ses) {
 /*
  * A window with unsaved edits does not simply vanish.
  *
- * The page reports whether there is unsaved work; this refuses the close while there is, and asks.
- * "Save" hands the work back to the page, because the page is the only side that can serialise a
- * tree and verify it -- and then waits for it to report itself clean rather than assuming it did.
+ * With autosave (#149) "unsaved" is usually a second-long state -- a change still in its pause --
+ * so the first thing done on close is to ask the page to write it now. If that is all it was, the
+ * window closes without a question. Only what is still not on disk a moment later is asked about:
+ * a new tree that has never had a file, a person half-edited in the panel, or a write that failed.
  *
- * The wait has a deadline and the deadline has an honest ending: if the page has not saved by
- * then, the window stays open and says so. An editor that hung on closing would be a worse bug
- * than the one this prevents.
+ * "Save" hands the work to the page, which is the only side that can serialise and verify a tree,
+ * and then waits for the page to say how it went -- not for a flag to flip within a deadline. The
+ * old ten-second deadline expired while somebody was still choosing a folder in the Save dialog,
+ * and put a second dialog on top of the first.
  */
 function guardUnsavedWork(win) {
   let letItGo = false;
+  let handling = false;
 
   win.on('close', (event) => {
     if (letItGo || !unsaved.get(win.id)) return;
     event.preventDefault();
+    if (handling) return;
+    handling = true;
 
     (async () => {
-      const answer = await dialog.showMessageBox(win, {
-        type: 'warning',
-        message: 'This tree has changes you have not saved.',
-        detail: 'Closing now loses them. There is no copy of these edits anywhere else.',
-        buttons: ['Save', 'Discard the changes', 'Cancel'],
-        defaultId: 0,
-        cancelId: 2,
-      });
+      try {
+        win.webContents.send('menu:command', 'file:flush');
+        if (await waitUntilSaved(win, 3000)) {
+          letItGo = true;
+          win.close();
+          return;
+        }
 
-      if (answer.response === 2) return;
-      if (answer.response === 1) { letItGo = true; win.close(); return; }
+        const answer = await dialog.showMessageBox(win, {
+          type: 'warning',
+          message: 'This tree has changes you have not saved.',
+          detail: 'Closing now loses them. There is no copy of these edits anywhere else.',
+          buttons: ['Save', 'Discard the changes', 'Cancel'],
+          defaultId: 0,
+          cancelId: 2,
+        });
 
-      win.webContents.send('menu:command', 'file:save');
-      const saved = await waitUntilSaved(win);
-      if (!saved) {
+        if (answer.response === 2) return;
+        if (answer.response === 1) { letItGo = true; win.close(); return; }
+
+        win.webContents.send('menu:command', 'file:saveForClose');
+        const outcome = await saveOutcome(win);
+        if (outcome === 'saved' || !unsaved.get(win.id)) {
+          letItGo = true;
+          win.close();
+          return;
+        }
+        // Backing out of the Save dialog is an answer, not a failure: the window stays, quietly.
+        if (outcome === 'cancelled') return;
         await dialog.showMessageBox(win, {
           type: 'warning',
           message: 'The tree has not been saved.',
-          detail: 'The window has been left open so nothing is lost. Try File then Save.',
+          detail: 'The window has been left open so nothing is lost. The problem is shown in it.',
           buttons: ['OK'],
         });
-        return;
+      } finally {
+        handling = false;
       }
-      letItGo = true;
-      win.close();
     })();
   });
 
   win.on('closed', () => unsaved.delete(win.id));
 }
 
-/** Polls for the page reporting itself clean. Ten seconds, then the honest answer. */
+/** Polls for the page reporting itself clean, up to a deadline. */
 async function waitUntilSaved(win, deadlineMs = 10_000) {
   const until = Date.now() + deadlineMs;
   while (Date.now() < until) {
@@ -687,6 +760,39 @@ async function waitUntilSaved(win, deadlineMs = 10_000) {
   }
   return !unsaved.get(win.id);
 }
+
+/** Saves the quit prompt is waiting on, by window, until the page reports how they went. */
+const pendingSaves = new Map();
+
+/**
+ * Resolves with the page's own account of a save: 'saved', 'cancelled' or 'failed'.
+ *
+ * The deadline is a last resort for a page that has stopped answering, and long on purpose -- it
+ * has to outlast somebody reading a Save dialog.
+ */
+function saveOutcome(win, deadlineMs = 10 * 60_000) {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      if (pendingSaves.get(win.id) === finish) {
+        pendingSaves.delete(win.id);
+        resolve('failed');
+      }
+    }, deadlineMs);
+    function finish(outcome) {
+      clearTimeout(timer);
+      resolve(outcome);
+    }
+    pendingSaves.set(win.id, finish);
+  });
+}
+
+ipcMain.on('tree:saveOutcome', (event, outcome) => {
+  const win = BrowserWindow.fromWebContents(event.sender);
+  const finish = win && pendingSaves.get(win.id);
+  if (!finish) return;
+  pendingSaves.delete(win.id);
+  finish(outcome);
+});
 
 async function createWindow() {
   const win = new BrowserWindow({
@@ -852,10 +958,10 @@ ipcMain.handle('tree:forget', async () => { await writeSession({}); });
  * Handing a document across the bridge for the main process to encode would put a second encoder
  * in the app and give the verification something other than the real bytes to check.
  */
-ipcMain.handle('tree:save', async (event, { bytes, path: target }) => {
+ipcMain.handle('tree:save', async (event, { bytes, path: target, quiet = false }) => {
   const win = BrowserWindow.fromWebContents(event.sender);
   if (!target) return { ok: false, reason: 'NO_PATH' };
-  return saveInto(win, target, bytes);
+  return saveInto(win, target, bytes, { quiet });
 });
 
 ipcMain.handle('tree:saveAs', async (event, { bytes, suggest }) => {
@@ -1053,12 +1159,16 @@ async function runEditSmoke(win, check) {
 
   seen = await page(() => ({
     counts: document.getElementById('counts')?.textContent ?? '',
-    unsaved: document.getElementById('unsaved')?.hidden === false,
+    saveState: document.getElementById('save-state')?.dataset.state ?? '',
+    saveAction: document.getElementById('save-state-action')?.hidden === false
+      ? document.getElementById('save-state-action').textContent : null,
     canUndo: document.getElementById('undo')?.disabled === false,
   }));
   check('a person and a child are recorded', /2 people/.test(seen.counts) && /1 connection/.test(seen.counts),
     seen.counts);
-  check('the window knows there is work not on disk', seen.unsaved === true);
+  // A new tree has nowhere to autosave to, so the bar says so and offers the one way out (#149).
+  check('a tree with no file says it is not saved, and offers to save it',
+    seen.saveState === 'untitled' && seen.saveAction === 'Save…', `${seen.saveState} / ${seen.saveAction}`);
   check('there is something to undo', seen.canUndo === true);
 
   // The rules, through the interface rather than around it: a child cannot also be a partner.
@@ -1096,10 +1206,12 @@ async function runEditSmoke(win, check) {
   check('the tree was written to disk', wrote > 0, `${wrote} bytes at ${target}`);
 
   seen = await page(() => ({
-    unsaved: document.getElementById('unsaved')?.hidden === false,
-    toast: document.getElementById('toast')?.textContent ?? '',
+    saveState: document.getElementById('save-state')?.dataset.state ?? '',
+    toast: document.getElementById('toast-text')?.textContent ?? '',
   }));
-  check('saving clears the unsaved mark', seen.unsaved === false, seen.toast);
+  check('saving says so, and says that changes save themselves from now on',
+    seen.saveState === 'saved' && /every change is saved as you make it/.test(seen.toast),
+    `${seen.saveState} — ${seen.toast}`);
 
   /*
    * Read back through the app itself. A file the writer can produce and the reader cannot open
@@ -1113,6 +1225,59 @@ async function runEditSmoke(win, check) {
   }));
   check('the saved file reopens with both people and the connection',
     /2 people/.test(seen.counts) && /1 connection/.test(seen.counts), seen.counts);
+
+  /*
+   * Autosave (#149): a tree with a file is written without anybody pressing Save.
+   *
+   * Asserted against the disk, not the page -- the page saying "Saved" is the claim, and the file's
+   * own contents are the proof. Then read back through the app, and the version from before the
+   * change looked for among the backups, where nothing is added beside the reader's own file.
+   */
+  const openPerson = async (name) => {
+    await page(() => document.querySelector('[data-view="index"]').click());
+    await settle(200);
+    await page((who) => [...document.querySelectorAll('#index-list .index-row')]
+      .find((row) => row.querySelector('.who')?.textContent === who)?.click(), name);
+    await settle(250);
+  };
+  const before = await fs.stat(target).then((s) => s.mtimeMs, () => 0);
+  await openPerson('Shyam Lal');
+  await type('f-notes', 'Grandfather. Born in Ballia. Written without pressing Save.');
+  await page(() => document.getElementById('panel-save').click());
+
+  let written = { state: '', mtime: before };
+  for (let waited = 0; waited < 6000; waited += 200) {
+    await settle(200);
+    written = {
+      state: await page(() => document.getElementById('save-state')?.dataset.state ?? ''),
+      mtime: await fs.stat(target).then((s) => s.mtimeMs, () => 0),
+    };
+    if (written.state === 'saved' && written.mtime > before) break;
+  }
+  check('a change reaches the file by itself, and the bar says so',
+    written.state === 'saved' && written.mtime > before, JSON.stringify(written));
+
+  await openInto(win, target);
+  await settle(900);
+  await openPerson('Shyam Lal');
+  seen = await page(() => document.getElementById('f-notes')?.value ?? '');
+  check('the file holds the change, read back through the app', /without pressing Save/.test(seen), seen);
+  await page(() => document.getElementById('panel-close').click());
+  await settle(150);
+
+  const backupRoot = path.join(app.getPath('userData'), 'backups');
+  const kept = [];
+  for (const folder of await fs.readdir(backupRoot).catch(() => [])) {
+    for (const name of await fs.readdir(path.join(backupRoot, folder)).catch(() => [])) {
+      if (name.endsWith('.ftree')) kept.push(path.join(folder, name));
+    }
+  }
+  check('the version before the change is kept among the backups', kept.length >= 1,
+    kept.join(', ') || '(none)');
+  const beside = await fs.readdir(path.dirname(target));
+  check('and nothing is left beside the reader\'s file',
+    !beside.includes(`${path.basename(target)}.bak`) && !beside.some((n) => n.includes('.saving-')),
+    beside.filter((n) => n.includes(path.basename(target))).join(', '));
 
   /*
    * Deleting somebody with a connection asks, and offers to keep their place.
@@ -2031,7 +2196,23 @@ async function runSmoke(win, file) {
     if (level >= 2) console.log(`       page: ${message}  (${source}:${line})`);
   });
 
-  await openInto(win, file);
+  /*
+   * The fixture is opened as a copy, never itself.
+   *
+   * Autosave (#149) writes a tree back to the file it came from a second after any change, and the
+   * sections below change trees. Opened directly, the fixture would be edited by one section and
+   * read, already edited, by the next -- and by the next run. Each opening gets its own copy in the
+   * run's own data folder, so every section starts from the tree it was written against.
+   */
+  let copies = 0;
+  const workingCopy = async () => {
+    copies += 1;
+    const copy = path.join(app.getPath('userData'), `copy-${copies}-${path.basename(file)}`);
+    await fs.copyFile(file, copy);
+    return copy;
+  };
+
+  await openInto(win, await workingCopy());
   // The page reads the file, lays it out and paints; give it room on a slow runner.
   await new Promise((r) => setTimeout(r, 2500));
 
@@ -2175,7 +2356,7 @@ async function runSmoke(win, file) {
    * passes in one order and fails in another.
    */
   const reopenSample = async () => {
-    await openInto(win, file);
+    await openInto(win, await workingCopy());
     await new Promise((resolve) => setTimeout(resolve, 500));
   };
 
@@ -2235,6 +2416,60 @@ async function runSmoke(win, file) {
     await fs.writeFile(process.env.FTREE_SMOKE_SHOT, image.toPNG());
     console.log(`       wrote ${process.env.FTREE_SMOKE_SHOT}`);
   }
+
+  /*
+   * Closing the window a moment after a change (#149). Last, because it closes the window.
+   *
+   * Under autosave "unsaved" is usually a change still in its pause, and the close must write it and
+   * go -- not put up a dialog asking about work that was a second from being saved. So: a change,
+   * then an immediate close, inside the pause. The window has to be gone without a question, and
+   * the change has to be in the file.
+   *
+   * Not behind a gate: it costs a few seconds and guards the one path every session ends on.
+   */
+  console.log('\n  -- closing a moment after a change --');
+  const lastCopy = await workingCopy();
+  await openInto(win, lastCopy);
+  await new Promise((resolve) => setTimeout(resolve, 900));
+  const onDisk = await fs.readFile(lastCopy);
+  // Two steps: "Add a person" lets go of the panel first, which is asynchronous, so the new person's
+  // form is not there until a moment after the click.
+  await win.webContents.executeJavaScript(`document.getElementById('add-person').click()`);
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  await win.webContents.executeJavaScript(`(() => {
+    const name = document.getElementById('f-name');
+    name.value = 'Added a moment before closing';
+    name.dispatchEvent(new Event('input', { bubbles: true }));
+    document.getElementById('panel-save').click();
+  })()`);
+  // The quit that follows a closed window would end this run before its last checks are printed.
+  app.removeAllListeners('window-all-closed');
+  const gone = new Promise((resolve) => win.once('closed', () => resolve('closed')));
+  win.close();
+  const outcome = await Promise.race([
+    gone, new Promise((resolve) => setTimeout(() => resolve('still open'), 6000))]);
+  check('a change a moment before closing is saved, and the window closes without asking',
+    outcome === 'closed', outcome);
+  /*
+   * Read with the app's own reader rather than compared as bytes: any rewrite changes the bytes --
+   * the export time is stamped in them -- so "different" would pass for a write that lost the edit.
+   * The reader is found beside the page, which is where packaging puts it as well, and loaded from
+   * a data: URL because this process's Node reads a bare `.js` as CommonJS; `archive.js` imports
+   * nothing, so it stands on its own.
+   */
+  const readerSource = await fs.readFile(
+    path.join(path.dirname(VIEWER), '..', '..', 'site', 'playground', 'archive.js'));
+  const reader = await import(`data:text/javascript;base64,${readerSource.toString('base64')}`);
+  const namesIn = async (bytes) => {
+    const archive = await reader.openArchive(
+      bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+    return reader.parseDocument(await archive.readText('tree.json')).people.map((p) => p.name);
+  };
+  const namesBefore = await namesIn(onDisk);
+  const namesAfter = await namesIn(await fs.readFile(lastCopy));
+  check('and the change is in the file', namesAfter.includes('Added a moment before closing')
+    && namesAfter.length === namesBefore.length + 1,
+    `${namesBefore.length} people before, ${namesAfter.length} after`);
 
   console.log(failures.length === 0 ? '\nSmoke test passed.' : `\n${failures.length} FAILED.`);
   app.exit(failures.length === 0 ? 0 : 1);

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -15,7 +15,7 @@
     "smoke": "electron . --no-sandbox",
     "pack:linux": "electron-builder --linux",
     "pack:win": "electron-builder --win nsis",
-    "test": "node --test update.test.js atomic.test.js identity.test.js settings.test.js smoke-gates.test.js suite.test.js \"renderer/*.test.js\" \"../site/playground/*.test.mjs\"",
+    "test": "node --test update.test.js atomic.test.js backups.test.js identity.test.js settings.test.js smoke-gates.test.js suite.test.js \"renderer/*.test.js\" \"../site/playground/*.test.mjs\"",
     "test:package": "node --test package.test.js"
   },
   "devDependencies": {

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -74,11 +74,22 @@ contextBridge.exposeInMainWorld('ftreeDesktop', {
    * Bytes, never a document: the page owns the format -- the writer, the reader it checks itself
    * with, and the tree. Sending a document for the other side to encode would put a second
    * encoder in the app and leave the verification checking something other than what gets
-   * written. The main process writes to a temporary file, fsyncs it, keeps the previous contents
-   * as `.bak` and renames atomically over the target.
+   * written. The main process backs up what was there (backups.js), writes to a temporary file,
+   * fsyncs it and renames atomically over the target.
+   *
+   * `quiet` is autosave's: a failure comes back as `{ ok: false, reason, code }` for the page to
+   * show in its own bar, rather than as a native error dialog every few seconds.
    */
-  saveTree: (bytes, path) => ipcRenderer.invoke('tree:save', { bytes, path }),
+  saveTree: (bytes, path, { quiet = false } = {}) => ipcRenderer.invoke('tree:save', { bytes, path, quiet }),
   saveTreeAs: (bytes, suggest) => ipcRenderer.invoke('tree:saveAs', { bytes, suggest }),
+
+  /**
+   * How a save the quit prompt asked for ended: 'saved', 'cancelled' or 'failed'.
+   *
+   * The prompt used to poll for the tree turning clean and give up after ten seconds -- which, for a
+   * new tree, is while the reader is still choosing a folder in the Save dialog.
+   */
+  reportSaveOutcome: (outcome) => ipcRenderer.send('tree:saveOutcome', outcome),
 
   /** Lets the window refuse to close on unsaved work, and marks the title bar as edited. */
   setDirty: (dirty) => ipcRenderer.send('tree:dirty', dirty),

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -41,6 +41,7 @@ import {
   DateProblem, draftFrom, withChange, dateProblems, isDirty, fieldsFrom, isBlankPerson,
   normaliseDateTyping,
 } from './person-draft.js';
+import { createAutosave, describeWriteFailure } from './autosave.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
 
@@ -145,10 +146,103 @@ function draftIsDirty() {
   return Boolean(person && isDirty(draft.values, person));
 }
 
-/** Keeps the window, the menu and the dot in step with whether there is work not on disk. */
+/* ------------------------------------------------------------------ autosave */
+
+/*
+ * The open tree is written back to its file a moment after every change (#149).
+ *
+ * Only a tree that has a file. A new one has nowhere to go until somebody picks a place, so it
+ * keeps a Save button and the quit prompt until then -- and from its first save on, it is written
+ * like any other. See autosave.js for the scheduling and backups.js for the earlier versions kept
+ * on the way.
+ */
+const autosave = createAutosave({
+  write: writeToFile,
+  onStatus: () => paintSaveState(),
+  onFailure: (error) => toast(
+    `Couldn’t save ${state.name}: ${describeWriteFailure(error)}. `
+      + 'Your changes are still here, and f-tree will keep trying.',
+    'bad',
+    { action: { label: 'Save as…', run: () => save({ as: true }) } },
+  ),
+});
+
+/**
+ * Writes the open tree to its file, if it has one and anything has changed.
+ *
+ * The signature is taken before the write and handed to `markSaved` after it, so an edit made while
+ * the bytes were on their way is still unsaved afterwards and gets the next write -- see
+ * `Tree.markSaved`.
+ */
+async function writeToFile() {
+  const tree = state.tree;
+  const target = state.path;
+  if (!tree || !target || !tree.isDirty || !shell) return;
+
+  const signature = tree.signature();
+  let made;
+  try {
+    made = await bytesForTree(tree, photosStillUsed());
+  } catch (error) {
+    if (error instanceof SaveRefused) throw new Error(`${error.message} ${error.detail}`);
+    throw error;
+  }
+  const result = await shell.saveTree(made.bytes, target, { quiet: true });
+  if (!result?.ok) {
+    throw Object.assign(new Error(result?.reason ?? 'the write did not finish'),
+      { code: result?.code ?? null });
+  }
+  // Another file may have been opened while this one was being written; it is not this one's to mark.
+  if (state.tree === tree) {
+    tree.markSaved(signature);
+    reflectDirty();
+  }
+}
+
+/** Starts the pause before a write, for a tree with a file and something new in it. */
+function scheduleAutosave() {
+  if (state.tree?.isDirty && state.path) autosave.changed();
+}
+
+/**
+ * The bar's word on whether the tree is on disk: the unsaved dot, grown into a sentence.
+ *
+ * Saving… while a write is pending or under way, Saved when it is done, and the two states that
+ * need a hand: a tree that has never had a file, which offers Save…, and a write that failed, which
+ * offers Retry. It is not a live region -- it changes on every edit, and a screen reader announcing
+ * "Saving… Saved" after each keystroke would be noise. A failure is announced by its toast.
+ */
+function paintSaveState() {
+  const chip = $('save-state');
+  if (!chip || !state.tree) return;
+
+  const status = autosave.status;
+  const view = !state.path ? 'untitled'
+    : status.state === 'error' ? 'error'
+    : status.state === 'pending' || status.state === 'saving' || state.tree.isDirty ? 'saving'
+    : 'saved';
+
+  chip.dataset.state = view;
+  $('save-state-text').textContent = {
+    untitled: 'Not saved yet',
+    saving: 'Saving…',
+    saved: 'Saved',
+    error: 'Not saved',
+  }[view];
+  chip.title = view === 'saved' ? `Every change is saved to ${state.path}`
+    : view === 'error' ? `Couldn’t save: ${describeWriteFailure(status.error)}`
+    : view === 'untitled' ? 'This tree has no file yet. Save it once and changes save themselves.'
+    : '';
+
+  const action = $('save-state-action');
+  action.hidden = view !== 'untitled' && view !== 'error';
+  action.textContent = view === 'untitled' ? 'Save…' : 'Retry';
+}
+
+/** Keeps the window, the menu and the save state in step with whether there is work not on disk. */
 function reflectDirty() {
   const dirty = Boolean(state.tree?.isDirty) || draftIsDirty();
-  $('unsaved').hidden = !dirty;
+  paintSaveState();
   $('save').dataset.dirty = String(dirty);
   $('undo').disabled = !state.tree?.canUndo;
   $('redo').disabled = !state.tree?.canRedo;
@@ -203,6 +297,9 @@ function rebuild({ refit = false } = {}) {
    */
   state.trace = null;
   if (!$('relate').hidden) renderRelation();
+
+  // Every change to the tree comes through here, so this is the one place autosave has to hear it.
+  scheduleAutosave();
 }
 
 /**
@@ -1585,7 +1682,7 @@ function ask({ title, body, options = [], actions = [], focus = null }) {
     for (const action of actions) {
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = `btn ${action.tone ?? 'quiet'}`;
+      button.className = action.tone === 'danger-quiet' ? 'btn-danger' : `btn ${action.tone ?? 'quiet'}`;
       button.textContent = action.label;
       button.addEventListener('click', () => finish(action.value ?? null));
       actionsBox.append(button);
@@ -1726,7 +1823,7 @@ function commitDraft() {
 
   state.fresh = null;
   state.draft = null;
-  flashPanel(fresh ? 'Added' : 'Saved');
+  flashPanel(fresh ? 'Added' : 'Updated');
   rebuild();
   return true;
 }
@@ -1908,7 +2005,7 @@ function redo() {
 /* ------------------------------------------------------------------ files */
 
 async function startNewTree() {
-  if (state.tree && !(await releasePanel())) return;
+  if (!(await releaseTree())) return;
   state.tree = new Tree({}, { ownTreeId: state.ownTreeId });
   state.draft = null;
   state.fresh = null;
@@ -1945,6 +2042,7 @@ async function openBytes(bytes, name, filePath) {
 
     state.tree = new Tree(doc, { ownTreeId: state.ownTreeId });
     state.tree.markSaved();
+    autosave.cancel();
     state.draft = null;
     state.fresh = null;
     state.photos = photos;
@@ -2198,45 +2296,119 @@ function photosStillUsed() {
   return kept;
 }
 
+/**
+ * Saves now, because somebody asked -- Ctrl+S, the menu, the bar, or the quit prompt.
+ *
+ * For a tree with a file this is autosave without the pause: the same write, just not waiting.
+ * For a tree without one, or Save as, it asks where; and from a tree's first save onwards every
+ * change is written by itself, which the confirmation says once, at the moment it becomes true.
+ *
+ * @returns {Promise<'saved'|'cancelled'|'failed'>} for the quit prompt, which has to know
+ */
 async function save({ as = false } = {}) {
-  if (!state.tree || state.saving) return;
+  if (!state.tree || state.saving) return 'failed';
   // Saving the file saves the person being edited too; a Ctrl+S that wrote everything except the
   // name on screen would be the one save somebody could not believe. A date that cannot be kept
   // stops the whole save, with the problem shown where it is.
-  if (!commitDraft()) return;
+  if (!commitDraft()) return 'failed';
+
+  if (!as && state.path) {
+    const ok = await autosave.flush();
+    if (ok) toast(`Every change is saved to ${state.name}.`);
+    return ok ? 'saved' : 'failed';
+  }
+
   state.saving = true;
   try {
+    const firstSave = !state.path;
+    const signature = state.tree.signature();
     let made;
     try {
       made = await bytesForTree(state.tree, photosStillUsed());
     } catch (error) {
       if (error instanceof SaveRefused) {
         toast(`${error.message}\n\n${error.detail}`, 'bad');
-        return;
+        return 'failed';
       }
       throw error;
     }
 
     const suggested = state.name?.endsWith('.ftree') ? state.name : `${state.name || 'family-tree'}.ftree`;
-    const result = (as || !state.path)
-      ? await shell.saveTreeAs(made.bytes, suggested)
-      : await shell.saveTree(made.bytes, state.path);
-
+    const result = await shell.saveTreeAs(made.bytes, suggested);
     if (!result?.ok) {
-      if (result?.reason !== 'CANCELLED') toast('That tree was not saved.', 'bad');
-      return;
+      if (result?.reason === 'CANCELLED') return 'cancelled';
+      toast('That tree was not saved.', 'bad');
+      return 'failed';
     }
 
     state.path = result.path;
     state.name = result.name;
     $('file-name').textContent = result.name;
-    state.tree.markSaved();
+    state.tree.markSaved(signature);
     reflectDirty();
     toast(`Saved ${count(made.people, 'person', 'people')} and `
-      + `${count(made.relationships, 'connection', 'connections')}.`);
+      + `${count(made.relationships, 'connection', 'connections')} to ${result.name}.`
+      + (firstSave ? ' From now on every change is saved as you make it.' : ''));
+    // Anything edited while the dialog was up goes to the new file straight away.
+    scheduleAutosave();
+    return 'saved';
   } finally {
     state.saving = false;
   }
+}
+
+/**
+ * Lets go of the open tree before another replaces it -- New tree, Open tree, Close tree.
+ *
+ * A tree with a file is flushed and let go without a word: that is what autosave means. What is
+ * left is asked about, because it is the one case where closing loses something: a tree that has
+ * never had a file, or one whose last write failed. Until this, opening another file while a new
+ * tree was unsaved simply threw the new tree away.
+ */
+async function releaseTree() {
+  if (!state.tree) return true;
+  if (!(await releasePanel())) return false;
+  if (!state.tree.isDirty) {
+    autosave.cancel();
+    return true;
+  }
+  if (state.path && (await autosave.flush())) {
+    autosave.cancel();
+    return true;
+  }
+
+  const untitled = !state.path;
+  const answer = await ask({
+    title: untitled ? 'Save this tree first?' : `${state.name} couldn’t be saved`,
+    body: untitled
+      ? 'It hasn’t been saved to a file yet, so closing it now loses it.'
+      : `${describeWriteFailure(autosave.status.error)}. Closing it now loses the changes made `
+        + 'since it was last saved.',
+    actions: [
+      { label: untitled ? 'Don’t save' : 'Discard changes', value: 'discard', tone: 'danger-quiet' },
+      { label: 'Cancel', value: null },
+      { label: untitled ? 'Save…' : 'Save as…', value: 'save', tone: 'primary' },
+    ],
+    focus: 2,
+  });
+  if (answer === 'save') return (await save({ as: true })) === 'saved';
+  if (answer === 'discard') {
+    autosave.cancel();
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Before the window closes: write what autosave had not got to yet.
+ *
+ * The main process asks this first and only puts up its own question if the tree is still not on
+ * disk a moment later -- so a change made a second before closing is simply saved, not asked about.
+ * A person half-edited in the panel is not saved here: nobody pressed Save, and the quit prompt is
+ * how they get asked.
+ */
+function flushForClose() {
+  if (state.path && !draftIsDirty()) autosave.flush();
 }
 
 /* ------------------------------------------------------------------ wiring */
@@ -2250,6 +2422,11 @@ function wireChrome() {
   $('redo').addEventListener('click', redo);
   $('panel-close').addEventListener('click', () => select(null));
   $('panel-save').addEventListener('click', () => commitDraft());
+  // The bar's save state offers the one thing each of its two awkward states needs.
+  $('save-state-action').addEventListener('click', () => {
+    if (!state.path) save({ as: true });
+    else autosave.flush();
+  });
   $('panel-remove').addEventListener('click', () => removeFromPanel());
 
   // A toast with a button in it holds still while somebody is reaching for the button.
@@ -2324,8 +2501,12 @@ function wireShell() {
   if (!shell) return;
 
   shell.onOpenTree(async (tree) => {
-    // Opening another file closes the panel as surely as clicking away does, so it asks the same.
-    if (state.tree && !(await releasePanel())) return;
+    // Opening another file closes this one as surely as Close does, so it asks the same things.
+    const reopening = Boolean(tree.path) && tree.path === state.path && state.tree?.isDirty;
+    if (!(await releaseTree())) return;
+    // The bytes were read before this tree's last changes were flushed to that same file, so they
+    // are older than what is on screen -- which is now exactly what is on disk. Keep it.
+    if (reopening) return;
     openBytes(tree.bytes, tree.name, tree.path);
   });
 
@@ -2333,6 +2514,11 @@ function wireShell() {
     if (command === 'file:new') { startNewTree(); return; }
     if (command === 'file:import') { importTree(); return; }
     if (command === 'file:save') { save(); return; }
+    if (command === 'file:flush') { flushForClose(); return; }
+    if (command === 'file:saveForClose') {
+      save().then((outcome) => shell.reportSaveOutcome?.(outcome));
+      return;
+    }
     if (command === 'file:saveAs') { save({ as: true }); return; }
     if (command === 'edit:undo') { undo(); return; }
     if (command === 'edit:redo') { redo(); return; }
@@ -2347,13 +2533,15 @@ function wireShell() {
     if (command === 'search') { $('search').focus(); return; }
     if (command === 'theme') { $('theme-btn').click(); return; }
     if (command === 'close') {
-      releasePanel().then((released) => { if (released) closeTree(); });
+      releaseTree().then((released) => { if (released) closeTree(); });
     }
   });
 }
 
 function closeTree() {
+  autosave.cancel();
   state.tree = null;
+  state.path = null;
   state.selected = null;
   state.draft = null;
   state.fresh = null;

--- a/desktop/renderer/autosave.js
+++ b/desktop/renderer/autosave.js
@@ -1,0 +1,155 @@
+/*
+ * Writing the open tree back to its file, a moment after every change.
+ *
+ * Until 0.6 nothing reached disk until somebody pressed Save, and the quit prompt was the only thing
+ * standing between an afternoon's work and a closed window (#149). On the phone there is no such
+ * thing as an unsaved tree: it is a database, always durable. The desktop's closest honest analogue
+ * is write-behind to the `.ftree` that is open -- the file *is* the document here -- so that is what
+ * this is.
+ *
+ * Deliberately not a write per change. A person typing a name, then a date, then adding a child
+ * makes a burst of edits, and each write reads the whole tree back to verify it (save.js), so the
+ * burst is coalesced: a write happens once changes have stopped for a moment. A change that arrives
+ * while a write is in flight is not lost and not raced; it is written as soon as that one finishes.
+ *
+ * A failed write does not fail silently. The status says so, and the caller is told once per run of
+ * failures rather than once per retry, because a full disk or an unplugged drive is one problem,
+ * not forty. Retries back off, and any new change retries at once.
+ *
+ * Pure apart from the timers, which are passed in so the tests can drive time by hand.
+ */
+
+/** How long changes must stop before the tree is written. */
+export const AUTOSAVE_DELAY_MS = 1200;
+
+/** How long to wait before trying a failed write again, each time it fails in a row. */
+export const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000];
+
+/**
+ * @param {object} options
+ * @param {() => Promise<void>} options.write writes the tree; resolves once it is on disk, throws if
+ *   it could not be. Deciding there is nothing to write is its business, not this module's.
+ * @param {(status: {state: string, error: Error|null, failures: number}) => void} [options.onStatus]
+ *   told of every change of state: 'idle', 'pending', 'saving', 'saved' or 'error'
+ * @param {(error: Error) => void} [options.onFailure] told once when writes start failing
+ * @param {number} [options.delay]
+ * @param {{setTimeout: Function, clearTimeout: Function}} [options.timers]
+ */
+export function createAutosave({
+  write,
+  onStatus = () => {},
+  onFailure = () => {},
+  delay = AUTOSAVE_DELAY_MS,
+  timers = globalThis,
+}) {
+  let timer = null;
+  let running = null;
+  let again = false;
+  let status = { state: 'idle', error: null, failures: 0 };
+
+  const set = (next) => {
+    status = { ...status, ...next };
+    onStatus(status);
+  };
+
+  const clear = () => {
+    if (timer !== null) timers.clearTimeout(timer);
+    timer = null;
+  };
+
+  const schedule = (ms) => {
+    clear();
+    timer = timers.setTimeout(() => { timer = null; run(); }, ms);
+  };
+
+  async function run() {
+    clear();
+    if (running) {
+      again = true;
+      return running;
+    }
+    set({ state: 'saving' });
+    running = (async () => {
+      try {
+        await write();
+        set({ state: 'saved', error: null, failures: 0 });
+        return true;
+      } catch (error) {
+        const failures = status.failures + 1;
+        set({ state: 'error', error, failures });
+        if (failures === 1) onFailure(error);
+        return false;
+      } finally {
+        running = null;
+      }
+    })();
+
+    const ok = await running;
+    if (again) {
+      // Something changed while that write was in flight. It is written now, not after another
+      // pause: the pause was for the burst, and this is its tail.
+      again = false;
+      return run();
+    }
+    if (!ok) schedule(RETRY_DELAYS_MS[Math.min(status.failures, RETRY_DELAYS_MS.length) - 1]);
+    return ok;
+  }
+
+  return {
+    /** The tree changed. Written once changes stop for `delay`, or at once if the last write failed. */
+    changed() {
+      if (running) {
+        again = true;
+        return;
+      }
+      // After a failure the status stays 'error' until a write works, but a new change is still the
+      // best moment to try again -- the drive may be back -- so it waits the ordinary pause, not
+      // the rest of the backoff.
+      if (status.state !== 'error') set({ state: 'pending' });
+      schedule(delay);
+    },
+
+    /**
+     * Writes now, without waiting out the pause, and resolves whether it worked.
+     *
+     * Waits for a write already in flight rather than starting a second beside it; the one it then
+     * starts picks up anything that changed meanwhile.
+     */
+    async flush() {
+      clear();
+      if (running) await running;
+      return run();
+    },
+
+    /** Forgets anything scheduled, for a tree that is being closed. */
+    cancel() {
+      clear();
+      again = false;
+      set({ state: 'idle', error: null, failures: 0 });
+    },
+
+    get status() {
+      return status;
+    },
+  };
+}
+
+/**
+ * Why a write failed, in words a person can act on.
+ *
+ * The codes are Node's, passed through by the main process. A message nobody recognises is shown
+ * as it came, because a vague rewording would hide the one detail that might explain it.
+ */
+export function describeWriteFailure(error) {
+  const text = String(error?.message ?? error ?? '');
+  const code = error?.code ?? /\b(E[A-Z]+)\b/.exec(text)?.[1];
+  switch (code) {
+    case 'ENOSPC': return 'the disk is full';
+    case 'EROFS': return 'that drive is read-only';
+    case 'EACCES':
+    case 'EPERM': return 'f-tree isn’t allowed to write there';
+    case 'ENOENT': return 'its folder is no longer there — was a drive removed?';
+    case 'EBUSY': return 'another program has the file open';
+    default: return text || 'the write did not finish';
+  }
+}

--- a/desktop/renderer/autosave.test.js
+++ b/desktop/renderer/autosave.test.js
@@ -1,0 +1,205 @@
+/*
+ * Autosave's scheduling (#149): the three cases the issue asked for -- many edits make one write, a
+ * failed write says so, and a tree with no file yet is left alone -- plus the ones that decide
+ * whether it can be trusted: nothing written twice at once, nothing lost in flight, a flush that
+ * really flushes.
+ *
+ * Time is driven by hand. A test that slept for the real delay would be slow, and one that slept
+ * for "about" the delay would be flaky in exactly the way that hides a scheduling bug.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert';
+
+import { createAutosave, describeWriteFailure, AUTOSAVE_DELAY_MS, RETRY_DELAYS_MS } from './autosave.js';
+
+/** A clock that only moves when told to. */
+function manualTimers() {
+  let now = 0;
+  let nextId = 1;
+  const pending = new Map();
+  return {
+    setTimeout(fn, ms) { const id = nextId++; pending.set(id, { at: now + ms, fn }); return id; },
+    clearTimeout(id) { pending.delete(id); },
+    /** Moves time on, running whatever falls due, in order. */
+    async advance(ms) {
+      const until = now + ms;
+      for (;;) {
+        const due = [...pending].filter(([, t]) => t.at <= until).sort((a, b) => a[1].at - b[1].at)[0];
+        if (!due) break;
+        pending.delete(due[0]);
+        now = due[1].at;
+        due[1].fn();
+        await settle();
+      }
+      now = until;
+    },
+    get scheduled() { return pending.size; },
+  };
+}
+
+/** Lets pending promise callbacks run. */
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+function harness({ fail = () => false } = {}) {
+  const timers = manualTimers();
+  const log = { writes: 0, statuses: [], failures: [] };
+  let release = null;
+  const autosave = createAutosave({
+    timers,
+    write: async () => {
+      log.writes += 1;
+      if (release) await new Promise((resolve) => { release.push(resolve); });
+      if (fail()) {
+        const error = new Error('ENOSPC: no space left on device, write');
+        error.code = 'ENOSPC';
+        throw error;
+      }
+    },
+    onStatus: (s) => log.statuses.push(s.state),
+    onFailure: (e) => log.failures.push(e),
+  });
+  return {
+    autosave, timers, log,
+    /** Makes writes wait until `finish()` is called. */
+    hold() { release = []; },
+    finish() { const all = release ?? []; release = null; all.forEach((r) => r()); },
+  };
+}
+
+test('many edits in a burst make one write', async () => {
+  const { autosave, timers, log } = harness();
+  for (let i = 0; i < 12; i += 1) {
+    autosave.changed();
+    await timers.advance(AUTOSAVE_DELAY_MS / 3);
+  }
+  assert.strictEqual(log.writes, 0, 'nothing written while the edits keep coming');
+  await timers.advance(AUTOSAVE_DELAY_MS);
+  assert.strictEqual(log.writes, 1);
+  assert.strictEqual(autosave.status.state, 'saved');
+});
+
+test('a write happens once the edits stop, not before', async () => {
+  const { autosave, timers, log } = harness();
+  autosave.changed();
+  assert.strictEqual(autosave.status.state, 'pending');
+  await timers.advance(AUTOSAVE_DELAY_MS - 1);
+  assert.strictEqual(log.writes, 0);
+  await timers.advance(1);
+  assert.strictEqual(log.writes, 1);
+});
+
+test('a change during a write is written straight after it, and never alongside it', async () => {
+  const h = harness();
+  h.autosave.changed();
+  h.hold();
+  await h.timers.advance(AUTOSAVE_DELAY_MS);
+  assert.strictEqual(h.log.writes, 1);
+  assert.strictEqual(h.autosave.status.state, 'saving');
+
+  h.autosave.changed();
+  h.autosave.changed();
+  await h.timers.advance(AUTOSAVE_DELAY_MS * 3);
+  assert.strictEqual(h.log.writes, 1, 'the second write waits for the first');
+
+  h.finish();
+  await settle();
+  await settle();
+  assert.strictEqual(h.log.writes, 2, 'and then the changes made meanwhile are written');
+  assert.strictEqual(h.autosave.status.state, 'saved');
+});
+
+test('a failed write is said once, however many times it fails', async () => {
+  const { autosave, timers, log } = harness({ fail: () => true });
+  autosave.changed();
+  await timers.advance(AUTOSAVE_DELAY_MS);
+  assert.strictEqual(autosave.status.state, 'error');
+  assert.strictEqual(log.failures.length, 1);
+
+  // The retries, backing off.
+  for (const wait of RETRY_DELAYS_MS) await timers.advance(wait);
+  assert.ok(log.writes >= RETRY_DELAYS_MS.length, `it kept trying: ${log.writes} attempts`);
+  assert.strictEqual(log.failures.length, 1, 'one problem, one notice');
+  assert.strictEqual(autosave.status.error.code, 'ENOSPC');
+});
+
+test('a write that works after failing clears the error, and the next failure is news again', async () => {
+  let failing = true;
+  const { autosave, timers, log } = harness({ fail: () => failing });
+  autosave.changed();
+  await timers.advance(AUTOSAVE_DELAY_MS);
+  failing = false;
+  await timers.advance(RETRY_DELAYS_MS[0]);
+  assert.strictEqual(autosave.status.state, 'saved');
+  assert.strictEqual(autosave.status.failures, 0);
+
+  failing = true;
+  autosave.changed();
+  await timers.advance(AUTOSAVE_DELAY_MS);
+  assert.strictEqual(log.failures.length, 2);
+});
+
+test('a new change after a failure tries again after the ordinary pause, not the backoff', async () => {
+  const { autosave, timers, log } = harness({ fail: () => log.writes < 2 });
+  autosave.changed();
+  await timers.advance(AUTOSAVE_DELAY_MS);
+  autosave.changed();
+  await timers.advance(AUTOSAVE_DELAY_MS);
+  assert.strictEqual(log.writes, 2);
+  assert.strictEqual(autosave.status.state, 'saved');
+});
+
+test('flush writes now, and resolves whether it worked', async () => {
+  const ok = harness();
+  ok.autosave.changed();
+  assert.strictEqual(await ok.autosave.flush(), true);
+  assert.strictEqual(ok.log.writes, 1);
+  await ok.timers.advance(AUTOSAVE_DELAY_MS * 2);
+  assert.strictEqual(ok.log.writes, 1, 'and the scheduled write it replaced does not also happen');
+
+  const bad = harness({ fail: () => true });
+  assert.strictEqual(await bad.autosave.flush(), false);
+});
+
+test('flush during a write waits for it, then writes what changed since', async () => {
+  const h = harness();
+  h.autosave.changed();
+  h.hold();
+  await h.timers.advance(AUTOSAVE_DELAY_MS);
+  const flushed = h.autosave.flush();
+  h.finish();
+  assert.strictEqual(await flushed, true);
+  assert.strictEqual(h.log.writes, 2);
+});
+
+test('nothing is scheduled until something changes -- a tree with no file writes nothing', async () => {
+  // The app only calls `changed()` for a tree that has a file to go to. An untitled tree never
+  // does, so it is never written, and it keeps its Save button and its quit prompt.
+  const { autosave, timers, log } = harness();
+  await timers.advance(AUTOSAVE_DELAY_MS * 10);
+  assert.strictEqual(log.writes, 0);
+  assert.strictEqual(autosave.status.state, 'idle');
+  assert.strictEqual(timers.scheduled, 0);
+});
+
+test('cancel forgets what was scheduled, for a tree being closed', async () => {
+  const { autosave, timers, log } = harness();
+  autosave.changed();
+  autosave.cancel();
+  await timers.advance(AUTOSAVE_DELAY_MS * 2);
+  assert.strictEqual(log.writes, 0);
+  assert.strictEqual(autosave.status.state, 'idle');
+});
+
+test('a failure is described in words a person can act on', () => {
+  const coded = (code) => Object.assign(new Error(`${code}: something`), { code });
+  assert.strictEqual(describeWriteFailure(coded('ENOSPC')), 'the disk is full');
+  assert.strictEqual(describeWriteFailure(coded('EROFS')), 'that drive is read-only');
+  assert.match(describeWriteFailure(coded('EACCES')), /allowed/);
+  assert.match(describeWriteFailure(coded('ENOENT')), /drive removed/);
+  // The code survives the trip across IPC only inside the message, so it is read from there too.
+  assert.strictEqual(describeWriteFailure(new Error('ENOSPC: no space left on device')),
+    'the disk is full');
+  assert.strictEqual(describeWriteFailure(new Error('something odd')), 'something odd',
+    'an unknown failure is shown as it came, not reworded into vagueness');
+});

--- a/desktop/renderer/document.js
+++ b/desktop/renderer/document.js
@@ -144,9 +144,15 @@ export class Tree {
     return this.future.at(-1)?.label ?? null;
   }
 
-  /** Called after a successful save. */
-  markSaved() {
-    this.savedAt = this.signature();
+  /**
+   * Called after a successful save, with the signature of what was *written*.
+   *
+   * Not "now". A write takes a moment -- the bytes are verified, then put on disk -- and under
+   * autosave an edit can land in that moment. Marking the tree saved as it is by then would call
+   * that edit saved when it is not on disk, and the next autosave would find nothing to write.
+   */
+  markSaved(signature = this.signature()) {
+    this.savedAt = signature;
   }
 
   /* -------------------------------------------------------------- the graph, for the rules */

--- a/desktop/renderer/document.test.js
+++ b/desktop/renderer/document.test.js
@@ -321,3 +321,17 @@ test('keeping someone as unknown clears every detail and keeps every connection'
 test('keeping nobody as unknown is refused', () => {
   assert.strictEqual(new Tree().clearDetails('nobody').reason, 'NO_SUCH_PERSON');
 });
+
+/* ---------------------------------------------------------------- saved, as of when */
+
+test('a tree is marked saved as of what was written, not as of now', () => {
+  // Autosave takes the signature, writes, and marks saved afterwards. An edit made meanwhile must
+  // still count as unsaved, or it is never written.
+  const { tree, child } = family();
+  const written = tree.signature();
+  tree.updatePerson(child, { notes: 'typed while the write was in flight' });
+  tree.markSaved(written);
+  assert.ok(tree.isDirty);
+  tree.markSaved();
+  assert.ok(!tree.isDirty);
+});

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -20,16 +20,77 @@
 }
 
 /*
- * Unsaved work, said with a dot.
+ * Which file, and whether it is on disk -- at every width.
  *
- * The alternative -- a word, or an asterisk on the file name -- is louder than the fact deserves.
- * Somebody mid-edit knows they are mid-edit; the dot is for coming back to a window after lunch.
+ * The viewer hides the file name below 1280px, which suits a reader: the chart already says what
+ * is open. Here the same place says whether the work is saved, and a window narrowed to 1100px is
+ * exactly when a failed write must still be visible. So the name gives up width, never the state.
  */
-.editor .unsaved {
-  color: var(--accent);
-  font-size: 20px;
-  line-height: 1;
+.editor .bar-file { display: flex; align-items: center; }
+.editor .file-name { max-width: calc(200px * var(--ui)); }
+@media (max-width: 1280px) { .editor .file-name { max-width: calc(130px * var(--ui)); } }
+
+/*
+ * The unsaved dot, grown into a word (#149).
+ *
+ * The dot used to mean "work not on disk". Under autosave that is true for about a second after
+ * each change, so the dot now says what is happening -- Saving…, Saved -- and keeps its colour for
+ * meaning: forest when the tree is on disk, brass while it is on its way or has nowhere to go, the
+ * refusal colour when a write failed. Still quiet: a word in the faint mono of the bar, never a
+ * banner.
+ */
+.editor .save-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: calc(11.5px * var(--ui));
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
+
+.editor .save-state-mark {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--forest);
+}
+
+.editor .save-state[data-state='saving'] .save-state-mark,
+.editor .save-state[data-state='untitled'] .save-state-mark { background: var(--brass); }
+
+.editor .save-state[data-state='error'] { color: var(--danger); }
+.editor .save-state[data-state='error'] .save-state-mark { background: var(--danger); }
+
+@media (prefers-reduced-motion: no-preference) {
+  .editor .save-state[data-state='saving'] .save-state-mark {
+    animation: save-state-pulse 1s ease-in-out infinite alternate;
+  }
+  @keyframes save-state-pulse { from { opacity: 1; } to { opacity: .3; } }
+}
+
+.editor .save-state-action {
+  font: inherit;
+  color: var(--ink);
+  background: var(--raised);
+  border: 1px solid var(--rule-strong);
+  border-radius: 999px;
+  padding: calc(3px * var(--ui)) calc(10px * var(--ui));
   margin-left: 2px;
+  cursor: pointer;
+  transition: border-color .12s, color .12s;
+}
+
+.editor .save-state-action:hover { border-color: var(--forest); color: var(--forest); }
+.editor .save-state[data-state='error'] .save-state-action { color: var(--danger); border-color: var(--danger); }
+.editor .save-state-action:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.editor .review-actions .btn-danger {
+  font-family: inherit;
+  font-size: 13.5px;
+  padding: 11px 20px;
+  margin-right: auto;
 }
 
 .editor .undo-pair {
@@ -1401,3 +1462,6 @@
 }
 
 .editor .nowrap { white-space: nowrap; }
+
+/* The quiet destructive answer sits apart at the left, the way the panel's own foot sets it. */
+.editor .ask .review-actions { flex: 1; justify-content: flex-end; }

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -52,8 +52,17 @@
 
     <div class="bar-file" data-when="loaded">
       <span class="file-name" id="file-name"></span>
-      <!-- Shown only while there is work not on disk. Quiet, and never a nag. -->
-      <span class="unsaved" id="unsaved" hidden title="Not saved yet">&bull;</span>
+      <!--
+        Whether the tree is on disk. This was a dot that appeared while there was unsaved work; with
+        autosave (#149) that is a second at a time, so the dot grew into a word -- Saving…, Saved --
+        and a button for the two states that need a hand: a new tree that has never had a file, and
+        a write that failed. Quiet, and never a nag.
+      -->
+      <span class="save-state" id="save-state" data-state="saved">
+        <i class="save-state-mark" aria-hidden="true"></i>
+        <span class="save-state-text" id="save-state-text">Saved</span>
+        <button type="button" class="save-state-action" id="save-state-action" hidden></button>
+      </span>
     </div>
 
     <div class="bar-spacer"></div>

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -27,6 +27,50 @@ which multiply a chart's width far faster than they add to what it tells you. Cl
 the reading to that person. Where the record goes further than the reading, it says so and offers
 to go on.
 
+## Saving: once, then automatic
+
+A tree with a file is **written back to it about a second after each change**
+([#149](https://github.com/thisisankit27/f-tree/issues/149)). The bar beside the file name says
+where things stand:
+
+| | |
+|---|---|
+| **Saved** | every change is on disk |
+| **Saving…** | a change is in its pause, or being written |
+| **Not saved yet** · *Save…* | a new tree that has never had a file. Save it once and it autosaves from then on |
+| **Not saved** · *Retry* | a write failed. The reason is in a toast, once, and f-tree keeps retrying with backoff |
+
+Changes are batched rather than written one by one (`renderer/autosave.js`). A write reads the
+whole tree back to verify it (`renderer/save.js`), and a burst of edits needs one write, not ten. A
+change that lands during a write is picked up straight after it. `Tree.markSaved` takes the
+signature of what was *written*, so an edit made mid-write is never marked saved by mistake.
+
+`Ctrl+S` still works, and just skips the pause. Closing the window first asks the page to write
+anything still in its pause, and closes without a question if that was all. The quit prompt is left
+for work that really isn't on disk: a new tree with no file yet, a person half-edited in the panel,
+or a failed write. Opening or starting another tree asks the same question in those cases. Before
+0.6 it quietly threw away a new tree that had never been saved.
+
+The phone does not autosave either: its tree lives in a database, so there is never an unsaved tree
+there. Writing back to the open file is the desktop's closest equivalent.
+
+### Backups
+
+Autosave makes a mistake permanent almost immediately, so earlier versions are kept
+(`desktop/backups.js`), following Android's rule for pre-import backups: *keep a few, not a growing
+pile*.
+
+- One copy of the file as it was **before the first write of each run**, so opening a tree and
+  spoiling it always leaves the version you opened.
+- Then **at most one every ten minutes** while writes continue.
+- The **newest five** per tree.
+
+They live in the app's own data folder, one folder per tree. The folder is named after the file,
+plus a hash of its path, so two `family.ftree`s never share one. Nothing is added beside your own
+file. The old sibling `<name>.bak` is gone, because under autosave it would have been overwritten
+every second. **File › Show backups** opens the folder. A backup is an ordinary `.ftree`: open it,
+and use Save as to keep it.
+
 ## Editing a person
 
 The person panel keeps its edits as a draft and writes them to the tree on **Save**, which is how
@@ -36,7 +80,7 @@ taken, and closing the panel with a field still focused depended on the browser 
 
 | | |
 |---|---|
-| **Save** | keeps the draft as one step in the history; disabled while there is nothing unsaved |
+| **Save** | keeps the draft as one step in the history (the panel then says *Updated*); disabled while there is nothing unsaved |
 | **Add** | the same button for somebody "Add a person" has just created, still blank |
 | **Discard** | backs out of that addition. The blank card goes, with no trace in the history (`Tree.withdraw`) |
 | **Delete this person** | for anybody already in the tree. Asks first when they have connections |


### PR DESCRIPTION
The third PR of #152. It builds #149, which **must land before the toolbar's Save button goes** (#150, next PR).

## What changes
**A tree with a file is written back to it ~1s after each change.** The unsaved dot becomes a word beside the file name:

| bar says | meaning |
|---|---|
| ● **Saved** | every change is on disk |
| ● **Saving…** (pulses; reduced-motion respected) | a change is in its pause, or being written |
| ● **Not saved yet** · `Save…` | a new tree with no file. **Your decision:** save once, then automatic |
| ● **Not saved** · `Retry` | a write failed; a toast says why once (*"the disk is full"*, *"was a drive removed?"*…), offers **Save as…**, and f-tree retries with backoff |

- **Batching:** a burst of edits makes one write. A change that lands mid-write is written straight after.
- **No lost edits mid-write:** `Tree.markSaved(signature)` records what was *written*, not "now".
- **Closing the window** first writes whatever is still pending, then closes *without a question*. The quit prompt remains only for an untitled tree, a half-edited person, or a failed write. It now waits for the page's actual save outcome instead of a 10s poll, which used to expire while you were still choosing a folder in Save As.
- **New / Open / Close tree** now ask about an untitled or unwritable tree. Before, opening another file silently discarded a new tree that had never been saved.
- **Ctrl+S** skips the pause. A first save says once: *"From now on every change is saved as you make it."*

## Backups (your decision: the app's own folder)
- `desktop/backups.js`, following Android's pre-import rule, *"keep a few, not a growing pile"*:
  - a copy **before the first write of each run**
  - then at most **one per 10 minutes**
  - the **newest 5** per tree
- They live in `userData/backups/<name>-<pathhash>/`, with a README naming the tree. **File › Show backups** opens the folder.
- **The sibling `<name>.bak` is removed.** Under autosave it would be overwritten every second, and nothing is added beside your file any more.
- A failed backup never blocks a save.

## Tests
- `backups.test.js` (14): the policy table, plus a real temp dir. 20 writes a second apart make one backup, the pre-write version; 9 writes ten minutes apart keep the newest 5.
- `autosave.test.js` (11, hand-driven clock): batching, write-after-in-flight, fail-once-then-retry, recovery, flush semantics, the no-file case, cancel, and failure wording.
- `document.test.js`: `markSaved(signature)` keeps a mid-write edit dirty.
- **Smoke** (now 116 ok locally):
  - the fixture is opened **as a fresh copy per section**, since autosave would otherwise edit it for later sections
  - new checks: the untitled chip; the first-save message; a change reaching the file *by itself* (checked on disk, then read back through the app); the pre-change version in backups; nothing beside the file
  - an **ungated final step** that edits and closes immediately: the window closes without asking, and the person is in the archive, read with the app's own reader

Also checked in Chromium with the bridge mocked to fail writes with `ENOSPC`: Saved → Saving… → Not saved + toast → Retry → Saved.

## Not in this PR
- The site's download pages still mention `.bak`. They describe the *stable* desktop (0.5.0), so I'll change that copy when 0.6.0 goes stable, not before. I'll open a follow-up issue.
- `git status --short app/` is empty.

Part of #152. Closes #149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)