### PR TITLE
chore(desktop): 0.6.0-beta.1, and the site offers only stable desktop builds

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "f-tree-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "f-tree-desktop",
-      "version": "0.5.0",
+      "version": "0.6.0-beta.1",
       "license": "MIT",
       "devDependencies": {
         "electron": "^33.2.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "f-tree-desktop",
   "productName": "f-tree",
-  "version": "0.5.0",
+  "version": "0.6.0-beta.1",
   "description": "A local-first family tree, on your own machine",
   "author": {
     "name": "thisisankit27",

--- a/site/app.js
+++ b/site/app.js
@@ -55,17 +55,24 @@
   }
 
   /*
-   * The newest desktop release.
+   * The newest *stable* desktop release.
    *
    * Found by its tag rather than by being newest, because desktop releases are published as
    * pre-releases on purpose - it is what keeps `releases/latest` answering with the newest
    * Android release for the app's own updater. See docs/desktop.md.
+   *
+   * And only a tag with no suffix. GitHub's pre-release flag cannot say "beta" for the desktop -
+   * every desktop release carries it - so the suffix does: `desktop-v0.6.0-beta.1` is a beta, as the
+   * desktop's own updater reads it (desktop/update.js). Matching any `desktop-v` tag would hand a
+   * beta to everybody who clicks Download, which is a stable release in all but name.
    */
+  var STABLE_DESKTOP = /^desktop-v\d+(\.\d+)*$/;
+
   function desktopFrom(releases) {
     var rel = null;
     for (var i = 0; i < releases.length; i++) {
       if (releases[i].draft) continue;
-      if (/^desktop-v/.test(releases[i].tag_name || '')) { rel = releases[i]; break; }
+      if (STABLE_DESKTOP.test(releases[i].tag_name || '')) { rel = releases[i]; break; }
     }
     if (!rel) return null;
 


### PR DESCRIPTION
Release prep for the #152 work as **desktop 0.6.0-beta.1**. Stacked on #163; retarget to `main` once that merges.

## The version
`desktop/package.json` (and lock): `0.5.0` → `0.6.0-beta.1`. The tag will be `desktop-v0.6.0-beta.1`.

A beta here is **the suffix on the tag**. Every desktop release is a GitHub pre-release, so that `releases/latest` keeps naming an Android release (see `desktop.yml`), which means the flag can't carry "beta". The desktop's own updater already reads the suffix, so this build is offered only to people who opted into betas. The Android updater can't parse `desktop-v…` at all.

## The site fix, which has to land before the tag
`site/app.js`'s `desktopFrom` took the newest `desktop-v*` tag, betas included. Tagging this beta would have put it behind **everyone's** Download button: a stable release in all but name, which isn't the plan until you say so. It now takes the newest tag with **no suffix**, the same rule `desktop/update.js` uses.
- Checked against six tag shapes.
- Checked against the live release list: the site still resolves to `desktop-v0.5.0`.

This touches the landing site's release lookup only. The viewer (`site/playground/`) is unchanged in this PR.

## Verified offline before tagging
| check | result |
|---|---|
| `npm test` | 346 pass |
| smoke harness from the checkout, every gate | 123 ok |
| same harness against a locally built `linux-unpacked` binary, run unconfined via `systemd-run` | **123 ok** |
| asar carries the new `backups.js`; the staged page carries `autosave.js`, `icons.js`, `person-draft.js` | yes |

Those last two rows are where 0.4.0 shipped broken while every checkout test was green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)