### PR TITLE
feat(desktop): Find a relation and Preferences on the bar, 'How are we related?' from a person (#150, #151)

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1162,14 +1162,33 @@ async function runEditSmoke(win, check) {
     saveState: document.getElementById('save-state')?.dataset.state ?? '',
     saveAction: document.getElementById('save-state-action')?.hidden === false
       ? document.getElementById('save-state-action').textContent : null,
-    canUndo: document.getElementById('undo')?.disabled === false,
   }));
   check('a person and a child are recorded', /2 people/.test(seen.counts) && /1 connection/.test(seen.counts),
     seen.counts);
   // A new tree has nowhere to autosave to, so the bar says so and offers the one way out (#149).
   check('a tree with no file says it is not saved, and offers to save it',
     seen.saveState === 'untitled' && seen.saveAction === 'Save…', `${seen.saveState} / ${seen.saveAction}`);
-  check('there is something to undo', seen.canUndo === true);
+
+  /*
+   * Undo without a button on the bar (#150): the menu's command, which is what Ctrl+Z sends. Focus is
+   * taken out of the form first, because inside a text field Ctrl+Z means the typing, not the tree.
+   */
+  await page(() => document.activeElement?.blur());
+  win.webContents.send('menu:command', 'edit:undo');
+  await settle();
+  const undone = await page(() => ({
+    counts: document.getElementById('counts')?.textContent ?? '',
+    toast: document.getElementById('toast-text')?.textContent ?? '',
+  }));
+  win.webContents.send('menu:command', 'edit:redo');
+  await settle();
+  const redone = await page(() => document.getElementById('counts')?.textContent ?? '');
+  // One step: "add Ravi as a child" is a person and a connection to the tree, and one act to the
+  // reader. Undone as two, it left Ravi floating with nothing joining him to anybody.
+  check('undo takes the child back in one step, and redo returns them, from the menu',
+    /1 person · 0 connections/.test(undone.counts) && /Undid: Add Ravi as a child/.test(undone.toast)
+      && /2 people · 1 connection/.test(redone),
+    `${undone.counts} (${undone.toast}) → ${redone}`);
 
   // The rules, through the interface rather than around it: a child cannot also be a partner.
   await page(() => {
@@ -1197,8 +1216,9 @@ async function runEditSmoke(win, check) {
     /1 connection/.test(seen.counts) && /already parent and child/i.test(seen.toast ?? ''),
     `${seen.counts} — ${seen.toast}`);
 
-  // Save, through the real writer and the real atomic write.
-  await page(() => document.getElementById('save').click());
+  // Save, through the bar's own Save… -- the one way to save a new tree now the toolbar button is
+  // gone (#150) -- and the real writer and the real atomic write.
+  await page(() => document.getElementById('save-state-action').click());
   await settle(1200);
 
   const target = process.env.FTREE_SMOKE_SAVE_TO;
@@ -1855,13 +1875,24 @@ async function runRelateSmoke(win, check) {
     editorOpen: document.getElementById('panel').hidden === false,
   }));
 
-  // The bar is deliberately not a way in -- see the note in app.js. Pinned, so that adding one
-  // later is a decision somebody makes on purpose rather than a header that quietly grows a row.
+  /*
+   * The bar is a way in now (#150), and it still has to be one row.
+   *
+   * It was kept off the bar while Undo, Redo and Save were on it, because one more icon wrapped the
+   * row at 1095px. Those three are gone; this pins that the button is there *and* that the header
+   * has not quietly grown a second row to fit it.
+   */
   const header = await page(() => ({
     height: Math.round(document.querySelector('header').getBoundingClientRect().height),
-    button: Boolean(document.getElementById('relate-btn')),
+    relate: document.getElementById('relate-btn')?.getAttribute('aria-label') ?? null,
+    prefs: document.getElementById('prefs-btn')?.getAttribute('aria-label') ?? null,
+    pressed: document.getElementById('relate-btn')?.getAttribute('aria-pressed') ?? null,
   }));
-  check('the bar stays one row', header.height <= 60 && !header.button, JSON.stringify(header));
+  check('the bar has Find a relation and Preferences, and stays one row',
+    header.height <= 60 && header.relate === 'Find a relation' && header.prefs === 'Preferences',
+    JSON.stringify(header));
+  check('and the relation button shows the question is open', header.pressed === 'true',
+    String(header.pressed));
 
   check('the relation finder opens', opened.shown, String(opened.shown));
   check('it is seeded from the person that was selected',
@@ -2037,7 +2068,67 @@ async function runRelateSmoke(win, check) {
   }));
   check('closing the question puts the panel away', !closed.shown, String(closed.shown));
 
+  /*
+   * From a person (#151): the question starts from whoever is open, with them in the first slot and
+   * the second left for the reader. Starting from the panel is the case with the trap in it -- the
+   * panel is closed first, which clears the selection -- so the name is checked, not assumed.
+   */
+  win.webContents.send('menu:command', 'view:index');
+  await settle();
+  const person = await page(() => {
+    const rows = [...document.querySelectorAll('#index-list .index-row')];
+    const row = rows[3] ?? rows[0];
+    row?.click();
+    return row?.querySelector('.who')?.textContent.trim() ?? '';
+  });
+  await settle();
+  await page(() => document.querySelector('#panel .relate-from')?.click());
+  await settle(500);
+  const fromPanel = await page(() => ({
+    shown: document.getElementById('relate').hidden === false,
+    a: document.getElementById('relate-a').value,
+    b: document.getElementById('relate-b').value,
+    focus: document.activeElement?.id ?? '',
+    editorOpen: document.getElementById('panel').hidden === false,
+  }));
+  check('"How are we related?" on a person starts the question from them',
+    fromPanel.shown && fromPanel.a === person && fromPanel.b === '' && fromPanel.focus === 'relate-b',
+    `${person} → ${JSON.stringify(fromPanel)}`);
+  check('and the person panel stands down for it', !fromPanel.editorOpen);
+
+  // The people list offers it on every row, beside the row rather than inside it.
+  win.webContents.send('menu:command', 'view:index');
+  await settle();
+  const listed = await page(() => {
+    const item = [...document.querySelectorAll('#index-list .index-item')][1];
+    item?.querySelector('.index-relate')?.click();
+    return item?.querySelector('.who')?.textContent.trim() ?? '';
+  });
+  await settle(500);
+  const fromList = await page(() => ({
+    a: document.getElementById('relate-a').value,
+    b: document.getElementById('relate-b').value,
+    view: document.getElementById('viewer').dataset.view,
+  }));
+  check('so does every row of the people list, replacing an earlier question',
+    fromList.a === listed && fromList.b === '' && fromList.view === 'chart',
+    `${listed} → ${JSON.stringify(fromList)}`);
+
+  // And the compact view, from the person it is centred on.
+  win.webContents.send('menu:command', 'view:compact');
+  await settle();
+  const centred = await page(() => {
+    const name = document.querySelector('.band-focus-name')?.textContent.trim() ?? '';
+    document.querySelector('.band-relate')?.click();
+    return name;
+  });
+  await settle(500);
+  const fromCompact = await page(() => document.getElementById('relate-a').value);
+  check('and the compact view, from the person it is centred on', Boolean(centred)
+    && fromCompact === centred, `${centred} → ${fromCompact}`);
+
   win.webContents.send('menu:command', 'view:chart');
+  await page(() => document.getElementById('relate-close').click());
   await settle(300);
 }
 
@@ -2107,12 +2198,23 @@ async function runImportSmoke(win, check) {
   const after = await page(() => ({
     counts: document.getElementById('counts').textContent,
     open: document.getElementById('review').open === true,
-    undo: document.getElementById('undo')?.disabled === false,
+    offersUndo: document.getElementById('toast-action')?.hidden === false
+      ? document.getElementById('toast-action').textContent : null,
   }));
 
   check('confirming closes the question', !after.open, String(after.open));
   check('the tree grew once it was confirmed', after.counts !== before.people, after.counts);
-  check('the whole import can be undone', after.undo, 'undo is available');
+
+  // Undone for real, in one step, rather than checking that a button is enabled: the toast offers
+  // Undo, and the menu's Undo -- what Ctrl+Z sends -- puts the tree back exactly as it was.
+  await page(() => document.activeElement?.blur());
+  win.webContents.send('menu:command', 'edit:undo');
+  await settle(400);
+  const reverted = await page(() => document.getElementById('counts').textContent);
+  check('the whole import can be undone, in one step', after.offersUndo === 'Undo'
+    && reverted === before.people, `${after.offersUndo} — ${after.counts} → ${reverted}`);
+  win.webContents.send('menu:command', 'edit:redo');
+  await settle(400);
 }
 
 /*
@@ -2160,6 +2262,16 @@ async function runMenuSmoke(win, check) {
   for (const label of ['Check for updates automatically', 'Offer me beta releases']) {
     check(`"${label}" is still a checkbox in the menu`, labels.includes(label));
   }
+
+  // With Undo and Redo off the bar (#150), the menu is where they are always found, on the keys
+  // every editor uses; and the backups autosave keeps are reachable from beside Save (#149).
+  const file = (menu ? menu.items : []).find((item) => item.label === 'File');
+  const fileItems = file ? file.submenu.items : [];
+  const accel = (label) => fileItems.find((item) => item.label === label)?.accelerator ?? null;
+  check('Undo and Redo are in the menu on the usual keys',
+    accel('Undo') === 'CmdOrCtrl+Z' && accel('Redo') === 'CmdOrCtrl+Shift+Z',
+    `${accel('Undo')} / ${accel('Redo')}`);
+  check('File > Show backups is there', fileItems.some((item) => item.label === 'Show backups'));
 }
 
 async function runSmoke(win, file) {
@@ -2234,8 +2346,10 @@ async function runSmoke(win, file) {
     })(),
     peopleNote: document.getElementById('index-note')?.textContent ?? null,
     // The editor's own surface. A page that reads a tree but cannot change one is not this app.
-    canEdit: Boolean(document.getElementById('add-person') && document.getElementById('save')),
-    undoPresent: Boolean(document.getElementById('undo') && document.getElementById('redo')),
+    canEdit: Boolean(document.getElementById('add-person') && document.getElementById('panel-save')),
+    // Gone from the bar on purpose (#150): saving is automatic and undo is the menu, Ctrl+Z and the
+    // toasts. Asserted absent, so they do not drift back in without somebody deciding they should.
+    toolbarLeftovers: ['undo', 'redo', 'save'].filter((id) => document.getElementById(id)),
     panelExists: Boolean(document.getElementById('panel')),
   })).toString()})()`);
 
@@ -2263,7 +2377,8 @@ async function runSmoke(win, file) {
   }
   check('the archive was read and counted', /\d+ people/.test(seen.counts ?? ''), String(seen.counts));
   check('the page can change a tree, not only read one', seen.canEdit === true);
-  check('undo and redo are there', seen.undoPresent === true);
+  check('the bar no longer carries Undo, Redo or Save', seen.toolbarLeftovers.length === 0,
+    seen.toolbarLeftovers.join(', ') || 'none');
   check('a person can be opened for editing', seen.panelExists === true);
   /*
    * The list is not a second opinion on the chart. At the zoom that fits a large family on one

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -2165,7 +2165,10 @@ async function runImportSmoke(win, check) {
   check('importing asks before it merges', asked.open, asked.title);
   check('the button says exactly what pressing it will do',
     /^(Add|Merge) \d+ /.test(asked.confirm), asked.confirm);
-  check('the dialog says the work is not on disk yet', /until you save/.test(asked.outcome),
+  // It used to say nothing reached the file until Save. Under autosave (#149) that is false for a
+  // tree with a file -- this one has one -- so it says how to get back instead, and where.
+  check('the dialog says how to take it back once it is written',
+    /One Undo puts all of it back/.test(asked.outcome) && /Show backups/.test(asked.outcome),
     asked.outcome);
   check('the tree is untouched while the question is open', asked.counts === before.people,
     asked.counts);

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -2312,8 +2312,13 @@ function openReview(plan, fileName, importedPhotos) {
     commitImport(plan, decisions, importedPhotos, fileName);
   };
 
-  $('review-outcome').textContent =
-    'Nothing is written to your file until you save. Undo puts all of it back.';
+  // Said as it now is. This used to promise that nothing reached the file until Save; under
+  // autosave (#149) the import is written a moment after it is confirmed, so the honest comfort is
+  // the two ways back -- one Undo, and the version from before kept among the backups.
+  $('review-outcome').textContent = state.path
+    ? 'Your file is updated once you confirm. One Undo puts all of it back, and the version from '
+      + 'before is kept in File › Show backups.'
+    : 'Nothing is written to a file until you save this tree. One Undo puts all of it back.';
 
   dialog.showModal();
   /*

--- a/desktop/renderer/app.js
+++ b/desktop/renderer/app.js
@@ -42,6 +42,7 @@ import {
   normaliseDateTyping,
 } from './person-draft.js';
 import { createAutosave, describeWriteFailure } from './autosave.js';
+import { relateIcon, prefsIcon } from './icons.js';
 
 const { PARENT, SPOUSE, SIBLING } = RelationshipType;
 
@@ -239,15 +240,22 @@ function paintSaveState() {
   action.textContent = view === 'untitled' ? 'Save…' : 'Retry';
 }
 
+/**
+ * Which file is open, in the bar and in the window's own title.
+ *
+ * The title is the copy that is always there: below 1180px the bar gives the name's width to the
+ * tools and keeps only the save state, and the title bar -- which every desktop shows anyway --
+ * goes on saying which tree this is.
+ */
+function showFileName(name) {
+  $('file-name').textContent = name ?? '';
+  document.title = name ? `${name} — f-tree` : 'f-tree';
+}
+
 /** Keeps the window, the menu and the save state in step with whether there is work not on disk. */
 function reflectDirty() {
   const dirty = Boolean(state.tree?.isDirty) || draftIsDirty();
   paintSaveState();
-  $('save').dataset.dirty = String(dirty);
-  $('undo').disabled = !state.tree?.canUndo;
-  $('redo').disabled = !state.tree?.canRedo;
-  $('undo').title = state.tree?.undoLabel ? `Undo: ${state.tree.undoLabel}` : 'Undo';
-  $('redo').title = state.tree?.redoLabel ? `Redo: ${state.tree.redoLabel}` : 'Redo';
   shell?.setDirty(dirty);
 }
 
@@ -335,7 +343,7 @@ function renderCounts() {
   const people = state.tree.people.length;
   $('counts').textContent = people === 0
     ? 'Nobody yet'
-    : `${count(people, 'person', 'people')}·`
+    : `${count(people, 'person', 'people')} · `
       + `${count(state.tree.relationships.length, 'connection', 'connections')}`;
 }
 
@@ -727,13 +735,17 @@ function wirePrefs() {
 /* ------------------------------------------------------------------ how two people are related */
 
 /*
- * Reached from the menu and the keyboard, and deliberately not from the bar.
+ * Reached from the bar, from a person, and from the menu and the keyboard.
  *
- * The website has a "Relate" button because a browser tab has nowhere else to put it. This bar
- * already carries what the website's does *and* the editing tools, and it is full: measured on a
- * 1095px window, adding one 26px icon took the header from 56px to 93px, because the row wraps.
- * The desktop has the affordance a tab does not -- View > How are two people related?, on Ctrl+R --
- * so the question is asked there, and the bar keeps the width it was designed for.
+ * For a while it was deliberately *not* on the bar. That bar carried Undo, Redo and Save as well as
+ * the viewer's tools, and measured on a 1095px window, one more 26px icon took the header from 56px
+ * to 93px because the row wrapped. #150 took those three off -- autosave made Save redundant and
+ * undo keeps Ctrl+Z, the menu and an Undo button in every toast -- which freed far more than one
+ * icon's width. Re-measured with the button in, and Preferences beside it: one 56px row at 1440,
+ * 1095 and every width down to 880, in both themes (the rules are at the end of editor.css).
+ *
+ * The bar's button starts a fresh question. The ones on a person (#151) continue from somebody
+ * already on screen, which is the commoner form of it: "how is *this* person related to me?"
  */
 
 /**
@@ -773,23 +785,41 @@ function forgetRelate() {
   const panel = $('relate');
   if (panel) {
     panel.hidden = true;
+    $('relate-btn')?.setAttribute('aria-pressed', 'false');
     $('relate-a').value = '';
     $('relate-b').value = '';
     $('relate-answer').replaceChildren();
   }
 }
 
-async function openRelate(seed = state.selected) {
+/**
+ * Opens the question, seeded with `seed` if there is one.
+ *
+ * The seed is taken as an argument and read *before* anything else happens, because the first thing
+ * this does is close the person panel -- which clears the selection. Relying on the selection would
+ * seed an empty slot, which is the one trap in starting from a person (#151).
+ *
+ * `fromPerson` is that case: the person asked about goes in the first slot even if an earlier
+ * question left somebody else there, and the second slot is emptied for the reader to fill.
+ */
+async function openRelate(seed = state.selected, { fromPerson = false } = {}) {
   // One question at a time. Both panels are positioned in the same corner, and two open at once
   // would be two things claiming to be what the window is about. Closing the person panel can be
   // refused -- it asks first if it holds unsaved edits -- and then the question waits.
   if (state.selected && !(await select(null))) return;
 
   $('relate').hidden = false;
+  $('relate-btn')?.setAttribute('aria-pressed', 'true');
 
-  // Seeded from whoever was selected, because "how is this person related to..." is the question
-  // somebody has in mind when they reach for this while looking at a person.
-  if (seed && state.graph?.people.has(seed) && !state.relateA) {
+  const known = seed && state.graph?.people.has(seed);
+  if (known && fromPerson) {
+    state.relateA = seed;
+    state.relateB = null;
+    $('relate-a').value = displayName(state.graph.people.get(seed));
+    $('relate-b').value = '';
+  } else if (known && !state.relateA) {
+    // Seeded from whoever was selected, because "how is this person related to..." is the question
+    // somebody has in mind when they reach for this while looking at a person.
     state.relateA = seed;
     $('relate-a').value = displayName(state.graph.people.get(seed));
   }
@@ -797,8 +827,15 @@ async function openRelate(seed = state.selected) {
   $(state.relateA ? 'relate-b' : 'relate-a').focus();
 }
 
+/** Asks "how are we related?" about one person: they are the first answer, the reader picks the second. */
+function relateFrom(id) {
+  setView('chart');
+  openRelate(id, { fromPerson: true });
+}
+
 function closeRelate() {
   $('relate').hidden = true;
+  $('relate-btn')?.setAttribute('aria-pressed', 'false');
   // The whole tree comes back. Leaving the chart cut down after the question is closed would strand
   // somebody on a three-person chart with no obvious way out.
   clearTrace();
@@ -1038,6 +1075,7 @@ function renderCompact() {
       $('compact').scrollTop = 0;
     },
     onEdit: (id) => select(id),
+    onRelate: (id) => relateFrom(id),
     onMore: () => {
       state.generationsUp += 2;
       state.generationsDown += 2;
@@ -1115,7 +1153,19 @@ function renderPeople() {
 
       row.append(left, how);
       row.addEventListener('click', () => select(person.id));
-      li.append(row);
+
+      // A second way into the question, beside the row rather than inside it: a button cannot hold
+      // another button, and the row's own click already means "open this person" (#151).
+      const relate = document.createElement('button');
+      relate.type = 'button';
+      relate.className = 'index-relate';
+      relate.append(relateIcon(15));
+      relate.setAttribute('aria-label', `How are we related? Starting from ${displayName(person)}`);
+      relate.title = 'How are we related?';
+      relate.addEventListener('click', () => relateFrom(person.id));
+
+      li.className = 'index-item';
+      li.append(row, relate);
       list.append(li);
     }
   }
@@ -1248,6 +1298,8 @@ function renderPanel() {
   const body = $('panel-body');
   body.replaceChildren();
   body.append(personForm(person), relativesSection(person));
+  // Not for somebody still being added: a blank person has no family to be asked about yet.
+  if (!isFresh(person)) body.append(relateRow(person));
   paintPanelState();
 }
 
@@ -1552,6 +1604,29 @@ function relativesSection(person) {
 
   box.append(addRelativeForm(person));
   return box;
+}
+
+/**
+ * "How are we related?" from the person already open (#151).
+ *
+ * Android offers it from the person sheet and the person page, in these words. Before this the
+ * desktop could only start the question from nothing, so the commonest form of it -- this person,
+ * and me -- cost the reader the selection they had already made and a name retyped from the screen.
+ */
+function relateRow(person) {
+  const row = document.createElement('div');
+  row.className = 'relate-row';
+  const button = document.createElement('button');
+  button.type = 'button';
+  button.className = 'relate-from';
+  button.append(relateIcon(16));
+  const words = document.createElement('span');
+  words.textContent = 'How are we related?';
+  button.append(words);
+  button.title = `How is ${displayName(person)} related to somebody else?`;
+  button.addEventListener('click', () => relateFrom(person.id));
+  row.append(button);
+  return row;
 }
 
 function addRelativeForm(person) {
@@ -1930,14 +2005,17 @@ function addRelative(subjectId, kind, name) {
   if (!result.ok) {
     /*
      * The person was added and the connection refused, which would leave a stranger floating in
-     * the tree that nobody asked for. Undo takes back the whole step, so what the reader sees is
-     * simply that nothing happened, and why.
+     * the tree that nobody asked for. The addition is withdrawn -- not undone, which would leave it
+     * waiting in Redo -- so what the reader sees is simply that nothing happened, and why.
      */
-    state.tree.undo();
+    state.tree.withdraw(added.id);
     toast(REFUSALS[result.reason] ?? 'That connection was not made.', 'bad');
     rebuild();
     return;
   }
+  // A person and a relationship to the tree, one act to the reader, so one step to undo.
+  const word = KINDS.find(([k]) => k === kind)[1].toLowerCase();
+  state.tree.combine(2, `Add ${name || 'someone'} as a ${word}`);
   state.adding = null;
   rebuild();
 }
@@ -2014,7 +2092,7 @@ async function startNewTree() {
   state.name = 'Untitled tree';
   state.selected = null;
   forgetRelate();
-  $('file-name').textContent = state.name;
+  showFileName(state.name);
   setState('loaded');
   chart.resize();
   rebuild({ refit: true });
@@ -2050,7 +2128,7 @@ async function openBytes(bytes, name, filePath) {
     state.name = name;
     state.selected = null;
     forgetRelate();
-    $('file-name').textContent = name;
+    showFileName(name);
     setState('loaded');
     chart.resize();
     rebuild({ refit: true });
@@ -2343,7 +2421,7 @@ async function save({ as = false } = {}) {
 
     state.path = result.path;
     state.name = result.name;
-    $('file-name').textContent = result.name;
+    showFileName(result.name);
     state.tree.markSaved(signature);
     reflectDirty();
     toast(`Saved ${count(made.people, 'person', 'people')} and `
@@ -2417,9 +2495,15 @@ function wireChrome() {
   $('start-new').addEventListener('click', startNewTree);
   $('choose').addEventListener('click', () => shell?.chooseTree());
   $('add-person').addEventListener('click', addPerson);
-  $('save').addEventListener('click', () => save());
-  $('undo').addEventListener('click', undo);
-  $('redo').addEventListener('click', redo);
+
+  // The two the bar gained when Undo, Redo and Save left it (#150). Their glyphs come from icons.js,
+  // which the panel, the list and the compact view draw theirs from too.
+  $('relate-btn').append(relateIcon(19));
+  $('relate-btn').addEventListener('click', () => {
+    if ($('relate').hidden) { setView('chart'); openRelate(); } else closeRelate();
+  });
+  $('prefs-btn').append(prefsIcon(15));
+  $('prefs-btn').addEventListener('click', openPrefs);
   $('panel-close').addEventListener('click', () => select(null));
   $('panel-save').addEventListener('click', () => commitDraft());
   // The bar's save state offers the one thing each of its two awkward states needs.
@@ -2540,6 +2624,7 @@ function wireShell() {
 
 function closeTree() {
   autosave.cancel();
+  showFileName(null);
   state.tree = null;
   state.path = null;
   state.selected = null;

--- a/desktop/renderer/bands.js
+++ b/desktop/renderer/bands.js
@@ -20,6 +20,7 @@
  */
 
 import { displayName, birthYear, lifespan } from '../../site/playground/model.js';
+import { relateIcon } from './icons.js';
 
 /**
  * What a generation is called, worked out from its distance rather than looked up.
@@ -111,7 +112,7 @@ function groupRow(group) {
  * different clicks on the same name would make both of them uncertain. So editing is offered once,
  * from the block for the person already centred, and the walk stays a single unambiguous action.
  */
-function focusBlock(focus, { onEdit }) {
+function focusBlock(focus, { onEdit, onRelate }) {
   const block = document.createElement('div');
   block.className = 'band-focus';
 
@@ -137,6 +138,17 @@ function focusBlock(focus, { onEdit }) {
   edit.textContent = 'Edit this person';
   edit.addEventListener('click', () => onEdit(focus.person.id));
   head.append(edit);
+
+  // The question the phone offers from every person, offered here from the person centred (#151).
+  if (onRelate) {
+    const relate = document.createElement('button');
+    relate.type = 'button';
+    relate.className = 'btn quiet band-edit band-relate';
+    relate.append(relateIcon(15));
+    relate.append(document.createTextNode('How are we related?'));
+    relate.addEventListener('click', () => onRelate(focus.person.id));
+    head.append(relate);
+  }
 
   block.append(head);
 
@@ -182,10 +194,11 @@ function bandSection(band) {
  * Draws a `CompactFamily` into `container`.
  *
  * `onFocus` is given a person's id when somebody clicks a name; `onEdit` when the centred person is
- * to be edited; `onMore` when the reader asks for another generation. All three are the caller's,
- * so this file holds no state and can be rendered twice with the same result.
+ * to be edited; `onRelate` when the reader asks how the centred person is related to somebody;
+ * `onMore` when the reader asks for another generation. All are the caller's, so this file holds no
+ * state and can be rendered twice with the same result.
  */
-export function renderBands(container, family, { onFocus, onEdit, onMore, generations }) {
+export function renderBands(container, family, { onFocus, onEdit, onRelate, onMore, generations }) {
   container.replaceChildren();
 
   if (family.isEmpty) {
@@ -210,7 +223,7 @@ export function renderBands(container, family, { onFocus, onEdit, onMore, genera
   container.append(head);
 
   for (const band of family.ancestors) container.append(bandSection(band));
-  container.append(focusBlock(family.focus, { onEdit }));
+  container.append(focusBlock(family.focus, { onEdit, onRelate }));
   if (family.siblings) container.append(bandSection(family.siblings));
   for (const band of family.descendants) container.append(bandSection(band));
 
@@ -223,10 +236,12 @@ export function renderBands(container, family, { onFocus, onEdit, onMore, genera
     container.append(more);
   }
 
-  container.addEventListener('click', (event) => {
+  // A property, not `addEventListener`: this runs on every render into the same container, and a
+  // listener added each time would walk the reading once per render so far on a single click.
+  container.onclick = (event) => {
     const name = event.target.closest('.band-name');
     if (name) onFocus(name.dataset.id);
-  });
+  };
 }
 
 /**

--- a/desktop/renderer/document.js
+++ b/desktop/renderer/document.js
@@ -196,6 +196,20 @@ export class Tree {
     return result ?? { ok: true };
   }
 
+  /**
+   * Makes the newest `count` steps one, under `label`.
+   *
+   * For an act the interface thinks of as one thing but the tree records as several -- "add Ravi as
+   * a child" is a person and then a relationship. Left as two, one undo takes back only the
+   * relationship and leaves a stranger floating in the tree that nobody asked for.
+   */
+  combine(count, label) {
+    if (count < 2 || this.past.length < count) return { ok: false, reason: 'NOTHING_TO_COMBINE' };
+    const steps = this.past.splice(-count);
+    this.past.push({ label, state: steps[0].state });
+    return { ok: true };
+  }
+
   undo() {
     if (!this.past.length) return { ok: false, reason: 'NOTHING_TO_UNDO' };
     const step = this.past.pop();

--- a/desktop/renderer/document.test.js
+++ b/desktop/renderer/document.test.js
@@ -335,3 +335,28 @@ test('a tree is marked saved as of what was written, not as of now', () => {
   tree.markSaved();
   assert.ok(!tree.isDirty);
 });
+
+/* ---------------------------------------------------------------- one act, one step */
+
+test('combining steps makes one act one undo', () => {
+  const { tree, father } = family();
+  const before = tree.signature();
+  const { id } = tree.addPerson({ name: 'Asha' });
+  tree.addRelationship({ from: father, to: id, type: PARENT });
+
+  assert.deepStrictEqual(tree.combine(2, 'Add Asha as a child'), { ok: true });
+  assert.strictEqual(tree.undoLabel, 'Add Asha as a child');
+  tree.undo();
+  assert.strictEqual(tree.signature(), before, 'one undo takes back the person and the connection');
+  tree.redo();
+  assert.ok(tree.person(id), 'and one redo puts both back');
+  assert.strictEqual(tree.relationships.filter((r) => r.to === id).length, 1);
+});
+
+test('there is nothing to combine without at least two steps', () => {
+  const tree = new Tree();
+  tree.addPerson({ name: 'Solo' });
+  assert.strictEqual(tree.combine(2, 'x').reason, 'NOTHING_TO_COMBINE');
+  assert.strictEqual(tree.combine(1, 'x').reason, 'NOTHING_TO_COMBINE');
+  assert.strictEqual(tree.undoLabel, 'Add Solo', 'and the history is untouched');
+});

--- a/desktop/renderer/editor.css
+++ b/desktop/renderer/editor.css
@@ -93,23 +93,13 @@
   margin-right: auto;
 }
 
-.editor .undo-pair {
-  display: inline-flex;
-  gap: 2px;
-}
-
-.editor .icon[disabled] {
-  opacity: 0.32;
-  cursor: default;
-}
-
 .editor .primary-tool {
   font-weight: 600;
 }
 
-.editor .save-btn[data-dirty='true'] {
-  font-weight: 600;
-}
+/* The relation finder's button stays lit while the question is open, as a toggle should. */
+.editor #relate-btn[aria-pressed='true'] { border-color: var(--forest); color: var(--forest); }
+.editor .bar .icon:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 /* ------------------------------------------------------------------ the person form */
 
@@ -1465,3 +1455,116 @@
 
 /* The quiet destructive answer sits apart at the left, the way the panel's own foot sets it. */
 .editor .ask .review-actions { flex: 1; justify-content: flex-end; }
+
+/* ------------------------------------------------------------------ how are we related, from a person */
+
+/*
+ * The question offered from a person (#151), in the three places a person is read.
+ *
+ * One mark everywhere -- Android's `compare_arrows` -- so it reads as one feature reached four ways.
+ * In the panel it is a quiet row under the family list: it continues from the person open, which
+ * makes it part of reading them rather than an action on them, and it keeps clear of the footer
+ * where the buttons that keep or delete the person live.
+ */
+.editor .relate-row {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--rule);
+}
+
+.editor .relate-from {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  font-family: var(--serif);
+  font-size: calc(14px * var(--ui));
+  color: var(--forest);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 9px;
+  padding: calc(9px * var(--ui)) calc(10px * var(--ui));
+  margin: 0 -10px;
+  width: calc(100% + 20px);
+  text-align: left;
+  cursor: pointer;
+  transition: background .12s;
+}
+
+.editor .relate-from:hover { background: var(--sunk); }
+.editor .relate-from:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.editor .relate-from svg { flex: none; }
+
+/*
+ * On a row of the people list: beside the row, not inside it, because the row is itself a button.
+ *
+ * Shown on hover and on focus rather than always, so a list of two hundred people is not two hundred
+ * identical icons down its right edge -- but it takes its place in the tab order all the time, so
+ * a keyboard reaches it without hovering anything.
+ */
+.editor .index-item { position: relative; }
+.editor .index-item .index-row { padding-right: 52px; }
+
+.editor .index-relate {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  width: calc(32px * var(--ui));
+  height: calc(32px * var(--ui));
+  display: grid;
+  place-items: center;
+  padding: 0;
+  color: var(--ink-soft);
+  background: var(--raised);
+  border: 1px solid var(--rule);
+  border-radius: 50%;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity .12s, border-color .12s, color .12s;
+}
+
+.editor .index-item:hover .index-relate,
+.editor .index-relate:focus-visible { opacity: 1; }
+.editor .index-relate:hover { border-color: var(--forest); color: var(--forest); }
+.editor .index-relate:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.editor .band-relate { display: inline-flex; align-items: center; gap: 7px; }
+
+/* ------------------------------------------------------------------ the bar, narrower */
+
+/*
+ * One row down to 1000px, and nothing dropped that has no other home.
+ *
+ * With Undo, Redo and Save gone the bar has two new icons and the save state; at 1095px -- the width
+ * the old objection to a relation button was measured at -- that is one row only if something gives.
+ * What gives is what is said twice: the file name, which the window's title bar carries at every
+ * width (see `showFileName`), and the zoom percentage, which the chart itself shows by what it
+ * draws. The search box narrows rather than going. The save state stays, because a failed write in
+ * a narrow window is exactly the thing that must not be hidden.
+ *
+ * Below 960px, with a tree open, the theme button steps aside as well: Preferences is on the bar
+ * now and holds Appearance, and the menu has it on Ctrl+Shift+D. The opener keeps it, because
+ * nothing else is on that screen.
+ *
+ * Measured with the sample family, in both themes: one 56px row at every width from 1440 down to
+ * 900. Below that the tools take a second row, which the window allows down to its 820px minimum.
+ */
+.editor .bar .icon { flex: none; }   /* never squeezed: a 28px circle reads as a different control */
+
+@media (max-width: 1240px) {
+  .editor .file-name { display: none; }
+  .editor .zoom-level { display: none; }
+  .editor .search { flex-basis: calc(180px * var(--ui)); }
+}
+
+@media (max-width: 1060px) {
+  .editor .bar { column-gap: 10px; }
+  .editor .bar-tools { gap: 7px; }
+  .editor .search { flex-basis: calc(150px * var(--ui)); min-width: calc(120px * var(--ui)); }
+  .editor .segmented button { padding-inline: calc(10px * var(--ui)); }
+  .editor .zoom { gap: 4px; }
+}
+
+@media (max-width: 960px) {
+  .editor.viewer[data-state='loaded'] .theme-btn { display: none; }
+}

--- a/desktop/renderer/icons.js
+++ b/desktop/renderer/icons.js
@@ -1,0 +1,66 @@
+/*
+ * The two glyphs the desktop draws in more than one place.
+ *
+ * "How are we related?" is offered from the bar, the person panel, the people list and the compact
+ * view (#150, #151), and it wears the same mark in all four so it reads as one feature reached four
+ * ways -- the mark Android uses at all three of its own entry points, Material's `compare_arrows`, so
+ * somebody moving between the phone and the laptop recognises it.
+ */
+
+const NS = 'http://www.w3.org/2000/svg';
+
+/** Material `compare_arrows`, the 24px path, as the Android app draws it (`Icons.Default.CompareArrows`). */
+const RELATE_PATH = 'M9.01 14H2v2h7.01v3L13 15l-3.99-4v3zm5.98-1v-3H22V8h-7.01V5L11 9l3.99 4z';
+
+/** A gear, stroked to match the bar's other stroked glyphs (the moon and the sun). */
+const PREFS_PATHS = [
+  'M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73'
+    + 'l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 '
+    + '2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44'
+    + 'a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 '
+    + '0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38'
+    + 'a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z',
+];
+
+function svg(size) {
+  const el = document.createElementNS(NS, 'svg');
+  el.setAttribute('width', String(size));
+  el.setAttribute('height', String(size));
+  el.setAttribute('viewBox', '0 0 24 24');
+  el.setAttribute('aria-hidden', 'true');
+  el.setAttribute('focusable', 'false');
+  return el;
+}
+
+/** The relation mark, filled in the current colour. */
+export function relateIcon(size = 16) {
+  const el = svg(size);
+  el.setAttribute('fill', 'currentColor');
+  const path = document.createElementNS(NS, 'path');
+  path.setAttribute('d', RELATE_PATH);
+  el.append(path);
+  return el;
+}
+
+/** The preferences gear. */
+export function prefsIcon(size = 15) {
+  const el = svg(size);
+  el.setAttribute('fill', 'none');
+  el.setAttribute('stroke', 'currentColor');
+  el.setAttribute('stroke-width', '1.8');
+  el.setAttribute('stroke-linecap', 'round');
+  el.setAttribute('stroke-linejoin', 'round');
+  for (const d of PREFS_PATHS) {
+    const path = document.createElementNS(NS, 'path');
+    path.setAttribute('d', d);
+    el.append(path);
+  }
+  const hub = document.createElementNS(NS, 'circle');
+  hub.setAttribute('cx', '12');
+  hub.setAttribute('cy', '12');
+  hub.setAttribute('r', '3');
+  el.append(hub);
+  return el;
+}
+
+export { RELATE_PATH };

--- a/desktop/renderer/index.html
+++ b/desktop/renderer/index.html
@@ -93,19 +93,12 @@
 
       <button type="button" class="tool primary-tool" id="add-person">Add a person</button>
 
-      <div class="undo-pair" role="group" aria-label="Undo and redo">
-        <button type="button" class="icon" id="undo" aria-label="Undo" disabled>
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M9 7 4 12l5 5"/><path d="M4 12h9a6 6 0 0 1 0 12h-1"/>
-          </svg>
-        </button>
-        <button type="button" class="icon" id="redo" aria-label="Redo" disabled>
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="m15 7 5 5-5 5"/><path d="M20 12h-9a6 6 0 0 0 0 12h1"/>
-          </svg>
-        </button>
-      </div>
-
+      <!--
+        No Undo, Redo or Save here any more (#150). Saving is automatic once a tree has a file (#149)
+        and the bar's save state offers Save… for the one tree that has none; undo is Ctrl+Z, the
+        menu, and an Undo button in every toast that announces something undoable. The room they
+        took is given to the two things that had no way in from the bar at all.
+      -->
       <div class="zoom">
         <button type="button" class="icon" id="zoom-out" aria-label="Zoom out">&minus;</button>
         <output class="zoom-level" id="zoom-level" aria-live="off">100%</output>
@@ -113,7 +106,11 @@
         <button type="button" class="tool" id="fit">Fit</button>
       </div>
 
-      <button type="button" class="tool save-btn" id="save">Save</button>
+      <!-- Android's own mark and words for it (`relation_find`), so the two shells say the same. -->
+      <button type="button" class="icon" id="relate-btn" aria-label="Find a relation"
+              title="Find a relation (R)" aria-pressed="false"></button>
+      <button type="button" class="icon" id="prefs-btn" aria-label="Preferences"
+              title="Preferences (Ctrl+,)"></button>
     </div>
   </header>
 

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -175,7 +175,7 @@ must be B's भांजा or भांजी*, computed independently from opp
 
 ## Settings
 
-`Settings > Preferences…`, on `Ctrl+,`. Family words, photographs on the chart, appearance, and the
+The gear on the bar, `Settings > Preferences…`, or `Ctrl+,`. Family words, photographs on the chart, appearance, and the
 two update settings. Every one of them is also in the native menu, and **both surfaces go through
 the same `settings:set`**, which rebuilds the menu from the result.
 
@@ -213,7 +213,7 @@ system's colours, not a lost setting.
 
 ## How two people are related
 
-`View > How are two people related?`, on `Ctrl+R`, or the `R` key. Pick two people; the answer is a
+The bar's relation button, `View > How are two people related?`, `Ctrl+R`, or the `R` key. Pick two people; the answer is a
 sentence, a chain of people you can click through, and the chart cut down to just that line, with the
 whole tree back when the question is closed. It is seeded from whoever is selected, because "how is
 *this* person related to…" is the question somebody has in mind when they reach for it.
@@ -231,10 +231,20 @@ Three sentences, and sometimes none:
 | a relative of somebody's spouse | *"Rekha is the **mother** of Ankit's wife."* |
 | none of those | no sentence at all — the chain says it exactly, and a sentence amounting to "these two are related somehow" tells a reader nothing the chain does not |
 
-There is no button for it on the toolbar, deliberately. The website has one because a browser tab has
-nowhere else to put it; this bar already carries what the website's does *and* the editing tools, and
-it is full — measured on a 1095px window, adding one 26px icon took the header from 56px to 93px
-because the row wraps. The menu is the affordance a tab does not have, so that is where it lives.
+It is reached four ways. The bar's **Find a relation** button (Android's `compare_arrows` mark and
+its `relation_find` words) starts a fresh question. **How are we related?** starts from somebody
+already on screen, which is the commoner form of the question
+([#151](https://github.com/thisisankit27/f-tree/issues/151)): from the person panel, from any row of
+the people list, and from the person the compact view is centred on. Starting from a person puts
+them in the first slot even if an earlier question left somebody else there, and empties the second
+for you to fill.
+
+For a while the bar deliberately had no button for it. Measured on a 1095px window, one more icon
+took the header from 56px to 93px because the row wrapped. #150 removed Undo, Redo and Save from the
+bar. Saving is automatic, and undo lives in Ctrl+Z, the menu, and an Undo button in every toast that
+announces something undoable. That freed the room, and the bar now also has **Preferences**.
+Re-measured: one 56px row from 1440 down to 880px. Below 1240px the file name moves to the window's
+title bar, and the bar keeps the save state.
 
 The rules about who appears live in `site/playground/focus.js` and `site/playground/compact.js`,
 ported from `graph/TreeLayoutEngine.kt` and `graph/CompactFamily.kt` with their test tables. On


### PR DESCRIPTION
The fourth PR of #152, and the last of the work. #149 (autosave) is merged, so Save can leave the bar.

## #150: the bar
- **Undo, Redo and Save are removed.**
  - Saving is automatic once a tree has a file. The bar's save state offers **Save…** for a tree that has none.
  - Undo is Ctrl+Z, the menu (asserted in smoke on the usual keys), and an **Undo button in every toast** that announces something undoable (added in #160).
- **Added, beside Fit:**
  - **Find a relation**: Android's `compare_arrows` mark and its `relation_find` words. It stays pressed while the question is open.
  - **Preferences**: a gear that opens the existing dialog.
- **The objection is answered, and re-measured.** The old comment said one more icon wrapped the header at 1095px. The new header is **one 56px row at 1440, at 1095, and at every width down to 880, in both themes**:
  - Below 1240px the file name moves to the **window title bar** (`sample-family.ftree — f-tree`) and the bar keeps the save state. A failed write must stay visible when the window is narrow.
  - The zoom percentage drops; the zoom buttons stay.
  - Below 1060px the tools tighten.
  - Below 960px, with a tree open, the theme button steps aside, since Preferences holds Appearance.
  - Below 880px, down to the window's 820px minimum, it takes two rows.
- The comment that argued against a relation button is rewritten to say what is now true, with the numbers in it.

## #151: "How are we related?" from a person
It is available in Android's words from three places:
- the **person panel**, under the family list, away from the Save/Delete footer
- every **row of the people list**, beside the row (a button can't hold a button), shown on hover and focus and always reachable by Tab
- the person the **compact view** is centred on (the fourth callback the issue suggested)

**The trap the issue names is handled:** `openRelate(id, { fromPerson: true })` takes the id explicitly and reads it before closing the panel, since closing clears the selection. Starting from a person replaces an earlier question's first slot and empties the second.

## Found and fixed on the way
- **"Add Ravi as a child" was two undo steps.** One undo took back only the connection and left Ravi floating. The toolbar's undo button made this cheap to miss. `Tree.combine` makes it one step (tested), and a refused connection now *withdraws* the added person rather than leaving it waiting in Redo.
- **The import review promised "Nothing is written to your file until you save"**, which autosave made false. It now says: *"Your file is updated once you confirm. One Undo puts all of it back, and the version from before is kept in File › Show backups."*
- The compact view added a click listener on every render, so one click walked the reading once per render so far.
- "23 people·27 connections" gets its spaces back.

## Verified locally
- `npm test`: **346 pass**
- full smoke, every CI gate: **123 ok, 0 failed**. New checks:
  - the bar's two buttons, and a one-row header
  - Undo/Redo/Save asserted gone from the bar, and on the usual keys in the menu next to Show backups
  - undo/redo from the menu (one step for add-a-child)
  - the import undone for real
  - all three from-a-person entry points, checking the first slot, the empty second slot and focus
- header height swept across 16 widths × 2 themes in Chromium, with screenshots at 1440, 1095, 900 and 820
- `git status --short app/` is empty

Part of #152. Closes #150, closes #151.

🤖 Generated with [Claude Code](https://claude.com/claude-code)